### PR TITLE
Update README and configure.ac message concerning double-conversion

### DIFF
--- a/README
+++ b/README
@@ -77,13 +77,18 @@ of by the bootstrap script.)
 Other Linux distributions
 -------------------------
 
-- double-conversion (http://code.google.com/p/double-conversion/)
+- double-conversion (https://github.com/floitsch/double-conversion/)
 
   Download and build double-conversion.
-  You may need to tell configure where to find it.
+  You may need to tell configure and make where to find it.
+  You also need its headers placed under a directory named "double-conversion",
+  so prepare a symlink first.
 
-  ./configure LDFLAGS=-L$DOUBLE_CONVERISON_HOME/ CPPFLAGS=-I$DOUBLE_CONVERISON_HOME/src/
+  [double-conversion/] ln -s src double-conversion
 
+  [folly/] ./configure LDFLAGS=-L$DOUBLE_CONVERISON_HOME/ CPPFLAGS=-I$DOUBLE_CONVERISON_HOME/
+
+  [folly/] LD_LIBRARY_PATH=$DOUBLE_CONVERISON_HOME/ make
 
 - additional platform specific dependencies:
 

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -77,7 +77,7 @@ AC_CHECK_HEADERS([fcntl.h features.h inttypes.h limits.h stdint.h stdlib.h strin
 
 AC_CHECK_HEADER(double-conversion/double-conversion.h, [], [AC_MSG_ERROR(
                 [Couldn't find double-conversion.h, please download from \
-                http://code.google.com/p/double-conversion/])], [])
+                https://github.com/floitsch/double-conversion/])], [])
 AC_CHECK_LIB([double-conversion],[ceil],[],[AC_MSG_ERROR(
              [Please install double-conversion library])])
 


### PR DESCRIPTION
Documentation about double-conversion seems outdated.

* #include path has changed
* SConstruct.double-conversion is no longer present, but was not necessary at all for successful `make`/`make check` for me.

As to the second point, the file was added years ago and removed last month.
I tried with latest release (v.1.1.5) and current master and `make check` just worked with both.