### PR TITLE
mods to compile on gcc-4.8

### DIFF
--- a/folly/detail/Clock.h
+++ b/folly/detail/Clock.h
@@ -32,7 +32,6 @@
 #include <pthread.h>
 #include <pthread_time.h>
 #else
-typedef uint8_t clockid_t;
 #define CLOCK_REALTIME 0
 
 int clock_gettime(clockid_t clk_id, struct timespec* ts);

--- a/folly/detail/ThreadLocalDetail.h
+++ b/folly/detail/ThreadLocalDetail.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+#include <boost/thread/lock_guard.hpp>
 #include <glog/logging.h>
 
 #include <folly/Foreach.h>

--- a/folly/m4/ax_boost_system.m4
+++ b/folly/m4/ax_boost_system.m4
@@ -35,72 +35,72 @@
 
 AC_DEFUN([AX_BOOST_SYSTEM],
 [
-	AC_ARG_WITH([boost-system],
-	AS_HELP_STRING([--with-boost-system@<:@=special-lib@:>@],
+    AC_ARG_WITH([boost-system],
+    AS_HELP_STRING([--with-boost-system@<:@=special-lib@:>@],
                    [use the System library from boost - it is possible to specify a certain library for the linker
                         e.g. --with-boost-system=boost_system-gcc-mt ]),
         [
         if test "$withval" = "no"; then
-			want_boost="no"
+            want_boost="no"
         elif test "$withval" = "yes"; then
             want_boost="yes"
             ax_boost_user_system_lib=""
         else
-		    want_boost="yes"
-		ax_boost_user_system_lib="$withval"
-		fi
+            want_boost="yes"
+        ax_boost_user_system_lib="$withval"
+        fi
         ],
         [want_boost="yes"]
-	)
+    )
 
-	if test "x$want_boost" = "xyes"; then
+    if test "x$want_boost" = "xyes"; then
         AC_REQUIRE([AC_PROG_CC])
         AC_REQUIRE([AC_CANONICAL_BUILD])
-		CPPFLAGS_SAVED="$CPPFLAGS"
-		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-		export CPPFLAGS
+        CPPFLAGS_SAVED="$CPPFLAGS"
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
 
-		LDFLAGS_SAVED="$LDFLAGS"
-		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
-		export LDFLAGS
+        LDFLAGS_SAVED="$LDFLAGS"
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
 
         AC_CACHE_CHECK(whether the Boost::System library is available,
-					   ax_cv_boost_system,
+                       ax_cv_boost_system,
         [AC_LANG_PUSH([C++])
-			 CXXFLAGS_SAVE=$CXXFLAGS
+             CXXFLAGS_SAVE=$CXXFLAGS
 
-			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/system/error_code.hpp>]],
+             AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/system/error_code.hpp>]],
                                    [[boost::system::system_category]])],
                    ax_cv_boost_system=yes, ax_cv_boost_system=no)
-			 CXXFLAGS=$CXXFLAGS_SAVE
+             CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
-		])
-		if test "x$ax_cv_boost_system" = "xyes"; then
-			AC_SUBST(BOOST_CPPFLAGS)
+        ])
+        if test "x$ax_cv_boost_system" = "xyes"; then
+            AC_SUBST(BOOST_CPPFLAGS)
 
-			AC_DEFINE(HAVE_BOOST_SYSTEM,,[define if the Boost::System library is available])
+            AC_DEFINE(HAVE_BOOST_SYSTEM,,[define if the Boost::System library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
-			LDFLAGS_SAVE=$LDFLAGS
+            LDFLAGS_SAVE=$LDFLAGS
             if test "x$ax_boost_user_system_lib" = "x"; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_system* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
+                    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                  [link_system="no"])
-				done
+                done
                 if test "x$link_system" != "xyes"; then
                 for libextension in `ls -r $BOOSTLIBDIR/boost_system* 2>/dev/null | sed 's,.*/,,' | sed -e 's,\..*,,'` ; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
+                    AC_CHECK_LIB($ax_lib, exit,
                                  [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                  [link_system="no"])
-				done
+                done
                 fi
 
             else
                for ax_lib in $ax_boost_user_system_lib boost_system-$ax_boost_user_system_lib; do
-				      AC_CHECK_LIB($ax_lib, exit,
+                      AC_CHECK_LIB($ax_lib, exit,
                                    [BOOST_SYSTEM_LIB="-l$ax_lib"; AC_SUBST(BOOST_SYSTEM_LIB) link_system="yes"; break],
                                    [link_system="no"])
                   done
@@ -109,12 +109,13 @@ AC_DEFUN([AX_BOOST_SYSTEM],
             if test "x$ax_lib" = "x"; then
                 AC_MSG_ERROR(Could not find a version of the library!)
             fi
-			if test "x$link_system" = "xno"; then
-				AC_MSG_ERROR(Could not link against $ax_lib !)
-			fi
-		fi
+            if test "x$link_system" = "xno"; then
+                AC_MSG_ERROR(Could not link against $ax_lib !)
+            fi
+        fi
 
-		CPPFLAGS="$CPPFLAGS_SAVED"
-	LDFLAGS="$LDFLAGS_SAVED"
-	fi
+        CPPFLAGS="$CPPFLAGS_SAVED"
+    LDFLAGS="$LDFLAGS_SAVED"
+    fi
 ])
+


### PR DESCRIPTION
STL changed has_trivial_destructor in is_trivially_destructible.
in order to support both 4.8 and 4.7 a locally defined trait is required, see

http://stackoverflow.com/questions/12702103/writing-code-that-works-when-has-trivial-destructor-is-defined-instead-of-is