### PR TITLE
Additional header check for bits/funcexcept.h

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -199,9 +199,11 @@ struct MaxAlign { char c; } __attribute__((__aligned__));
 
 #if defined(__has_include)
 #if __has_include(<bits/functexcept.h>)
-#define FOLLY_HAVE_BITS_FUNCTEXCEPT_H
+#undef FOLLY_HAVE_BITS_FUNCTEXCEPT_H
+#define FOLLY_HAVE_BITS_FUNCTEXCEPT_H 1
 #else
 #undef FOLLY_HAVE_BITS_FUNCTEXCEPT_H
+#define FOLLY_HAVE_BITS_FUNCTEXCEPT_H 0
 #endif
 #endif
 // Provide our own std::__throw_* wrappers for platforms that don't have them

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -197,6 +197,13 @@ struct MaxAlign { char c; } __attribute__((__aligned__));
 #include <folly/detail/Clock.h>
 #endif
 
+#if defined(__has_include)
+#if __has_include(<bits/functexcept.h>)
+#define FOLLY_HAVE_BITS_FUNCTEXCEPT_H
+#else
+#undef FOLLY_HAVE_BITS_FUNCTEXCEPT_H
+#endif
+#endif
 // Provide our own std::__throw_* wrappers for platforms that don't have them
 #if FOLLY_HAVE_BITS_FUNCTEXCEPT_H
 #include <bits/functexcept.h>


### PR DESCRIPTION
Added an ad-hoc existance check for bits/functexcept.h on clang. This is required if folly is configured for the wrong standard library implementation.