### PR TITLE
SmoothLoopTime has a "constexpr constructor" and a "constexpr get" member

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -485,10 +485,10 @@ class EventBase : private boost::noncopyable,
 
   class SmoothLoopTime {
    public:
-    explicit SmoothLoopTime(uint64_t timeInterval)
-      : expCoeff_(-1.0/timeInterval)
-      , value_(0.0)
-      , oldBusyLeftover_(0) {
+    constexpr explicit SmoothLoopTime(uint64_t timeInterval)
+      : expCoeff_{-1.0/timeInterval}
+      , value_{0.0}
+      , oldBusyLeftover_{0} {
       VLOG(11) << "expCoeff_ " << expCoeff_ << " " << __PRETTY_FUNCTION__;
     }
 
@@ -497,7 +497,7 @@ class EventBase : private boost::noncopyable,
 
     void addSample(int64_t idle, int64_t busy);
 
-    double get() const {
+    constexpr double get() const {
       return value_;
     }
 


### PR DESCRIPTION
The constructor "explicit SmoothLoopTime::SmoothLoopTime(uint64_t);" 

may construct during compilation, and same with

"double SmoothLoopTime::get() const;" member.


Test Plan:

all folly/tests, make check for 37 tests, passed.