### PR TITLE
BackoffTimeout disallow copy, move, default ctor

### DIFF
--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -116,6 +116,8 @@ void AsyncServerSocket::RemoteAcceptor::messageAvailable(
  */
 class AsyncServerSocket::BackoffTimeout : public AsyncTimeout {
  public:
+  // It disallow copy, move, and default ctor
+  BackoffTimeout(BackoffTimeout&&) = delete;
   BackoffTimeout(AsyncServerSocket* socket)
     : AsyncTimeout(socket->getEventBase()),
       socket_(socket) {}


### PR DESCRIPTION
BackoffTimeout disallow copy construction, copy assignment,

move construction, move assignment, and default

construction.