### PR TITLE
folly::kNoFD can be constexpr

### DIFF
--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -57,7 +57,7 @@ class FunctionLoopCallback : public EventBase::LoopCallback {
 
 namespace folly {
 
-const int kNoFD = -1;
+constexpr const int kNoFD = -1;
 
 /*
  * EventBase::FunctionRunner


### PR DESCRIPTION
We may compute folly::kNoFD during compilation.


Test Plan:

All folly/tests, make check for 37 tests, passed.