### PR TITLE
Bugfix uriEscapeTable generate.

### DIFF
--- a/folly/build/generate_escape_tables.py
+++ b/folly/build/generate_escape_tables.py
@@ -79,9 +79,9 @@ def generate(f):
     # 4 = always percent-encode
     f.write("extern const unsigned char uriEscapeTable[] = {")
     passthrough = (
-        list(range(ord('0'), ord('9'))) +
-        list(range(ord('A'), ord('Z'))) +
-        list(range(ord('a'), ord('z'))) +
+        list(map(ord, '0123456789')) +
+        list(map(ord, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')) +
+        list(map(ord, 'abcdefghijklmnopqrstuvwxyz')) +
         list(map(ord, '-_.~')))
     for i in range(0, 256):
         if i % 16 == 0:

--- a/folly/test/StringTest.cpp
+++ b/folly/test/StringTest.cpp
@@ -220,6 +220,9 @@ TEST(Escape, uriEscape) {
                                                         UriEscapeMode::PATH));
   EXPECT_EQ("hello%2c+%2fworld", uriEscape<std::string>("hello, /world",
                                                         UriEscapeMode::QUERY));
+  EXPECT_EQ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~",
+            uriEscape<std::string>(
+                "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.~"));
 }
 
 TEST(Escape, uriUnescape) {


### PR DESCRIPTION
generate_escape_tables.py uses python range function which does not include the end of the range.