### PR TITLE
LoopCallback disallows copy and move, but allows default ctor

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -113,7 +113,10 @@ class EventBase : private boost::noncopyable,
    */
   class LoopCallback {
    public:
-    virtual ~LoopCallback() {}
+    // It disallows copy and move, but allows default ctor
+    LoopCallback& operator=(LoopCallback&&) = delete;
+    
+    virtual ~LoopCallback() = default;
 
     virtual void runLoopCallback() noexcept = 0;
     void cancelLoopCallback() {


### PR DESCRIPTION
EventBase::LoopCallback disallows copy construction, copy assignment,

move construction, and move assignment. But it allows default

construction for classes which inherit from it, to construct

base subobject for derived classes.

And compiler can generate =defaulted definition

for EventBase::~LoopCallback.

Test Plan:

All folly/tests, make check for 37 tests, passed.