### PR TITLE
Include type_traits in ForEach.h

### DIFF
--- a/folly/Foreach.h
+++ b/folly/Foreach.h
@@ -47,6 +47,8 @@
  * generates code 100% identical to the handwritten loop.
  */
 
+#include <type_traits>
+
 #include <boost/type_traits/remove_cv.hpp>
 
 /*


### PR DESCRIPTION
Without this, `make check` doesn't compile for me.

Maybe for some boost versions, `type_traits` is includeded from the `remove_cv.hpp`.

I use boost 1.57.0 and gcc 4.9.2
