### PR TITLE
Json: Fix decodeUtf8 to handle 4-byte encodings.

### DIFF
--- a/folly/json.cpp
+++ b/folly/json.cpp
@@ -75,7 +75,7 @@ char32_t decodeUtf8(
 
   fst <<= 1;
 
-  for (unsigned int i = 1; i != 3 && p + i < e; ++i) {
+  for (unsigned int i = 1; i != 4 && p + i < e; ++i) {
     unsigned char tmp = p[i];
 
     if ((tmp & 0xC0) != 0x80) {


### PR DESCRIPTION
All 4 byte encoded unicode characters were considered invalid
when validate_utf8 or skip_invalid_utf8 were enabled.