### PR TITLE
RequestEventBase disallows copy, move, and default ctor

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -57,6 +57,9 @@ class EventBaseObserver {
 // request via RequestContext. See Request.h for that mechanism.
 class RequestEventBase : public RequestData {
  public:
+  // It disallows copy, move, and default ctor
+  RequestEventBase(RequestEventBase&&) = delete;
+  
   static EventBase* get() {
     auto data = dynamic_cast<RequestEventBase*>(
         RequestContext::get()->getContextData(kContextDataName));
@@ -73,7 +76,7 @@ class RequestEventBase : public RequestData {
   }
 
  private:
-  explicit RequestEventBase(EventBase* eb) : eb_(eb) {}
+  explicit RequestEventBase(EventBase* eb) : eb_{eb} {}
   EventBase* eb_;
   static constexpr const char* kContextDataName{"EventBase"};
 };


### PR DESCRIPTION
RequestEventBase disallows copy construction, copy assignment,

move construction, move assignment, and default

construction.

Test Plan:

All folly/tests, make check for 37 tests, passed.