### PR TITLE
Fix conflicting typedef with /usr/include/time.h

### DIFF
--- a/folly/detail/Clock.h
+++ b/folly/detail/Clock.h
@@ -29,7 +29,7 @@
           that do not support clock_gettime(2).
 #endif
 
-typedef uint8_t clockid_t;
+typedef __clockid_t clockid_t;
 #define CLOCK_REALTIME 0
 
 int clock_gettime(clockid_t clk_id, struct timespec* ts);


### PR DESCRIPTION
I'm building hhvm on Archlinux with GCC 4.9.0 and encountered the following error.
```
In file included from /path/to/hhvm/third-party/folly/folly/Portability.h:144:0,
                 from /path/to/hhvm/third-party/folly/folly/Range.h:23,
                 from /path/to/hhvm/third-party/folly/folly/Range.cpp:20:
/path/to/hhvm/third-party/folly/folly/detail/Clock.h:32:17: error: conflicting declaration 'typedef uint8_t clockid_t'
 typedef uint8_t clockid_t;
                 ^
In file included from /usr/lib/gcc/x86_64-unknown-linux-gnu/4.9.0/../../../../include/c++/4.9.0/ctime:42:0,
                 from /path/to/hhvm/third-party/folly/folly/detail/Clock.h:20,
                 from /path/to/hhvm/third-party/folly/folly/Portability.h:144,
                 from /path/to/hhvm/third-party/folly/folly/Range.h:23,
                 from /path/to/hhvm/third-party/folly/folly/Range.cpp:20:
/usr/include/time.h:91:21: note: previous declaration as 'typedef __clockid_t clockid_t'
 typedef __clockid_t clockid_t;
                     ^
```