### PR TITLE
EmulatedFutexAtomic doesn't copy or move

### DIFF
--- a/folly/detail/Futex.h
+++ b/folly/detail/Futex.h
@@ -136,7 +136,8 @@ struct EmulatedFutexAtomic : public std::atomic<T> {
   EmulatedFutexAtomic() noexcept = default;
   constexpr /* implicit */ EmulatedFutexAtomic(T init) noexcept
       : std::atomic<T>(init) {}
-  EmulatedFutexAtomic(const EmulatedFutexAtomic& rhs) = delete;
+  // It doesn't copy or move
+  EmulatedFutexAtomic(EmulatedFutexAtomic&& rhs) = delete;
 };
 
 /* Available specializations, with definitions elsewhere */


### PR DESCRIPTION
EmulatedFutexAtomic concisely says here that it doesn't copy construct,
move construct, copy assign, or move assign.