### PR TITLE
AsyncServerSocket disallow copy, move, and default ctor

### DIFF
--- a/folly/io/async/AsyncServerSocket.h
+++ b/folly/io/async/AsyncServerSocket.h
@@ -59,7 +59,9 @@ namespace folly {
 class AsyncServerSocket : public DelayedDestruction {
  public:
   typedef std::unique_ptr<AsyncServerSocket, Destructor> UniquePtr;
-
+ // It disallow copy, move, and default construction.
+  AsyncServerSocket(AsyncServerSocket&&) = delete;
+  
   class AcceptCallback {
    public:
     virtual ~AcceptCallback() {}


### PR DESCRIPTION
AsyncServerSocket disallow copy construction, copy assignment,

move construction, move assignment, and default

construction.

Test Plan: all folly/tests, make check for 37 tests, passed.