### PR TITLE
fix folly build on OSX and BSD

### DIFF
--- a/folly/MemoryMapping.cpp
+++ b/folly/MemoryMapping.cpp
@@ -16,6 +16,7 @@
 
 #include "folly/MemoryMapping.h"
 #include "folly/Format.h"
+#include "folly/Portability.h"
 
 #ifdef __linux__
 #include "folly/experimental/io/HugePages.h"

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -34,6 +34,12 @@
  #endif
 #endif
 
+#ifndef MAP_ANONYMOUS
+ #include <sys/mman.h>
+ #ifdef MAP_ANON
+  #define MAP_ANONYMOUS MAP_ANON
+ #endif
+#endif
 
 // MaxAlign: max_align_t isn't supported by gcc
 #ifdef __GNUC__


### PR DESCRIPTION
A recent change in folly/MemoryMapping.cpp uses MAP_ANONYMOUS, which is
named MAP_ANON on OSX/BSD.
