### PR TITLE
EventBaseObserver disallows copy, move, and default ctor

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -45,7 +45,10 @@ class NotificationQueue;
 
 class EventBaseObserver {
  public:
-  virtual ~EventBaseObserver() {}
+  // It disallows copy, move, and default ctor
+  EventBaseObserver(EventBaseObserver&&) = delete;
+  
+  virtual ~EventBaseObserver() = default;
 
   virtual uint32_t getSampleRate() const = 0;
 


### PR DESCRIPTION
EventBaseObserver disallows copy construction, copy assignment,

move construction, move assignment, and default

construction.

And compiler can generate =defaulted definition

for ~EventBaseObserver.

Test Plan:

All folly/tests, make check for 37 tests, passed.