### PR TITLE
Improvement fbvector.computePushBackCapacity

### DIFF
--- a/folly/FBVector.h
+++ b/folly/FBVector.h
@@ -1148,14 +1148,14 @@ private:
   //
 
   size_type computePushBackCapacity() const {
-    return empty() ? std::max(64 / sizeof(T), size_type(1))
-      : capacity() < folly::jemallocMinInPlaceExpandable / sizeof(T)
-      ? capacity() * 2
-      : sizeof(T) > folly::jemallocMinInPlaceExpandable / 2 && capacity() == 1
-      ? 2
-      : capacity() > 4096 * 32 / sizeof(T)
-      ? capacity() * 2
-      : (capacity() * 3 + 1) / 2;
+    if (empty()) {
+      return std::max(64 / sizeof(T), size_type(1));
+    }
+    size_t oldSize = capacity() * sizeof(T);
+    if (oldSize < folly::jemallocMinInPlaceExpandable || oldSize > 4096 * 32) {
+      return capacity() * 2;
+    }
+    return (capacity() * 3 + 1) / 2;
   }
 
   template <class... Args>


### PR DESCRIPTION
##### 0. Let's take the original code...
```c++
return empty() ? std::max(64 / sizeof(T), size_type(1))
  : capacity() < folly::jemallocMinInPlaceExpandable / sizeof(T)
  ? capacity() * 2
  : sizeof(T) > folly::jemallocMinInPlaceExpandable / 2 && capacity() == 1
  ? 2
  : capacity() > 4096 * 32 / sizeof(T)
  ? capacity() * 2
  : (capacity() * 3 + 1) / 2;
```

##### 1. ...and make it easier to read:
```c++
// fist condition
if (empty()) {
  return std::max(64 / sizeof(T), size_type(1));
}
// second condition
if (capacity() < folly::jemallocMinInPlaceExpandable / sizeof(T)) {
  return capacity() * 2; 
}
// third condition
if (sizeof(T) > folly::jemallocMinInPlaceExpandable / 2 && capacity() == 1) {
  return 2;
}
// fourth condition
if (capacity() > 4096 * 32 / sizeof(T)) {
  return capacity() * 2;    
}
// else
return (capacity() * 3 + 1) / 2;
```

##### 2. Next, remove the redundant branches:
Look at the third condition. If `capacity() == 1` then 
```
capacity() * 2 == (capacity() * 3 + 1) / 2 == 2
```
So, we can throw it without changing the behavior of the code:

```c++
// fist condition
if (empty()) {
  return std::max(64 / sizeof(T), size_type(1));
}
// second condition
if (capacity() < folly::jemallocMinInPlaceExpandable / sizeof(T)) {
  return capacity() * 2; 
}
// fourth condition
if (capacity() > 4096 * 32 / sizeof(T)) {
  return capacity() * 2;    
}
// else
return (capacity() * 3 + 1) / 2;
```

##### 3. Now replace division by multiplication:
For integer arithmetic following rules are true:
```c++
(a < b / c) == (a * c + c <= b)
(a > b / c) == (a * c > b)
```
So this code is equivalent:
```c++
// fist condition
if (empty()) {
  return std::max(64 / sizeof(T), size_type(1));
}
// second condition
if (capacity() * sizeof(T) + sizeof(T) <= folly::jemallocMinInPlaceExpandable) {
  return capacity() * 2; 
}
// fourth condition
if (capacity() * sizeof(T) > 4096 * 32) {
  return capacity() * 2;    
}
// else
return (capacity() * 3 + 1) / 2;
```

#### 4. Hmm... The second condition looks weird now!
```c++
capacity() * sizeof(T) + sizeof(T) <= folly::jemallocMinInPlaceExpandable
```
It seems like `+ sizeof(T)` is superfluous and a comparison operator was supposed to be strict. I think the problem here is that integer division played a low-down trick with the author of the original code. From the description to a `jemallocMinInPlaceExpandable`:

> Blocks larger than or equal to 4096 bytes can in fact be expanded in place.

So replace second condition to:
```c++
capacity() * sizeof(T) < folly::jemallocMinInPlaceExpandable
```

#### 5. Finally, combine the second and fourth branching:
```c++
    if (empty()) {
      return std::max(64 / sizeof(T), size_type(1));
    }
    size_t oldSize = capacity() * sizeof(T);
    if (oldSize < folly::jemallocMinInPlaceExpandable || oldSize > 4096 * 32) {
      return capacity() * 2;
    }
    return (capacity() * 3 + 1) / 2;
```
This code is contained in this PR. 
Please let me know if I'm completely wrong with my thoughts.