### PR TITLE
Make the STL functions in FunctionalExcept.cpp conditionally compiled

### DIFF
--- a/folly/detail/FunctionalExcept.cpp
+++ b/folly/detail/FunctionalExcept.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#ifndef FOLLY_HAVE_BITS_FUNCTEXCEPT_H
+
 #include "folly/detail/FunctionalExcept.h"
 
 #include <stdexcept>
@@ -39,3 +41,5 @@ void __throw_bad_alloc() {
 #endif
 
 FOLLY_NAMESPACE_STD_END
+
+#endif  // FOLLY_HAVE_BITS_FUNCTEXCEPT_H


### PR DESCRIPTION
Make the STL functions in FunctionalExcept.cpp conditionally compiled 
based on the config.

Without this patch, programs which statically link libfolly and newer
versions of libstdc++ will cretae linker errors because of multiple
definitions of the __throw_* functions: one from libfolly and one from
libstdc++.