### PR TITLE
don't use readFromSysfs on non-linux

### DIFF
--- a/folly/detail/CacheLocality.cpp
+++ b/folly/detail/CacheLocality.cpp
@@ -32,11 +32,13 @@ namespace folly { namespace detail {
 
 /// Returns the best real CacheLocality information available
 static CacheLocality getSystemLocalityInfo() {
+#ifdef __linux
   try {
     return CacheLocality::readFromSysfs();
   } catch (...) {
     // keep trying
   }
+#endif
 
   long numCpus = sysconf(_SC_NPROCESSORS_CONF);
   if (numCpus <= 0) {


### PR DESCRIPTION
It eventually tries to read from /sys/devices which is not portable.
Let's just fall back to sysconf/CacheLocality::uniform.

This fixes a runtime crash on OSX, but CYGWIN/BSD were probably also
affected.
