### PR TITLE
Remove unecessary header file in AtomicHashMap

### DIFF
--- a/folly/AtomicHashMap.h
+++ b/folly/AtomicHashMap.h
@@ -85,7 +85,6 @@
 #include <boost/iterator/iterator_facade.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#include <glog/logging.h>
 
 #include <stdexcept>
 #include <functional>


### PR DESCRIPTION
AtomicHashMap doesn't need to include the glog/logging.h header so remove it.
