### PR TITLE
RunInLoopCallback disallows copy, move, and default ctor

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -562,6 +562,9 @@ class EventBase : private boost::noncopyable,
   // Helper class used to short circuit runInEventBaseThread
   class RunInLoopCallback : public LoopCallback {
    public:
+    // It disallows copy, move, and default ctor
+    RunInLoopCallback(RunInLoopCallback&&) = delete;
+    
     RunInLoopCallback(void (*fn)(void*), void* arg);
     void runLoopCallback() noexcept;
 


### PR DESCRIPTION
EventBase::RunInLoopCallback disallows copy construction,

copy assignment, move construction, move assignment, and default

construction.


Test Plan:

All folly/tests, make check for 37 tests, passed.