### PR TITLE
EventBase disallows copy, move, and default ctor

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -96,8 +96,7 @@ class RequestEventBase : public RequestData {
  * EventBase from other threads.  When it is safe to call a method from
  * another thread it is explicitly listed in the method comments.
  */
-class EventBase : private boost::noncopyable,
-                  public TimeoutManager,
+class EventBase : public TimeoutManager,
                   public DrivableExecutor {
  public:
   /**
@@ -111,6 +110,9 @@ class EventBase : private boost::noncopyable,
    * If a LoopCallback object is destroyed while it is scheduled to be run in
    * the next loop iteration, it will automatically be cancelled.
    */
+  // It disallows copy, move, and default ctor
+  EventBase(EventBase&&) = delete;
+  
   class LoopCallback {
    public:
     virtual ~LoopCallback() {}
@@ -666,7 +668,7 @@ class EventBase : private boost::noncopyable,
 
   // we'll wait this long before running deferred callbacks if the event
   // loop is idle.
-  static const int kDEFAULT_IDLE_WAIT_USEC = 20000; // 20ms
+  static constexpr const int kDEFAULT_IDLE_WAIT_USEC = 20000; // 20ms
 
   // Wrap-around loop counter to detect beginning of each loop
   uint64_t nextLoopCnt_;


### PR DESCRIPTION
EventBase doesn't inherit from boost::noncopyable

anymore, thus, maybe, a little more readable.

EventBase disallows copy construction, copy assignment,

move construction, move assignment, and default

construction.

We may compute kDEFAULT_IDLE_WAIT_USEC during compilation.

Test Plan:

All folly/tests, make check for 37 tests, passed.