### PR TITLE
Updated dependencies on Ubuntu

### DIFF
--- a/README
+++ b/README
@@ -39,6 +39,7 @@ sudo apt-get install \
     liblz4-dev \
     liblzma-dev \
     libsnappy-dev \
+    libssl-dev \
     make \
     zlib1g-dev \
     binutils-dev \


### PR DESCRIPTION
Following the current installation instructions on Ubuntu (both 13.10 and 14.04) fail when running ./configure:

```
checking for SSL_ctrl in -lssl... no
configure: error: "Error: libssl required"
```

Adding libssl-dev to the required dependencies fixes the issue.
