### PR TITLE
Add python binary check to build configuration

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -250,15 +250,15 @@ nobase_follyinclude_HEADERS = \
 	wangle/detail/FSM.h
 
 FormatTables.cpp: build/generate_format_tables.py
-	build/generate_format_tables.py
+	$(PYTHON_BIN) build/generate_format_tables.py
 CLEANFILES += FormatTables.cpp
 
 EscapeTables.cpp: build/generate_escape_tables.py
-	build/generate_escape_tables.py
+	$(PYTHON_BIN) build/generate_escape_tables.py
 CLEANFILES += EscapeTables.cpp
 
 GroupVarintTables.cpp: build/generate_varint_tables.py
-	build/generate_varint_tables.py
+	$(PYTHON_BIN) build/generate_varint_tables.py
 CLEANFILES += GroupVarintTables.cpp
 
 libfollybase_la_SOURCES = \

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -71,6 +71,9 @@ AX_BOOST_REGEX
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 
+# Check for working Python binary and libs.
+AX_PYTHON
+
 # Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS([fcntl.h features.h inttypes.h limits.h stdint.h stdlib.h string.h sys/time.h unistd.h mutex.h malloc.h emmintrin.h byteswap.h bits/functexcept.h bits/c++config.h])

--- a/folly/m4/ax_python.m4
+++ b/folly/m4/ax_python.m4
@@ -1,0 +1,98 @@
+# ===========================================================================
+#         http://www.gnu.org/software/autoconf-archive/ax_python.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PYTHON
+#
+# DESCRIPTION
+#
+#   This macro does a complete Python development environment check.
+#
+#   It recurses through several python versions (from 2.1 to 2.6 in this
+#   version), looking for an executable. When it finds an executable, it
+#   looks to find the header files and library.
+#
+#   It sets PYTHON_BIN to the name of the python executable,
+#   PYTHON_INCLUDE_DIR to the directory holding the header files, and
+#   PYTHON_LIB to the name of the Python library.
+#
+#   This macro calls AC_SUBST on PYTHON_BIN (via AC_CHECK_PROG),
+#   PYTHON_INCLUDE_DIR and PYTHON_LIB.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Michael Tindal
+#
+#   This program is free software; you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation; either version 2 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 14
+
+AC_DEFUN([AX_PYTHON],
+[AC_MSG_CHECKING(for python build information)
+AC_MSG_RESULT([])
+for python in python3.3 python3.2 python3.1 python3.0 python2.7 python2.6 python2.5 python2.4 python2.3 python2.2 python2.1 python; do
+AC_CHECK_PROGS(PYTHON_BIN, [$python])
+ax_python_bin=$PYTHON_BIN
+if test x$ax_python_bin != x; then
+   AC_CHECK_LIB($ax_python_bin, main, ax_python_lib=$ax_python_bin, ax_python_lib=no)
+   if test x$ax_python_lib == xno; then
+     AC_CHECK_LIB(${ax_python_bin}m, main, ax_python_lib=${ax_python_bin}m, ax_python_lib=no)
+   fi
+   if test x$ax_python_lib != xno; then
+     ax_python_header=`$ax_python_bin -c "from distutils.sysconfig import *; print(get_config_var('CONFINCLUDEPY'))"`
+     if test x$ax_python_header != x; then
+       break;
+     fi
+   fi
+fi
+done
+if test x$ax_python_bin = x; then
+   ax_python_bin=no
+fi
+if test x$ax_python_header = x; then
+   ax_python_header=no
+fi
+if test x$ax_python_lib = x; then
+   ax_python_lib=no
+fi
+
+AC_MSG_RESULT([  results of the Python check:])
+AC_MSG_RESULT([    Binary:      $ax_python_bin])
+AC_MSG_RESULT([    Library:     $ax_python_lib])
+AC_MSG_RESULT([    Include Dir: $ax_python_header])
+
+if test x$ax_python_header != xno; then
+  PYTHON_INCLUDE_DIR=$ax_python_header
+  AC_SUBST(PYTHON_INCLUDE_DIR)
+fi
+if test x$ax_python_lib != xno; then
+  PYTHON_LIB=$ax_python_lib
+  AC_SUBST(PYTHON_LIB)
+fi
+])dnl


### PR DESCRIPTION
#### Overview:
Currently when a user attempts to build folly without a python binary on their machine, the build will fail with a long and cryptic error message from the Makefile.

This commit will add the autoconf macro `m4/ax_python.m4` which will look for a python executable as well as the associated header files and libraries. If found, the macro will then set the binary path to `PYTHON_BIN`. That variable will then be used by the Makefile to execute the `build/generate*.py` files.

#### This commit rectifies the following use cases: 

**Problem**
The user's python binary is followed by the python version number (i.e., `python2.7`). This happens in Linux distributions such as Arch Linux and possibly others.
**Solution**
This patch will recurse through several python versions looking for a possible executable followed by its version number and then execute python scripts using the found executable.

**Problem**
The user does not have a python version on their machine and is confused as to why make fails, presenting a cryptic and verbose error message.
**Solution**
This patch will cause the configuration stage of the build to fail while subsequently presenting a clear error message explaining that python is required for the build to complete.