### PR TITLE
FunctionLoopCallback disallows copy, move, and default ctor

### DIFF
--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -38,11 +38,14 @@ using folly::EventBase;
 template <typename Callback>
 class FunctionLoopCallback : public EventBase::LoopCallback {
  public:
+  // It disallows copy, move, and default ctor
+  FunctionLoopCallback(FunctionLoopCallback&&) = delete;
+  
   explicit FunctionLoopCallback(Cob&& function)
-      : function_(std::move(function)) {}
+      : function_{std::move(function)} {}
 
   explicit FunctionLoopCallback(const Cob& function)
-      : function_(function) {}
+      : function_{function} {}
 
   virtual void runLoopCallback() noexcept {
     function_();


### PR DESCRIPTION
FunctionLoopCallback disallows copy construction,

copy assignment, move construction, move assignment, and default

construction.


Test Plan:

All folly/tests, make check for 37 tests, passed.