### PR TITLE
Remove duplicated Exception.h

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -62,14 +62,13 @@ nobase_follyinclude_HEADERS = \
 	dynamic.h \
 	dynamic-inl.h \
 	Exception.h \
+	ExceptionWrapper.h \
 	FBString.h \
 	FBVector.h \
 	File.h \
 	FileUtil.h \
 	Fingerprint.h \
 	folly-config.h \
-	Exception.h \
-	ExceptionWrapper.h \
 	Foreach.h \
 	FormatArg.h \
 	Format.h \


### PR DESCRIPTION
There is a duplicated Exception.h in "nobase_follyinclude_HEADERS" section in Makefile.am, which makes installing procedure fail.

This update removed the extra "Exception.h" and put "ExceptionWrapper.h" to its place in alphabetical order.

Thanks!
