### PR TITLE
be explicit about what we're passing to Endian::big

### DIFF
--- a/folly/MacAddress.cpp
+++ b/folly/MacAddress.cpp
@@ -24,7 +24,7 @@ using std::string;
 
 namespace folly {
 
-const MacAddress MacAddress::BROADCAST{Endian::big(0xffffffffffffU)};
+const MacAddress MacAddress::BROADCAST{Endian::big(uint64_t(0xffffffffffffU))};
 const MacAddress MacAddress::ZERO;
 
 MacAddress::MacAddress(StringPiece str) {


### PR DESCRIPTION
This prevents a linker error on OSX:
Undefined symbols for architecture x86_64:
  "folly::detail::EndianIntBase<unsigned long>::swap(unsigned long)",
  referenced from:
        __GLOBAL__sub_I_MacAddress.cpp in libfolly.a(MacAddress.cpp.o)
    ld: symbol(s) not found for architecture x86_64
