### PR TITLE
CobTimeout disallows copy, move, and default ctor

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -584,8 +584,11 @@ class EventBase : private boost::noncopyable,
   // appropriate client-provided Cob
   class CobTimeout : public AsyncTimeout {
    public:
+    // It disallows copy, move, and default ctor
+    CobTimeout(CobTimeout&&) = delete;
+    
     CobTimeout(EventBase* b, const Cob& c, TimeoutManager::InternalEnum in)
-        : AsyncTimeout(b, in), cob_(c) {}
+        : AsyncTimeout{b, in}, cob_{c} {}
 
     virtual void timeoutExpired() noexcept;
 


### PR DESCRIPTION
EventBase::CobTimeout disallows copy construction,

copy assignment, move construction, move assignment, and default

construction.


Test Plan:

All folly/tests, make check for 37 tests, passed.