### PR TITLE
Constexpr macro

### DIFF
--- a/folly/Arena.h
+++ b/folly/Arena.h
@@ -154,9 +154,9 @@ class Arena {
   // max_align_t are supported by gcc 4.6.2.
 
  public:
-  static constexpr size_t kDefaultMinBlockSize = 4096 - sizeof(Block);
-  static constexpr size_t kNoSizeLimit = 0;
-  static constexpr size_t kDefaultMaxAlign = alignof(Block);
+  static FOLLY_CONSTEXPR size_t kDefaultMinBlockSize = 4096 - sizeof(Block);
+  static FOLLY_CONSTEXPR size_t kNoSizeLimit = 0;
+  static FOLLY_CONSTEXPR size_t kDefaultMaxAlign = alignof(Block);
 
  private:
   bool isAligned(uintptr_t address) const {

--- a/folly/AtomicBitSet.h
+++ b/folly/AtomicBitSet.h
@@ -84,7 +84,7 @@ class AtomicBitSet : private boost::noncopyable {
   /**
    * Return the size of the bitset.
    */
-  constexpr size_t size() const {
+  FOLLY_CONSTEXPR size_t size() const {
     return N;
   }
 
@@ -100,19 +100,19 @@ class AtomicBitSet : private boost::noncopyable {
 #endif
   typedef std::atomic<BlockType> AtomicBlockType;
 
-  static constexpr size_t kBitsPerBlock =
+  static FOLLY_CONSTEXPR size_t kBitsPerBlock =
     std::numeric_limits<BlockType>::digits;
 
-  static constexpr size_t blockIndex(size_t bit) {
+  static FOLLY_CONSTEXPR size_t blockIndex(size_t bit) {
     return bit / kBitsPerBlock;
   }
 
-  static constexpr size_t bitOffset(size_t bit) {
+  static FOLLY_CONSTEXPR size_t bitOffset(size_t bit) {
     return bit % kBitsPerBlock;
   }
 
   // avoid casts
-  static constexpr BlockType kOne = 1;
+  static FOLLY_CONSTEXPR BlockType kOne = 1;
 
   std::array<AtomicBlockType, N> data_;
 };

--- a/folly/AtomicHashArray.h
+++ b/folly/AtomicHashArray.h
@@ -128,7 +128,7 @@ class AtomicHashArray : boost::noncopyable {
     int    entryCountThreadCacheSize;
     size_t capacity; // if positive, overrides maxLoadFactor
 
-    constexpr Config() : emptyKey((KeyT)-1),
+	FOLLY_CONSTEXPR Config() : emptyKey((KeyT)-1),
                          lockedKey((KeyT)-2),
                          erasedKey((KeyT)-3),
                          maxLoadFactor(0.8),

--- a/folly/AtomicStruct.h
+++ b/folly/AtomicStruct.h
@@ -66,7 +66,7 @@ class AtomicStruct {
   AtomicStruct(AtomicStruct<T> const &) = delete;
   AtomicStruct<T>& operator= (AtomicStruct<T> const &) = delete;
 
-  constexpr /* implicit */ AtomicStruct(T v) noexcept : data(encode(v)) {}
+  FOLLY_CONSTEXPR /* implicit */ AtomicStruct(T v) noexcept : data(encode(v)) {}
 
   bool is_lock_free() const noexcept {
     return data.is_lock_free();

--- a/folly/Bits.h
+++ b/folly/Bits.h
@@ -61,7 +61,7 @@
 #error GCC required
 #endif
 
-#ifndef __clang__
+#if defined(FOLLY_HAS_CONSTEXPR) && !defined(_clang__)
 #define FOLLY_INTRINSIC_CONSTEXPR constexpr
 #else
 // Unlike GCC, in Clang (as of 3.2) intrinsics aren't constexpr.
@@ -196,7 +196,7 @@ nextPowTwo(T v) {
 }
 
 template <class T>
-inline constexpr
+inline FOLLY_CONSTEXPR
 typename std::enable_if<
   std::is_integral<T>::value && std::is_unsigned<T>::value,
   bool>::type
@@ -248,7 +248,7 @@ struct EndianIntBase {
 #else
 
 template<class Int16>
-inline constexpr typename std::enable_if<
+inline FOLLY_CONSTEXPR typename std::enable_if<
   sizeof(Int16) == 2,
   Int16>::type
 our_bswap16(Int16 x) {
@@ -322,7 +322,7 @@ class Endian {
     BIG
   };
 
-  static constexpr Order order =
+  static FOLLY_CONSTEXPR Order order =
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     Order::LITTLE;
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__

--- a/folly/ConcurrentSkipList-inl.h
+++ b/folly/ConcurrentSkipList-inl.h
@@ -71,7 +71,7 @@ class SkipListNode : private boost::noncopyable {
   }
 
   template<typename NodeAlloc>
-  static constexpr bool destroyIsNoOp() {
+  static FOLLY_CONSTEXPR bool destroyIsNoOp() {
     return IsArenaAllocator<NodeAlloc>::value &&
            boost::has_trivial_destructor<std::atomic<SkipListNode*>>::value;
   }

--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -145,7 +145,7 @@ struct last_element<> {
 namespace detail {
 
 template <typename IntegerType>
-constexpr unsigned int
+FOLLY_CONSTEXPR unsigned int
 digitsEnough() {
   return ceil((double(sizeof(IntegerType) * CHAR_BIT) * M_LN2) / M_LN10);
 }
@@ -594,9 +594,9 @@ namespace detail {
 // Out-of-range flag value, larger than the largest value that can fit in
 // four decimal bytes (9999), but four of these added up together should
 // still not overflow uint16_t.
-constexpr int32_t OOR = 10000;
+FOLLY_CONSTEXPR int32_t OOR = 10000;
 
-__attribute__((aligned(16))) constexpr uint16_t shift1[] = {
+__attribute__((aligned(16))) FOLLY_CONSTEXPR uint16_t shift1[] = {
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  // 0-9
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  10
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  20
@@ -625,7 +625,7 @@ __attribute__((aligned(16))) constexpr uint16_t shift1[] = {
   OOR, OOR, OOR, OOR, OOR, OOR                       // 250
 };
 
-__attribute__((aligned(16))) constexpr uint16_t shift10[] = {
+__attribute__((aligned(16))) FOLLY_CONSTEXPR uint16_t shift10[] = {
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  // 0-9
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  10
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  20
@@ -654,7 +654,7 @@ __attribute__((aligned(16))) constexpr uint16_t shift10[] = {
   OOR, OOR, OOR, OOR, OOR, OOR                       // 250
 };
 
-__attribute__((aligned(16))) constexpr uint16_t shift100[] = {
+__attribute__((aligned(16))) FOLLY_CONSTEXPR uint16_t shift100[] = {
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  // 0-9
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  10
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  20
@@ -683,7 +683,7 @@ __attribute__((aligned(16))) constexpr uint16_t shift100[] = {
   OOR, OOR, OOR, OOR, OOR, OOR                       // 250
 };
 
-__attribute__((aligned(16))) constexpr uint16_t shift1000[] = {
+__attribute__((aligned(16))) FOLLY_CONSTEXPR uint16_t shift1000[] = {
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  // 0-9
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  10
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  20

--- a/folly/FileUtil.h
+++ b/folly/FileUtil.h
@@ -142,7 +142,7 @@ bool readFile(const char* file_name, Container& out,
   // but don't rely on it. In particular, if the size is zero, we
   // should attempt to read stuff. If not zero, we'll attempt to read
   // one extra byte.
-  constexpr size_t initialAlloc = 1024 * 4;
+  FOLLY_CONSTEXPR size_t initialAlloc = 1024 * 4;
   out.resize(
     std::min(
       buf.st_size > 0 ? folly::to<size_t>(buf.st_size + 1) : initialAlloc,

--- a/folly/Format-inl.h
+++ b/folly/Format-inl.h
@@ -303,7 +303,7 @@ void formatString(StringPiece val, FormatArg& arg, FormatCallback& cb) {
     val.reset(val.data(), arg.precision);
   }
 
-  constexpr int padBufSize = 128;
+  FOLLY_CONSTEXPR int padBufSize = 128;
   char padBuf[padBufSize];
 
   // Output padding, no more than padBufSize at once
@@ -463,7 +463,7 @@ class FormatValue<
     // ,d: 26 bytes (including thousands separators!)
     // + nul terminator
     // + 3 for sign and prefix shenanigans (see below)
-    constexpr size_t valBufSize = 69;
+	FOLLY_CONSTEXPR size_t valBufSize = 69;
     char valBuf[valBufSize];
     char* valBufBegin = nullptr;
     char* valBufEnd = nullptr;
@@ -1112,7 +1112,7 @@ class FormatValue<std::tuple<Args...>> {
   }
 
  private:
-  static constexpr size_t valueCount = std::tuple_size<Tuple>::value;
+  static FOLLY_CONSTEXPR size_t valueCount = std::tuple_size<Tuple>::value;
 
   template <size_t K, class Callback>
   typename std::enable_if<K == valueCount>::type

--- a/folly/Format.h
+++ b/folly/Format.h
@@ -126,7 +126,7 @@ class Formatter {
 
   typedef std::tuple<FormatValue<
       typename std::decay<Args>::type>...> ValueTuple;
-  static constexpr size_t valueCount = std::tuple_size<ValueTuple>::value;
+  static FOLLY_CONSTEXPR size_t valueCount = std::tuple_size<ValueTuple>::value;
 
   FOLLY_NORETURN void handleFormatStrError() const;
   template <class Output>

--- a/folly/FormatArg.h
+++ b/folly/FormatArg.h
@@ -90,7 +90,7 @@ struct FormatArg {
   /**
    * Fill
    */
-  static constexpr char kDefaultFill = '\0';
+  static FOLLY_CONSTEXPR char kDefaultFill = '\0';
   char fill;
 
   /**
@@ -131,19 +131,19 @@ struct FormatArg {
   /**
    * Field width
    */
-  static constexpr int kDefaultWidth = -1;
+  static FOLLY_CONSTEXPR int kDefaultWidth = -1;
   int width;
 
   /**
    * Precision
    */
-  static constexpr int kDefaultPrecision = -1;
+  static FOLLY_CONSTEXPR int kDefaultPrecision = -1;
   int precision;
 
   /**
    * Presentation
    */
-  static constexpr char kDefaultPresentation = '\0';
+  static FOLLY_CONSTEXPR char kDefaultPresentation = '\0';
   char presentation;
 
   /**

--- a/folly/IndexedMemPool.h
+++ b/folly/IndexedMemPool.h
@@ -90,13 +90,13 @@ struct IndexedMemPool : boost::noncopyable {
   // these are public because clients may need to reason about the number
   // of bits required to hold indices from a pool, given its capacity
 
-  static constexpr uint32_t maxIndexForCapacity(uint32_t capacity) {
+  static FOLLY_CONSTEXPR uint32_t maxIndexForCapacity(uint32_t capacity) {
     // index of uint32_t(-1) == UINT32_MAX is reserved for isAllocated tracking
     return std::min(uint64_t(capacity) + (NumLocalLists - 1) * LocalListLimit,
                     uint64_t(uint32_t(-1) - 1));
   }
 
-  static constexpr uint32_t capacityForMaxIndex(uint32_t maxIndex) {
+  static FOLLY_CONSTEXPR uint32_t capacityForMaxIndex(uint32_t maxIndex) {
     return maxIndex - (NumLocalLists - 1) * LocalListLimit;
   }
 

--- a/folly/LifoSem.h
+++ b/folly/LifoSem.h
@@ -230,13 +230,13 @@ class LifoSemHead {
     assert(!isNodeIdx());
     return uint32_t(bits);
   }
-  inline constexpr bool isNodeIdx() const {
+  inline FOLLY_CONSTEXPR bool isNodeIdx() const {
     return (bits & IsNodeIdxMask) != 0;
   }
-  inline constexpr bool isShutdown() const {
+  inline FOLLY_CONSTEXPR bool isShutdown() const {
     return (bits & IsShutdownMask) != 0;
   }
-  inline constexpr uint32_t seq() const {
+  inline FOLLY_CONSTEXPR uint32_t seq() const {
     return uint32_t(bits >> SeqShift);
   }
 
@@ -244,7 +244,7 @@ class LifoSemHead {
 
   /// This should only be used for initial construction, not for setting
   /// the value, because it clears the sequence number
-  static inline constexpr LifoSemHead fresh(uint32_t value) {
+  static inline FOLLY_CONSTEXPR LifoSemHead fresh(uint32_t value) {
     return LifoSemHead{ value };
   }
 
@@ -296,10 +296,10 @@ class LifoSemHead {
     return LifoSemHead{ bits | IsShutdownMask };
   }
 
-  inline constexpr bool operator== (const LifoSemHead& rhs) const {
+  inline FOLLY_CONSTEXPR bool operator== (const LifoSemHead& rhs) const {
     return bits == rhs.bits;
   }
-  inline constexpr bool operator!= (const LifoSemHead& rhs) const {
+  inline FOLLY_CONSTEXPR bool operator!= (const LifoSemHead& rhs) const {
     return !(*this == rhs);
   }
 };

--- a/folly/MPMCPipeline.h
+++ b/folly/MPMCPipeline.h
@@ -98,7 +98,7 @@ template <class In, class... Stages> class MPMCPipeline {
              detail::MPMCPipelineStageImpl<
                  typename detail::PipelineStageInfo<Stages>::value_type>...>
     StageTuple;
-  static constexpr size_t kAmplification =
+  static FOLLY_CONSTEXPR size_t kAmplification =
     detail::AmplificationProduct<StageInfos>::value;
 
  public:

--- a/folly/Memory.h
+++ b/folly/Memory.h
@@ -247,7 +247,7 @@ class is_simple_allocator {
   typedef value_type* pointer;
 
 public:
-  constexpr static bool value = !has_destroy<allocator, void(pointer)>::value
+	FOLLY_CONSTEXPR static bool value = !has_destroy<allocator, void(pointer)>::value
     && !has_destroy<allocator, void(void*)>::value;
 };
 

--- a/folly/Padded.h
+++ b/folly/Padded.h
@@ -72,9 +72,9 @@ template <class T, size_t NS>
 class Node<T, NS, typename detail::NodeValid<T,NS>::type> {
  public:
   typedef T value_type;
-  static constexpr size_t kNodeSize = NS;
-  static constexpr size_t kElementCount = NS / sizeof(T);
-  static constexpr size_t kPaddingBytes = NS % sizeof(T);
+  static FOLLY_CONSTEXPR size_t kNodeSize = NS;
+  static FOLLY_CONSTEXPR size_t kElementCount = NS / sizeof(T);
+  static FOLLY_CONSTEXPR size_t kPaddingBytes = NS % sizeof(T);
 
   T* data() { return storage_.data; }
   const T* data() const { return storage_.data; }
@@ -89,7 +89,7 @@ class Node<T, NS, typename detail::NodeValid<T,NS>::type> {
   /**
    * Return the number of nodes needed to represent n values.  Rounds up.
    */
-  static constexpr size_t nodeCount(size_t n) {
+  static FOLLY_CONSTEXPR size_t nodeCount(size_t n) {
     return (n + kElementCount - 1) / kElementCount;
   }
 
@@ -97,7 +97,7 @@ class Node<T, NS, typename detail::NodeValid<T,NS>::type> {
    * Return the total byte size needed to represent n values, rounded up
    * to the nearest full node.
    */
-  static constexpr size_t paddedByteSize(size_t n) {
+  static FOLLY_CONSTEXPR size_t paddedByteSize(size_t n) {
     return nodeCount(n) * NS;
   }
 
@@ -107,7 +107,7 @@ class Node<T, NS, typename detail::NodeValid<T,NS>::type> {
    * return non-zero if kPaddingBytes != 0, as the padding at the end of
    * the last node is not included in the result.
    */
-  static constexpr size_t paddingBytes(size_t n) {
+  static FOLLY_CONSTEXPR size_t paddingBytes(size_t n) {
     return (n ? (kPaddingBytes +
                  (kElementCount - 1 - (n-1) % kElementCount) * sizeof(T)) :
             0);
@@ -120,7 +120,7 @@ class Node<T, NS, typename detail::NodeValid<T,NS>::type> {
    * the padding at the end of the last node is not included in the result.
    * Note that the calculation below works for n=0 correctly (returns 0).
    */
-  static constexpr size_t unpaddedByteSize(size_t n) {
+  static FOLLY_CONSTEXPR size_t unpaddedByteSize(size_t n) {
     return paddedByteSize(n) - paddingBytes(n);
   }
 
@@ -133,11 +133,11 @@ class Node<T, NS, typename detail::NodeValid<T,NS>::type> {
 
 // We must define kElementCount and kPaddingBytes to work around a bug
 // in gtest that odr-uses them.
-template <class T, size_t NS> constexpr size_t
+template <class T, size_t NS> FOLLY_CONSTEXPR size_t
 Node<T, NS, typename detail::NodeValid<T,NS>::type>::kNodeSize;
-template <class T, size_t NS> constexpr size_t
+template <class T, size_t NS> FOLLY_CONSTEXPR size_t
 Node<T, NS, typename detail::NodeValid<T,NS>::type>::kElementCount;
-template <class T, size_t NS> constexpr size_t
+template <class T, size_t NS> FOLLY_CONSTEXPR size_t
 Node<T, NS, typename detail::NodeValid<T,NS>::type>::kPaddingBytes;
 
 template <class Iter> class Iterator;
@@ -223,7 +223,7 @@ class Iterator : public detail::IteratorBase<Iter>::type {
   }
 
   void advance(typename Super::difference_type n) {
-    constexpr ssize_t elementCount = Node::kElementCount;  // signed!
+    FOLLY_CONSTEXPR ssize_t elementCount = Node::kElementCount;  // signed!
     ssize_t newPos = pos_ + n;
     if (newPos >= 0 && newPos < elementCount) {
       pos_ = newPos;
@@ -254,7 +254,7 @@ class Iterator : public detail::IteratorBase<Iter>::type {
   }
 
   typename Super::difference_type distance_to(const Iterator& other) const {
-    constexpr ssize_t elementCount = Node::kElementCount;  // signed!
+    FOLLY_CONSTEXPR ssize_t elementCount = Node::kElementCount;  // signed!
     ssize_t nblocks =
       std::distance(this->base_reference(), other.base_reference());
     return nblocks * elementCount + (other.pos_ - pos_);
@@ -336,7 +336,7 @@ class Adaptor {
   typedef typename const_iterator::difference_type difference_type;
   typedef typename Container::size_type size_type;
 
-  static constexpr size_t kElementsPerNode = Node::kElementCount;
+  static FOLLY_CONSTEXPR size_t kElementsPerNode = Node::kElementCount;
   // Constructors
   Adaptor() : lastCount_(Node::kElementCount) { }
   explicit Adaptor(Container c, size_t lastCount=Node::kElementCount)

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -115,6 +115,18 @@ struct MaxAlign { char c; } __attribute__((aligned));
 # error cannot define platform specific thread local storage
 #endif
 
+/* Define macro wrappers for c++11's constexpr keyword, which
+isn't yet support in MSVC */
+#if !defined(FOLLY_HAVE_CONSTEXPR)
+# if defined(__clang__) || __GNUC_PREREQ(4, 7)
+# define FOLLY_CONSTEXPR constexpr
+# else
+# define FOLLY_CONSTEXPR const
+# endif
+#else
+# define FOLLY_CONSTEXPR constexpr
+#endif
+
 // Define to 1 if you have the `preadv' and `pwritev' functions, respectively
 #if !defined(FOLLY_HAVE_PREADV) && !defined(FOLLY_HAVE_PWRITEV)
 # if defined(__GLIBC_PREREQ)

--- a/folly/Random.h
+++ b/folly/Random.h
@@ -56,10 +56,10 @@ class ThreadLocalPRNG {
     return getImpl(local_);
   }
 
-  static constexpr result_type min() {
+  static FOLLY_CONSTEXPR result_type min() {
     return std::numeric_limits<result_type>::min();
   }
-  static constexpr result_type max() {
+  static FOLLY_CONSTEXPR result_type max() {
     return std::numeric_limits<result_type>::max();
   }
   friend class Random;

--- a/folly/Range.cpp
+++ b/folly/Range.cpp
@@ -61,7 +61,7 @@ namespace {
 
 // It's okay if pages are bigger than this (as powers of two), but they should
 // not be smaller.
-constexpr size_t kMinPageSize = 4096;
+FOLLY_CONSTEXPR size_t kMinPageSize = 4096;
 static_assert(kMinPageSize >= 16,
               "kMinPageSize must be at least SSE register size");
 #define PAGE_FOR(addr) \

--- a/folly/Range.h
+++ b/folly/Range.h
@@ -164,7 +164,7 @@ public:
 
 #if FOLLY_HAVE_CONSTEXPR_STRLEN
   // Works only for Range<const char*>
-  /* implicit */ constexpr Range(Iter str)
+  /* implicit */ FOLLY_CONSTEXPR Range(Iter str)
       : b_(str), e_(str + strlen(str)) {}
 #else
   // Works only for Range<const char*>

--- a/folly/SmallLocks.h
+++ b/folly/SmallLocks.h
@@ -297,7 +297,7 @@ struct SpinLockArray {
     return data_[i].lock;
   }
 
-  constexpr size_t size() const { return N; }
+  FOLLY_CONSTEXPR size_t size() const { return N; }
 
  private:
   struct PaddedSpinLock {

--- a/folly/Subprocess.cpp
+++ b/folly/Subprocess.cpp
@@ -41,8 +41,8 @@
 
 extern char** environ;
 
-constexpr int kExecFailure = 127;
-constexpr int kChildFailure = 126;
+FOLLY_CONSTEXPR int kExecFailure = 127;
+FOLLY_CONSTEXPR int kChildFailure = 126;
 
 namespace folly {
 

--- a/folly/Subprocess.h
+++ b/folly/Subprocess.h
@@ -142,8 +142,8 @@ class ProcessReturnCode {
   void enforce(State state) const;
  private:
   explicit ProcessReturnCode(int rv) : rawStatus_(rv) { }
-  static constexpr int RV_NOT_STARTED = -2;
-  static constexpr int RV_RUNNING = -1;
+  static FOLLY_CONSTEXPR int RV_NOT_STARTED = -2;
+  static FOLLY_CONSTEXPR int RV_RUNNING = -1;
 
   int rawStatus_;
 };

--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -42,6 +42,21 @@
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/mpl/not.hpp>
 
+/**
+* The lack of constexpr means that using
+* std::numeric_limits<LHS>::min() in a template will fail
+* however boost has a clever workaround for this in the form
+* of boost's integer_traits
+*/
+#ifdef FOLLY_HAVE_CONSTEXPR
+#define FOLLY_LIMITS_MAX(x) std::numeric_limits<x>::max()
+#define FOLLY_LIMITS_MIN(x) std::numeric_limits<x>::min()
+#else
+#include <boost/integer_traits.hpp>
+#define FOLLY_LIMITS_MAX(x) boost::integer_traits<x>::const_max
+#define FOLLY_LIMITS_MIN(x) boost::integer_traits<x>::const_min
+#endif
+
 namespace folly {
 
 /**
@@ -343,8 +358,8 @@ struct is_negative_impl<T, false> {
 template <typename RHS, RHS rhs, typename LHS>
 bool less_than_impl(
   typename std::enable_if<
-    (rhs <= std::numeric_limits<LHS>::max()
-      && rhs > std::numeric_limits<LHS>::min()),
+    (rhs <= FOLLY_LIMITS_MIN(LHS)
+      && rhs > FOLLY_LIMITS_MAX(LHS)),
     LHS
   >::type const lhs
 ) {
@@ -354,7 +369,7 @@ bool less_than_impl(
 template <typename RHS, RHS rhs, typename LHS>
 bool less_than_impl(
   typename std::enable_if<
-    (rhs > std::numeric_limits<LHS>::max()),
+    (rhs > FOLLY_LIMITS_MAX(LHS)),
     LHS
   >::type const
 ) {
@@ -364,7 +379,7 @@ bool less_than_impl(
 template <typename RHS, RHS rhs, typename LHS>
 bool less_than_impl(
   typename std::enable_if<
-    (rhs <= std::numeric_limits<LHS>::min()),
+    (rhs <= FOLLY_LIMITS_MIN(LHS)),
     LHS
   >::type const
 ) {
@@ -374,8 +389,8 @@ bool less_than_impl(
 template <typename RHS, RHS rhs, typename LHS>
 bool greater_than_impl(
   typename std::enable_if<
-    (rhs <= std::numeric_limits<LHS>::max()
-      && rhs >= std::numeric_limits<LHS>::min()),
+    (rhs <= FOLLY_LIMITS_MAX(LHS)
+      && rhs >= FOLLY_LIMITS_MIN(LHS)),
     LHS
   >::type const lhs
 ) {
@@ -385,7 +400,7 @@ bool greater_than_impl(
 template <typename RHS, RHS rhs, typename LHS>
 bool greater_than_impl(
   typename std::enable_if<
-    (rhs > std::numeric_limits<LHS>::max()),
+    (rhs > FOLLY_LIMITS_MAX(LHS)),
     LHS
   >::type const
 ) {
@@ -395,7 +410,7 @@ bool greater_than_impl(
 template <typename RHS, RHS rhs, typename LHS>
 bool greater_than_impl(
   typename std::enable_if<
-    (rhs < std::numeric_limits<LHS>::min()),
+    (rhs < FOLLY_LIMITS_MIN(LHS)),
     LHS
   >::type const
 ) {

--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -312,10 +312,10 @@ template <typename T>
 class is_complete {
   template <unsigned long long> struct sfinae {};
   template <typename U>
-  constexpr static bool test(sfinae<sizeof(U)>*) { return true; }
-  template <typename> constexpr static bool test(...) { return false; }
+  FOLLY_CONSTEXPR static bool test(sfinae<sizeof(U)>*) { return true; }
+  template <typename> FOLLY_CONSTEXPR static bool test(...) { return false; }
 public:
-  constexpr static bool value = test<T>(nullptr);
+  FOLLY_CONSTEXPR static bool value = test<T>(nullptr);
 };
 
 /*
@@ -332,12 +332,12 @@ namespace detail {
 
 template <typename T, bool>
 struct is_negative_impl {
-  constexpr static bool check(T x) { return x < 0; }
+  FOLLY_CONSTEXPR static bool check(T x) { return x < 0; }
 };
 
 template <typename T>
 struct is_negative_impl<T, false> {
-  constexpr static bool check(T x) { return false; }
+  FOLLY_CONSTEXPR static bool check(T x) { return false; }
 };
 
 template <typename RHS, RHS rhs, typename LHS>
@@ -406,21 +406,21 @@ bool greater_than_impl(
 
 // same as `x < 0`
 template <typename T>
-constexpr bool is_negative(T x) {
+FOLLY_CONSTEXPR bool is_negative(T x) {
   return folly::detail::is_negative_impl<T, std::is_signed<T>::value>::check(x);
 }
 
 // same as `x <= 0`
 template <typename T>
-constexpr bool is_non_positive(T x) { return !x || folly::is_negative(x); }
+FOLLY_CONSTEXPR bool is_non_positive(T x) { return !x || folly::is_negative(x); }
 
 // same as `x > 0`
 template <typename T>
-constexpr bool is_positive(T x) { return !is_non_positive(x); }
+FOLLY_CONSTEXPR bool is_positive(T x) { return !is_non_positive(x); }
 
 // same as `x >= 0`
 template <typename T>
-constexpr bool is_non_negative(T x) {
+FOLLY_CONSTEXPR bool is_non_negative(T x) {
   return !x || is_positive(x);
 }
 
@@ -458,12 +458,12 @@ FOLLY_ASSUME_FBVECTOR_COMPATIBLE_1(boost::shared_ptr);
       typename UTheClass_, RTheReturn_ (UTheClass_::*)(TTheArgs_...) cv_qual \
     > struct sfinae {}; \
     template <typename UTheClass_> \
-    constexpr static bool test(sfinae<UTheClass_, &UTheClass_::func_name>*) \
+	FOLLY_CONSTEXPR static bool test(sfinae<UTheClass_, &UTheClass_::func_name>*) \
     { return true; } \
     template <typename> \
-    constexpr static bool test(...) { return false; } \
+	FOLLY_CONSTEXPR static bool test(...) { return false; } \
   public: \
-    constexpr static bool value = test<TTheClass_>(nullptr); \
+  FOLLY_CONSTEXPR static bool value = test<TTheClass_>(nullptr); \
   }
 
 /*

--- a/folly/Varint.h
+++ b/folly/Varint.h
@@ -37,12 +37,12 @@ namespace folly {
 /**
  * Maximum length (in bytes) of the varint encoding of a 32-bit value.
  */
-constexpr size_t kMaxVarintLength32 = 5;
+FOLLY_CONSTEXPR size_t kMaxVarintLength32 = 5;
 
 /**
  * Maximum length (in bytes) of the varint encoding of a 64-bit value.
  */
-constexpr size_t kMaxVarintLength64 = 10;
+FOLLY_CONSTEXPR size_t kMaxVarintLength64 = 10;
 
 /**
  * Encode a value in the given buffer, returning the number of bytes used

--- a/folly/detail/MPMCPipelineDetail.h
+++ b/folly/detail/MPMCPipelineDetail.h
@@ -25,7 +25,7 @@ template <class T, class... Stages> class MPMCPipeline;
 template <class T, size_t Amp> class MPMCPipelineStage {
  public:
   typedef T value_type;
-  static constexpr size_t kAmplification = Amp;
+  static FOLLY_CONSTEXPR size_t kAmplification = Amp;
 };
 
 namespace detail {
@@ -35,13 +35,13 @@ namespace detail {
  * we use MPMCPipelineStage<>
  */
 template <class T> struct PipelineStageInfo {
-  static constexpr size_t kAmplification = 1;
+	static FOLLY_CONSTEXPR size_t kAmplification = 1;
   typedef T value_type;
 };
 
 template <class T, size_t Amp>
 struct PipelineStageInfo<MPMCPipelineStage<T, Amp>> {
-  static constexpr size_t kAmplification = Amp;
+  static FOLLY_CONSTEXPR size_t kAmplification = Amp;
   typedef T value_type;
 };
 
@@ -112,12 +112,12 @@ class MPMCPipelineStageImpl {
 template <class Tuple> struct AmplificationProduct;
 
 template <> struct AmplificationProduct<std::tuple<>> {
-  static constexpr size_t value = 1;
+  static FOLLY_CONSTEXPR size_t value = 1;
 };
 
 template <class T, class... Ts>
 struct AmplificationProduct<std::tuple<T, Ts...>> {
-  static constexpr size_t value =
+  static FOLLY_CONSTEXPR size_t value =
     T::kAmplification *
     AmplificationProduct<std::tuple<Ts...>>::value;
 };

--- a/folly/experimental/Bits.h
+++ b/folly/experimental/Bits.h
@@ -123,27 +123,27 @@ struct Bits {
   /**
    * Number of bits in a block.
    */
-  static constexpr size_t bitsPerBlock = std::numeric_limits<
+  static FOLLY_CONSTEXPR size_t bitsPerBlock = std::numeric_limits<
       typename std::make_unsigned<UnderlyingType>::type>::digits;
 
   /**
    * Byte index of the given bit.
    */
-  static constexpr size_t blockIndex(size_t bit) {
+  static FOLLY_CONSTEXPR size_t blockIndex(size_t bit) {
     return bit / bitsPerBlock;
   }
 
   /**
    * Offset in block of the given bit.
    */
-  static constexpr size_t bitOffset(size_t bit) {
+  static FOLLY_CONSTEXPR size_t bitOffset(size_t bit) {
     return bit % bitsPerBlock;
   }
 
   /**
    * Number of blocks used by the given number of bits.
    */
-  static constexpr size_t blockCount(size_t nbits) {
+  static FOLLY_CONSTEXPR size_t blockCount(size_t nbits) {
     return nbits / bitsPerBlock + (nbits % bitsPerBlock != 0);
   }
 
@@ -192,10 +192,10 @@ struct Bits {
   // (bitStart < sizeof(T) * 8, bitStart + count <= sizeof(T) * 8)
   static UnderlyingType innerGet(const T* p, size_t bitStart, size_t count);
 
-  static constexpr UnderlyingType zero = UnderlyingType(0);
-  static constexpr UnderlyingType one = UnderlyingType(1);
+  static FOLLY_CONSTEXPR UnderlyingType zero = UnderlyingType(0);
+  static FOLLY_CONSTEXPR UnderlyingType one = UnderlyingType(1);
 
-  static constexpr UnderlyingType ones(size_t count) {
+  static FOLLY_CONSTEXPR UnderlyingType ones(size_t count) {
     return count < bitsPerBlock ? (one << count) - 1 : ~zero;
   }
 };

--- a/folly/experimental/EliasFanoCoding.h
+++ b/folly/experimental/EliasFanoCoding.h
@@ -94,9 +94,9 @@ struct EliasFanoEncoder {
   typedef Value ValueType;
   typedef SkipValue SkipValueType;
 
-  static constexpr size_t skipQuantum = kSkipQuantum;
-  static constexpr size_t forwardQuantum = kForwardQuantum;
-  static constexpr size_t version = kVersion;
+  static FOLLY_CONSTEXPR size_t skipQuantum = kSkipQuantum;
+  static FOLLY_CONSTEXPR size_t forwardQuantum = kForwardQuantum;
+  static FOLLY_CONSTEXPR size_t version = kVersion;
 
   static uint8_t defaultNumLowerBits(size_t upperBound, size_t size) {
     if (size == 0 || upperBound < size) {
@@ -176,7 +176,7 @@ struct EliasFanoEncoder {
     size_t numSkipPointers = 0;
     /* static */ if (skipQuantum != 0) {
       // Workaround to avoid 'division by zero' compile-time error.
-      constexpr size_t q = skipQuantum ?: 1;
+      FOLLY_CONSTEXPR size_t q = skipQuantum ?: 1;
       /* static */ if (kVersion > 0) {
         CHECK_LT(size, std::numeric_limits<SkipValueType>::max());
       } else {
@@ -212,7 +212,7 @@ struct EliasFanoEncoder {
     size_t numForwardPointers = 0;
     /* static */ if (forwardQuantum != 0) {
       // Workaround to avoid 'division by zero' compile-time error.
-      constexpr size_t q = forwardQuantum ?: 1;
+      FOLLY_CONSTEXPR size_t q = forwardQuantum ?: 1;
       /* static */ if (kVersion > 0) {
         CHECK_LT(upperBound >> numLowerBits,
                  std::numeric_limits<SkipValueType>::max());
@@ -342,7 +342,7 @@ class UpperBitsReader {
     // Use forward pointer.
     if (Encoder::forwardQuantum > 0 && n > Encoder::forwardQuantum) {
       // Workaround to avoid 'division by zero' compile-time error.
-      constexpr size_t q = Encoder::forwardQuantum ?: 1;
+      FOLLY_CONSTEXPR size_t q = Encoder::forwardQuantum ?: 1;
 
       const size_t steps = position_ / q;
       const size_t dest =
@@ -390,7 +390,7 @@ class UpperBitsReader {
     // Use skip pointer.
     if (Encoder::skipQuantum > 0 && v >= value_ + Encoder::skipQuantum) {
       // Workaround to avoid 'division by zero' compile-time error.
-      constexpr size_t q = Encoder::skipQuantum ?: 1;
+      FOLLY_CONSTEXPR size_t q = Encoder::skipQuantum ?: 1;
 
       const size_t steps = v / q;
       const size_t dest =
@@ -416,7 +416,7 @@ class UpperBitsReader {
     size_t cnt;
     size_t skip = v - (8 * outer_ - position_ - 1);
 
-    constexpr size_t kBitsPerBlock = 8 * sizeof(block_t);
+	FOLLY_CONSTEXPR size_t kBitsPerBlock = 8 * sizeof(block_t);
     while ((cnt = Instructions::popcount(~block_)) < skip) {
       skip -= cnt;
       position_ += kBitsPerBlock - cnt;
@@ -425,8 +425,8 @@ class UpperBitsReader {
     }
 
     // Try to skip half-block.
-    constexpr size_t kBitsPerHalfBlock = 4 * sizeof(block_t);
-    constexpr block_t halfBlockMask = (block_t(1) << kBitsPerHalfBlock) - 1;
+	FOLLY_CONSTEXPR size_t kBitsPerHalfBlock = 4 * sizeof(block_t);
+	FOLLY_CONSTEXPR block_t halfBlockMask = (block_t(1) << kBitsPerHalfBlock) - 1;
     if ((cnt = Instructions::popcount(~block_ & halfBlockMask)) < skip) {
       position_ += kBitsPerHalfBlock - cnt;
       block_ &= ~halfBlockMask;

--- a/folly/experimental/EventCount.h
+++ b/folly/experimental/EventCount.h
@@ -128,9 +128,9 @@ class EventCount {
   static_assert(sizeof(uint64_t) == 8, "bad platform");
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-  static constexpr size_t kEpochOffset = 1;
+  static FOLLY_CONSTEXPR size_t kEpochOffset = 1;
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-  static constexpr size_t kEpochOffset = 0;  // in units of sizeof(int)
+  static FOLLY_CONSTEXPR size_t kEpochOffset = 0;  // in units of sizeof(int)
 #else
 # error Your machine uses a weird endianness!
 #endif
@@ -139,11 +139,11 @@ class EventCount {
   // waiter count in the least significant 32 bits.
   std::atomic<uint64_t> val_;
 
-  static constexpr uint64_t kAddWaiter = uint64_t(1);
-  static constexpr uint64_t kSubWaiter = uint64_t(-1);
-  static constexpr size_t  kEpochShift = 32;
-  static constexpr uint64_t kAddEpoch = uint64_t(1) << kEpochShift;
-  static constexpr uint64_t kWaiterMask = kAddEpoch - 1;
+  static FOLLY_CONSTEXPR uint64_t kAddWaiter = uint64_t(1);
+  static FOLLY_CONSTEXPR uint64_t kSubWaiter = uint64_t(-1);
+  static FOLLY_CONSTEXPR size_t  kEpochShift = 32;
+  static FOLLY_CONSTEXPR uint64_t kAddEpoch = uint64_t(1) << kEpochShift;
+  static FOLLY_CONSTEXPR uint64_t kWaiterMask = kAddEpoch - 1;
 };
 
 inline void EventCount::notify() noexcept {

--- a/folly/experimental/exception_tracer/ExceptionTracer.cpp
+++ b/folly/experimental/exception_tracer/ExceptionTracer.cpp
@@ -56,7 +56,7 @@ std::ostream& operator<<(std::ostream& out, const ExceptionInfo& info) {
   try {
     ssize_t frameCount = info.frames.size();
     // Skip our own internal frames
-    static constexpr size_t skip = 3;
+	static FOLLY_CONSTEXPR size_t skip = 3;
 
     if (frameCount > skip) {
       auto addresses = info.frames.data() + skip;

--- a/folly/experimental/exception_tracer/ExceptionTracerBenchmark.cpp
+++ b/folly/experimental/exception_tracer/ExceptionTracerBenchmark.cpp
@@ -44,7 +44,7 @@ void loop(int iters) {
 
 BENCHMARK(ExceptionTracer, iters) {
   std::vector<std::thread> threads;
-  constexpr size_t kNumThreads = 10;
+  FOLLY_CONSTEXPR size_t kNumThreads = 10;
   threads.resize(10);
   for (auto& t : threads) {
     t = std::thread([iters] () { loop(iters); });

--- a/folly/experimental/exception_tracer/StackTrace.h
+++ b/folly/experimental/exception_tracer/StackTrace.h
@@ -24,7 +24,7 @@
 
 namespace folly { namespace exception_tracer {
 
-constexpr size_t kMaxFrames = 500;
+FOLLY_CONSTEXPR size_t kMaxFrames = 500;
 
 struct StackTrace {
   StackTrace() : frameCount(0) { }

--- a/folly/experimental/io/test/AsyncIOTest.cpp
+++ b/folly/experimental/io/test/AsyncIOTest.cpp
@@ -41,7 +41,7 @@ using folly::AsyncIOQueue;
 
 namespace {
 
-constexpr size_t kAlign = 4096;  // align reads to 4096 B (for O_DIRECT)
+FOLLY_CONSTEXPR size_t kAlign = 4096;  // align reads to 4096 B (for O_DIRECT)
 
 struct TestSpec {
   off_t start;

--- a/folly/experimental/symbolizer/ElfCache.h
+++ b/folly/experimental/symbolizer/ElfCache.h
@@ -82,7 +82,7 @@ class SignalSafeElfCache : public ElfCacheBase {
       return data_;
     }
 
-    static constexpr size_t kMaxSize = PATH_MAX - 1;
+	static FOLLY_CONSTEXPR size_t kMaxSize = PATH_MAX - 1;
 
    private:
     char data_[kMaxSize + 1];

--- a/folly/experimental/symbolizer/SignalHandler.cpp
+++ b/folly/experimental/symbolizer/SignalHandler.cpp
@@ -189,7 +189,7 @@ void dumpSignalInfo(int signum, siginfo_t* siginfo) {
 }
 
 namespace {
-constexpr size_t kDefaultCapacity = 500;
+FOLLY_CONSTEXPR size_t kDefaultCapacity = 500;
 
 // Note: not thread-safe, but that's okay, as we only let one thread
 // in our signal handler at a time.
@@ -203,7 +203,7 @@ FOLLY_NOINLINE void dumpStackTrace(bool symbolize);
 void dumpStackTrace(bool symbolize) {
   SCOPE_EXIT { fsyncNoInt(STDERR_FILENO); };
   // Get and symbolize stack trace
-  constexpr size_t kMaxStackTraceDepth = 100;
+  FOLLY_CONSTEXPR size_t kMaxStackTraceDepth = 100;
   FrameArray<kMaxStackTraceDepth> addresses;
 
   // Skip the getStackTrace frame
@@ -235,7 +235,7 @@ void dumpStackTrace(bool symbolize) {
 // take to indicate "no thread in the signal handler".
 //
 // POSIX defines PTHREAD_NULL for this purpose, but that's not available.
-constexpr pthread_t kInvalidThreadId = 0;
+FOLLY_CONSTEXPR pthread_t kInvalidThreadId = 0;
 
 std::atomic<pthread_t> gSignalThread(kInvalidThreadId);
 std::atomic<bool> gInRecursiveSignalHandler(false);

--- a/folly/experimental/symbolizer/Symbolizer.cpp
+++ b/folly/experimental/symbolizer/Symbolizer.cpp
@@ -153,7 +153,7 @@ bool parseProcMapsLine(StringPiece line,
 }
 
 ElfCache* defaultElfCache() {
-  static constexpr size_t defaultCapacity = 500;
+  static FOLLY_CONSTEXPR size_t defaultCapacity = 500;
   static ElfCache cache(defaultCapacity);
   return &cache;
 }
@@ -268,7 +268,7 @@ const SymbolizePrinter::Color kFunctionColor = SymbolizePrinter::Color::PURPLE;
 const SymbolizePrinter::Color kFileColor = SymbolizePrinter::Color::DEFAULT;
 }  // namespace
 
-constexpr char AddressFormatter::bufTemplate[];
+FOLLY_CONSTEXPR char AddressFormatter::bufTemplate[];
 
 AddressFormatter::AddressFormatter() {
   memcpy(buf_, bufTemplate, sizeof(buf_));

--- a/folly/experimental/symbolizer/Symbolizer.h
+++ b/folly/experimental/symbolizer/Symbolizer.h
@@ -147,7 +147,7 @@ class AddressFormatter {
   StringPiece format(uintptr_t address);
 
  private:
-  static constexpr char bufTemplate[] = "    @ 0000000000000000";
+  static FOLLY_CONSTEXPR char bufTemplate[] = "    @ 0000000000000000";
   char buf_[sizeof(bufTemplate)];
 };
 

--- a/folly/experimental/symbolizer/test/StackTraceTest.cpp
+++ b/folly/experimental/symbolizer/test/StackTraceTest.cpp
@@ -27,7 +27,7 @@ FOLLY_NOINLINE void foo1();
 FOLLY_NOINLINE void foo2();
 
 void verifyStackTraces() {
-  constexpr size_t kMaxAddresses = 100;
+  FOLLY_CONSTEXPR size_t kMaxAddresses = 100;
   FrameArray<kMaxAddresses> fa;
   CHECK(getStackTrace(fa));
 

--- a/folly/experimental/test/EliasFanoCodingTest.cpp
+++ b/folly/experimental/test/EliasFanoCodingTest.cpp
@@ -22,7 +22,7 @@ using namespace folly::compression;
 
 template <size_t kVersion>
 struct TestType {
-  static constexpr size_t Version = kVersion;
+  static FOLLY_CONSTEXPR size_t Version = kVersion;
 };
 
 template <class T>
@@ -69,8 +69,8 @@ TYPED_TEST(EliasFanoCodingTest, SkipForwardPointers) {
 
 namespace bm {
 
-constexpr size_t k1M = 1000000;
-constexpr size_t kVersion = 1;
+FOLLY_CONSTEXPR size_t k1M = 1000000;
+FOLLY_CONSTEXPR size_t kVersion = 1;
 
 typedef EliasFanoEncoder<uint32_t, uint32_t, 128, 128, kVersion> Encoder;
 typedef EliasFanoReader<Encoder> Reader;

--- a/folly/gen/Base-inl.h
+++ b/folly/gen/Base-inl.h
@@ -396,7 +396,7 @@ class Map : public Operator<Map<Predicate>> {
       });
     }
 
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Source,
@@ -462,7 +462,7 @@ class Filter : public Operator<Filter<Predicate>> {
       });
     }
 
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Source,
@@ -539,7 +539,7 @@ class Until : public Operator<Until<Predicate>> {
   }
 
   // Theoretically an 'until' might stop an infinite
-  static constexpr bool infinite = false;
+  static FOLLY_CONSTEXPR bool infinite = false;
 };
 
 /**
@@ -732,7 +732,7 @@ class Skip : public Operator<Skip> {
         });
     }
 
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Source,
@@ -1044,7 +1044,7 @@ class Batch : public Operator<Batch> {
       return shouldContinue;
     }
 
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Source,
@@ -1505,7 +1505,7 @@ class Concat : public Operator<Concat> {
         });
     }
 
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Value,
@@ -1641,7 +1641,7 @@ class GuardImpl : public Operator<GuardImpl<Exception, ErrorHandler>> {
       });
     }
 
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Value,
@@ -1706,7 +1706,7 @@ class Cycle : public Operator<Cycle> {
     }
 
     // not actually infinite, since an empty generator will end the cycles.
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Source,
@@ -1774,7 +1774,7 @@ class Dereference : public Operator<Dereference> {
     }
 
     // not actually infinite, since an empty generator will end the cycles.
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Source,

--- a/folly/gen/Core-inl.h
+++ b/folly/gen/Core-inl.h
@@ -33,27 +33,27 @@ namespace folly { namespace gen {
  */
 template<class Candidate, class Expected>
 class IsCompatibleSignature {
-  static constexpr bool value = false;
+  static FOLLY_CONSTEXPR bool value = false;
 };
 
 template<class Candidate,
          class ExpectedReturn,
          class... ArgTypes>
 class IsCompatibleSignature<Candidate, ExpectedReturn(ArgTypes...)> {
-  template<class F,
-           class ActualReturn =
+  template<class F,tur
+           class ActualRen =
              decltype(std::declval<F>()(std::declval<ArgTypes>()...)),
            bool good = std::is_same<ExpectedReturn, ActualReturn>::value>
-  static constexpr bool testArgs(int* p) {
+  static FOLLY_CONSTEXPR bool testArgs(int* p) {
     return good;
   }
 
   template<class F>
-  static constexpr bool testArgs(...) {
+  static FOLLY_CONSTEXPR bool testArgs(...) {
     return false;
   }
 public:
-  static constexpr bool value = testArgs<Candidate>(nullptr);
+  static FOLLY_CONSTEXPR bool value = testArgs<Candidate>(nullptr);
 };
 
 /**
@@ -178,7 +178,7 @@ class GenImpl : public FBounded<Self> {
   // Child classes should override if the sequence generated is *definitely*
   // infinite. 'infinite' may be false_type for some infinite sequences
   // (due the the Halting Problem).
-  static constexpr bool infinite = false;
+  static FOLLY_CONSTEXPR bool infinite = false;
 };
 
 template<class LeftValue,
@@ -358,7 +358,7 @@ public:
     second_.foreach(std::forward<Body>(body));
   }
 
-  static constexpr bool infinite = First::infinite || Second::infinite;
+  static FOLLY_CONSTEXPR bool infinite = First::infinite || Second::infinite;
 };
 
 } // detail

--- a/folly/gen/File-inl.h
+++ b/folly/gen/File-inl.h
@@ -55,7 +55,7 @@ class FileReader : public GenImpl<ByteRange, FileReader> {
 
   // Technically, there could be infinite files (e.g. /dev/random), but people
   // who open those can do so at their own risk.
-  static constexpr bool infinite = false;
+  static FOLLY_CONSTEXPR bool infinite = false;
 
  private:
   File file_;

--- a/folly/gen/ParallelMap-inl.h
+++ b/folly/gen/ParallelMap-inl.h
@@ -233,7 +233,7 @@ class PMap : public Operator<PMap<Predicate>> {
       return more;
     }
 
-    static constexpr bool infinite = Source::infinite;
+    static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Source,

--- a/folly/gen/String-inl.h
+++ b/folly/gen/String-inl.h
@@ -86,7 +86,7 @@ class StringResplitter : public Operator<StringResplitter> {
           if (!buffer) {
             // Arbitrarily assume that we have half a line and get enough
             // room for twice that.
-            constexpr size_t kDefaultLineSize = 256;
+            FOLLY_CONSTEXPR size_t kDefaultLineSize = 256;
             buffer = IOBuf::create(std::max(kDefaultLineSize, 2 * in.size()));
           }
           buffer->reserve(0, in.size());
@@ -110,7 +110,7 @@ class StringResplitter : public Operator<StringResplitter> {
       return true;
     }
 
-    static constexpr bool infinite = Source::infinite;
+	static FOLLY_CONSTEXPR bool infinite = Source::infinite;
   };
 
   template<class Source,

--- a/folly/gen/test/ParallelBenchmark.cpp
+++ b/folly/gen/test/ParallelBenchmark.cpp
@@ -33,7 +33,7 @@ using namespace folly::gen;
 using std::vector;
 
 
-constexpr int kFib = 28;  // unit of work
+FOLLY_CONSTEXPR int kFib = 28;  // unit of work
 size_t fib(int n) { return n <= 1 ? 1 : fib(n - 1) + fib(n - 2); }
 
 static auto add = [](int a, int b) { return a + b; };

--- a/folly/gen/test/ParallelMapBenchmark.cpp
+++ b/folly/gen/test/ParallelMapBenchmark.cpp
@@ -30,7 +30,7 @@ DEFINE_int32(threads,
              std::max(1, (int32_t) sysconf(_SC_NPROCESSORS_CONF) / 2),
              "Num threads.");
 
-constexpr int kFib = 35;  // unit of work
+FOLLY_CONSTEXPR int kFib = 35;  // unit of work
 size_t fib(int n) { return n <= 1 ? 1 : fib(n-1) * fib(n-2); }
 
 BENCHMARK(FibSumMap, n) {

--- a/folly/io/Compression.cpp
+++ b/folly/io/Compression.cpp
@@ -506,8 +506,8 @@ std::unique_ptr<IOBuf> ZlibCodec::doCompress(const IOBuf* data) {
   uint64_t maxCompressedLength = deflateBound(&stream, uncompressedLength);
 
   // Max 64MiB in one go
-  constexpr uint32_t maxSingleStepLength = uint32_t(64) << 20;    // 64MiB
-  constexpr uint32_t defaultBufferLength = uint32_t(4) << 20;     // 4MiB
+  FOLLY_CONSTEXPR uint32_t maxSingleStepLength = uint32_t(64) << 20;    // 64MiB
+  FOLLY_CONSTEXPR uint32_t defaultBufferLength = uint32_t(4) << 20;     // 4MiB
 
   auto out = addOutputBuffer(
       &stream,
@@ -579,8 +579,8 @@ std::unique_ptr<IOBuf> ZlibCodec::doUncompress(const IOBuf* data,
   };
 
   // Max 64MiB in one go
-  constexpr uint32_t maxSingleStepLength = uint32_t(64) << 20;    // 64MiB
-  constexpr uint32_t defaultBufferLength = uint32_t(4) << 20;     // 4MiB
+  FOLLY_CONSTEXPR uint32_t maxSingleStepLength = uint32_t(64) << 20;    // 64MiB
+  FOLLY_CONSTEXPR uint32_t defaultBufferLength = uint32_t(4) << 20;     // 4MiB
 
   auto out = addOutputBuffer(
       &stream,
@@ -714,8 +714,8 @@ std::unique_ptr<IOBuf> LZMA2Codec::doCompress(const IOBuf* data) {
   uint64_t maxCompressedLength = lzma_stream_buffer_bound(uncompressedLength);
 
   // Max 64MiB in one go
-  constexpr uint32_t maxSingleStepLength = uint32_t(64) << 20;    // 64MiB
-  constexpr uint32_t defaultBufferLength = uint32_t(4) << 20;     // 4MiB
+  FOLLY_CONSTEXPR uint32_t maxSingleStepLength = uint32_t(64) << 20;    // 64MiB
+  FOLLY_CONSTEXPR uint32_t defaultBufferLength = uint32_t(4) << 20;     // 4MiB
 
   auto out = addOutputBuffer(
     &stream,
@@ -806,8 +806,8 @@ std::unique_ptr<IOBuf> LZMA2Codec::doUncompress(const IOBuf* data,
   SCOPE_EXIT { lzma_end(&stream); };
 
   // Max 64MiB in one go
-  constexpr uint32_t maxSingleStepLength = uint32_t(64) << 20;    // 64MiB
-  constexpr uint32_t defaultBufferLength = uint32_t(4) << 20;     // 4MiB
+  FOLLY_CONSTEXPR uint32_t maxSingleStepLength = uint32_t(64) << 20;    // 64MiB
+  FOLLY_CONSTEXPR uint32_t defaultBufferLength = uint32_t(4) << 20;     // 4MiB
 
   folly::io::Cursor cursor(data);
   uint64_t actualUncompressedLength;

--- a/folly/io/Compression.h
+++ b/folly/io/Compression.h
@@ -119,7 +119,7 @@ class Codec {
    * Regardless of the behavior of the underlying compressor, uncompressing
    * an empty IOBuf chain will return an empty IOBuf chain.
    */
-  static constexpr uint64_t UNKNOWN_UNCOMPRESSED_LENGTH = uint64_t(-1);
+  static FOLLY_CONSTEXPR uint64_t UNKNOWN_UNCOMPRESSED_LENGTH = uint64_t(-1);
 
   std::unique_ptr<IOBuf> uncompress(
       const IOBuf* data,
@@ -140,9 +140,9 @@ class Codec {
   CodecType type_;
 };
 
-constexpr int COMPRESSION_LEVEL_FASTEST = -1;
-constexpr int COMPRESSION_LEVEL_DEFAULT = -2;
-constexpr int COMPRESSION_LEVEL_BEST = -3;
+FOLLY_CONSTEXPR int COMPRESSION_LEVEL_FASTEST = -1;
+FOLLY_CONSTEXPR int COMPRESSION_LEVEL_DEFAULT = -2;
+FOLLY_CONSTEXPR int COMPRESSION_LEVEL_BEST = -3;
 
 /**
  * Return a codec for the given type. Throws on error.  The level

--- a/folly/io/RecordIO-inl.h
+++ b/folly/io/RecordIO-inl.h
@@ -66,7 +66,7 @@ struct Header {
   // Any values will do, except that the sequence must not have a
   // repeated prefix (that is, if we see kMagic, we know that the next
   // occurrence must start at least 4 bytes later)
-  static constexpr uint32_t kMagic = 0xeac313a1;
+  static FOLLY_CONSTEXPR uint32_t kMagic = 0xeac313a1;
   uint32_t magic;
   uint8_t  version;       // backwards incompatible version, currently 0
   uint8_t  hashFunction;  // 0 = SpookyHashV2
@@ -82,7 +82,7 @@ static_assert(offsetof(Header, headerHash) + sizeof(Header::headerHash) ==
 
 }  // namespace detail
 
-constexpr size_t headerSize() { return sizeof(detail::Header); }
+FOLLY_CONSTEXPR size_t headerSize() { return sizeof(detail::Header); }
 
 inline RecordInfo findRecord(ByteRange range, uint32_t fileId) {
   return findRecord(range, range, fileId);

--- a/folly/io/RecordIO.cpp
+++ b/folly/io/RecordIO.cpp
@@ -109,7 +109,7 @@ using namespace detail;
 
 namespace {
 
-constexpr uint32_t kHashSeed = 0xdeadbeef;  // for mcurtiss
+FOLLY_CONSTEXPR uint32_t kHashSeed = 0xdeadbeef;  // for mcurtiss
 
 uint32_t headerHash(const Header& header) {
   return hash::SpookyHashV2::Hash32(&header, offsetof(Header, headerHash),

--- a/folly/io/RecordIO.h
+++ b/folly/io/RecordIO.h
@@ -128,7 +128,7 @@ namespace recordio_helpers {
 /**
  * Header size.
  */
-constexpr size_t headerSize();  // defined in RecordIO-inl.h
+FOLLY_CONSTEXPR size_t headerSize();  // defined in RecordIO-inl.h
 
 /**
  * Write a header in the buffer.  We will prepend the header to the front

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -82,8 +82,8 @@ class RandomDataHolder : public DataHolder {
 
 RandomDataHolder::RandomDataHolder(size_t sizeLog2)
   : DataHolder(sizeLog2) {
-  constexpr size_t numThreadsLog2 = 3;
-  constexpr size_t numThreads = size_t(1) << numThreadsLog2;
+  FOLLY_CONSTEXPR size_t numThreadsLog2 = 3;
+  FOLLY_CONSTEXPR size_t numThreads = size_t(1) << numThreadsLog2;
 
   uint32_t seed = randomNumberSeed();
 
@@ -116,7 +116,7 @@ ConstantDataHolder::ConstantDataHolder(size_t sizeLog2)
   memset(data_.get(), 'a', size_);
 }
 
-constexpr size_t dataSizeLog2 = 27;  // 128MiB
+FOLLY_CONSTEXPR size_t dataSizeLog2 = 27;  // 128MiB
 RandomDataHolder randomDataHolder(dataSizeLog2);
 ConstantDataHolder constantDataHolder(dataSizeLog2);
 
@@ -195,7 +195,7 @@ class CompressionCorruptionTest : public testing::TestWithParam<CodecType> {
 };
 
 void CompressionCorruptionTest::runSimpleTest(const DataHolder& dh) {
-  constexpr uint64_t uncompressedLength = 42;
+  FOLLY_CONSTEXPR uint64_t uncompressedLength = 42;
   auto original = IOBuf::wrapBuffer(dh.data(uncompressedLength));
   auto compressed = codec_->compress(original.get());
 

--- a/folly/io/test/RecordIOTest.cpp
+++ b/folly/io/test/RecordIOTest.cpp
@@ -88,7 +88,7 @@ TEST(RecordIOTest, Simple) {
 }
 
 TEST(RecordIOTest, SmallRecords) {
-  constexpr size_t kSize = 10;
+  FOLLY_CONSTEXPR size_t kSize = 10;
   char tmp[kSize];
   memset(tmp, 'x', kSize);
   TemporaryFile file;

--- a/folly/small_vector.h
+++ b/folly/small_vector.h
@@ -228,7 +228,7 @@ namespace detail {
     IntegralSizePolicy() : size_(0) {}
 
   protected:
-    static constexpr std::size_t policyMaxSize() {
+    static FOLLY_CONSTEXPR std::size_t policyMaxSize() {
       return SizeType(~kExternMask);
     }
 
@@ -282,7 +282,7 @@ namespace detail {
   protected:
     static bool const kShouldUseHeap = ShouldUseHeap;
 
-    static constexpr std::size_t policyMaxSize() {
+	static FOLLY_CONSTEXPR std::size_t policyMaxSize() {
       return SizeType(~(SizeType(1) << kLockBit | kExternMask));
     }
 
@@ -529,7 +529,7 @@ public:
     return std::lexicographical_compare(begin(), end(), o.begin(), o.end());
   }
 
-  static constexpr size_type max_size() {
+  static FOLLY_CONSTEXPR size_type max_size() {
     return !BaseType::kShouldUseHeap ? MaxInline
                                      : BaseType::policyMaxSize();
   }

--- a/folly/test/AtomicBitSetTest.cpp
+++ b/folly/test/AtomicBitSetTest.cpp
@@ -22,7 +22,7 @@
 namespace folly { namespace test {
 
 TEST(AtomicBitSet, Simple) {
-  constexpr size_t kSize = 1000;
+  FOLLY_CONSTEXPR size_t kSize = 1000;
   AtomicBitSet<kSize> bs;
 
   EXPECT_EQ(kSize, bs.size());

--- a/folly/test/DeterministicSchedule.h
+++ b/folly/test/DeterministicSchedule.h
@@ -155,7 +155,7 @@ struct DeterministicAtomic {
   DeterministicAtomic(DeterministicAtomic<T> const &) = delete;
   DeterministicAtomic<T>& operator= (DeterministicAtomic<T> const &) = delete;
 
-  constexpr /* implicit */ DeterministicAtomic(T v) noexcept : data(v) {}
+  FOLLY_CONSTEXPR /* implicit */ DeterministicAtomic(T v) noexcept : data(v) {}
 
   bool is_lock_free() const noexcept {
     return data.is_lock_free();

--- a/folly/test/FileTest.cpp
+++ b/folly/test/FileTest.cpp
@@ -141,7 +141,7 @@ TEST(File, Locks) {
   typedef boost::shared_lock<File> SharedLock;
 
   // Find out where we are.
-  static constexpr size_t pathLength = 2048;
+  static FOLLY_CONSTEXPR size_t pathLength = 2048;
   char buf[pathLength + 1];
   int r = readlink("/proc/self/exe", buf, pathLength);
   CHECK_ERR(r);

--- a/folly/test/MPMCPipelineTest.cpp
+++ b/folly/test/MPMCPipelineTest.cpp
@@ -75,7 +75,7 @@ TEST(MPMCPipeline, TrivialAmplification) {
 }
 
 TEST(MPMCPipeline, MultiThreaded) {
-  constexpr size_t numThreadsPerStage = 6;
+  FOLLY_CONSTEXPR size_t numThreadsPerStage = 6;
   MPMCPipeline<int, std::string, std::string> a(5, 5, 5);
 
   std::vector<std::thread> threads;
@@ -124,7 +124,7 @@ TEST(MPMCPipeline, MultiThreaded) {
     }
   });
 
-  constexpr size_t numValues = 1000;
+  FOLLY_CONSTEXPR size_t numValues = 1000;
   for (size_t i = 0; i < numValues; ++i) {
     a.blockingWrite(i);
   }

--- a/folly/test/RangeFindBenchmark.cpp
+++ b/folly/test/RangeFindBenchmark.cpp
@@ -40,7 +40,7 @@ using namespace std;
 namespace {
 
 std::string str;
-constexpr int kVstrSize = 16;
+FOLLY_CONSTEXPR int kVstrSize = 16;
 std::vector<std::string> vstr;
 std::vector<StringPiece> vstrp;
 

--- a/folly/test/RangeTest.cpp
+++ b/folly/test/RangeTest.cpp
@@ -249,7 +249,7 @@ void expectEQ(const T& a, const T& b) {
 
 TEST(StringPiece, EightBitComparisons) {
   char values[] = {'\x00', '\x20', '\x40', '\x7f', '\x80', '\xc0', '\xff'};
-  constexpr size_t count = sizeof(values) / sizeof(values[0]);
+  FOLLY_CONSTEXPR size_t count = sizeof(values) / sizeof(values[0]);
   for (size_t i = 0; i < count; ++i) {
     std::string a(1, values[i]);
     // Defeat copy-on-write
@@ -298,13 +298,13 @@ TEST(StringPiece, InvalidRange) {
 }
 
 #if FOLLY_HAVE_CONSTEXPR_STRLEN
-constexpr char helloArray[] = "hello";
+FOLLY_CONSTEXPR char helloArray[] = "hello";
 
 TEST(StringPiece, Constexpr) {
-  constexpr StringPiece hello1("hello");
+  FOLLY_CONSTEXPR StringPiece hello1("hello");
   EXPECT_EQ("hello", hello1);
 
-  constexpr StringPiece hello2(helloArray);
+  FOLLY_CONSTEXPR StringPiece hello2(helloArray);
   EXPECT_EQ("hello", hello2);
 }
 #endif

--- a/folly/test/SubprocessTest.cpp
+++ b/folly/test/SubprocessTest.cpp
@@ -179,7 +179,7 @@ TEST(SimpleSubprocessTest, FdLeakTest) {
 
 TEST(ParentDeathSubprocessTest, ParentDeathSignal) {
   // Find out where we are.
-  static constexpr size_t pathLength = 2048;
+  static FOLLY_CONSTEXPR size_t pathLength = 2048;
   char buf[pathLength + 1];
   int r = readlink("/proc/self/exe", buf, pathLength);
   CHECK_ERR(r);

--- a/folly/test/SubprocessTestParentDeathHelper.cpp
+++ b/folly/test/SubprocessTestParentDeathHelper.cpp
@@ -39,7 +39,7 @@ using folly::Subprocess;
 DEFINE_bool(child, false, "");
 
 namespace {
-constexpr int kSignal = SIGUSR1;
+FOLLY_CONSTEXPR int kSignal = SIGUSR1;
 }  // namespace
 
 void runChild(const char* file) {

--- a/folly/test/ThreadLocalTest.cpp
+++ b/folly/test/ThreadLocalTest.cpp
@@ -305,7 +305,7 @@ TEST(ThreadLocal, Movable2) {
 
 namespace {
 
-constexpr size_t kFillObjectSize = 300;
+FOLLY_CONSTEXPR size_t kFillObjectSize = 300;
 
 std::atomic<uint64_t> gDestroyed;
 
@@ -348,11 +348,11 @@ class FillObject {
 
 #if FOLLY_HAVE_STD__THIS_THREAD__SLEEP_FOR
 TEST(ThreadLocal, Stress) {
-  constexpr size_t numFillObjects = 250;
+  FOLLY_CONSTEXPR size_t numFillObjects = 250;
   std::array<ThreadLocalPtr<FillObject>, numFillObjects> objects;
 
-  constexpr size_t numThreads = 32;
-  constexpr size_t numReps = 20;
+  FOLLY_CONSTEXPR size_t numThreads = 32;
+  FOLLY_CONSTEXPR size_t numReps = 20;
 
   std::vector<std::thread> threads;
   threads.reserve(numThreads);

--- a/folly/test/VarintTest.cpp
+++ b/folly/test/VarintTest.cpp
@@ -96,7 +96,7 @@ TEST(ZigZag, Simple) {
 
 namespace {
 
-constexpr size_t kNumValues = 1000;
+FOLLY_CONSTEXPR size_t kNumValues = 1000;
 std::vector<uint64_t> gValues;
 std::vector<uint64_t> gDecodedValues;
 std::vector<uint8_t> gEncoded;


### PR DESCRIPTION
adds a FOLLY_CONSTEXPR define - controlled by portability.h

This shouldn't change any existing functionality, only make visual studio not puke on constexpr