### PR TITLE
Update build instructions for Ubuntu 12.10

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@ Dependencies
 
 - additional platform specific dependencies:
 
-  Ubuntu 12.04 64-bit
+  Ubuntu 12.10 64-bit
     - g++
     - automake
     - autoconf
@@ -44,10 +44,7 @@ Dependencies
     - libtool
     - libboost1.46-all-dev
     - libgoogle-glog-dev
-        This package has been removed from 12.04 -- use the one from 11.10
-    - gflags (packages need to be downloaded from below)
-        http://gflags.googlecode.com/files/libgflags-dev_2.0-1_amd64.deb
-        http://gflags.googlecode.com/files/libgflags0_2.0-1_amd64.deb
+    - libgflags-dev
     - scons (for double-conversion)
 
   Fedora 17 64-bit

--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -18,6 +18,7 @@ lib_LTLIBRARIES = libgtestmain.la libgtest.la
 
 libgtestmain_la_CPPFLAGS = -Igtest-1.6.0 -Igtest-1.6.0/src
 libgtestmain_la_SOURCES = gtest-1.6.0/src/gtest-all.cc gtest-1.6.0/src/gtest_main.cc
+libgtestmain_la_LIBADD = -lpthread
 
 libgtest_la_CPPFLAGS = -Igtest-1.6.0 -Igtest-1.6.0/src
 libgtest_la_SOURCES = gtest-1.6.0/src/gtest-all.cc


### PR DESCRIPTION
Couldn't get build on Ubuntu 12.04 to work due to version issues w/g++ and boost.  Seems to work better, with more default libs, in 12.10.  One small change to get libgtest to build
