### PR TITLE
AcceptCallback disallow undeclared copy and move, but allow default ctor

### DIFF
--- a/folly/io/async/AsyncServerSocket.h
+++ b/folly/io/async/AsyncServerSocket.h
@@ -62,6 +62,9 @@ class AsyncServerSocket : public DelayedDestruction {
 
   class AcceptCallback {
    public:
+    // AcceptCallback disallow undeclared copy and move.
+    // But allow implicit default construction
+    AcceptCallback& operator=(AcceptCallback&&) = delete;
     virtual ~AcceptCallback() {}
 
     /**


### PR DESCRIPTION
AcceptCallback disallow undeclared copy construction, copy assignment,

move construction, move assignment. But it allow implicit default

construction.

Test Plan: all folly/tests, make check for 37 tests, passed.