### PR TITLE
Fix Traits.h std::* declarations conflict with libc++

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -235,6 +235,8 @@ template <class T> struct IsZeroInitializable
  * although that is not guaranteed by the standard.
  */
 
+#ifndef _LIBCPP_VERSION
+
 FOLLY_NAMESPACE_STD_BEGIN
 
 template <class T, class U>
@@ -260,6 +262,23 @@ template <class T>
   class shared_ptr;
 
 FOLLY_NAMESPACE_STD_END
+
+#else
+
+/**
+ * libc++ doesn't like the std::* classes being (re)defined (in an
+ * incompatible way), so use the official ones instead.
+ */
+#include <utility>
+#include <string>
+#include <vector>
+#include <deque>
+#include <list>
+#include <set>
+#include <map>
+#include <memory>
+
+#endif
 
 namespace boost {
 


### PR DESCRIPTION
When compiling folly with clang and libc++, the declaration in folly/Traits.h
clash with the ones from the system library. Fix this by including the original
ones, instead of trying to do that ourselves.