### PR TITLE
Fix mistake with Makefile.am for spooky tests.

### DIFF
--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -173,12 +173,12 @@ cpuid_test_SOURCES = CpuIdTest.cpp
 cpuid_test_LDADD = libgtestmain.la $(top_builddir)/libfolly.la
 TESTS += cpuid_test
 
-spooky_hash_test_SOURCES = SpookyHashV1Test.cpp
-spooky_hash_test_LDADD = -lrt $(top_builddir)/libfolly.la
+spooky_hash_v1_test_SOURCES = SpookyHashV1Test.cpp
+spooky_hash_v1_test_LDADD = -lrt $(top_builddir)/libfolly.la
 TESTS += spooky_hash_v1_test
 
-spooky_hash_test_SOURCES = SpookyHashV2Test.cpp
-spooky_hash_test_LDADD = -lrt $(top_builddir)/libfolly.la
+spooky_hash_v2_test_SOURCES = SpookyHashV2Test.cpp
+spooky_hash_v2_test_LDADD = -lrt $(top_builddir)/libfolly.la
 TESTS += spooky_hash_v2_test
 
 check_PROGRAMS= $(TESTS)


### PR DESCRIPTION
Tests not compiling due to a copy and paste error in Makefile.am.
