### PR TITLE
FunctionRunner disallows copy and move, but allows default ctor

### DIFF
--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -66,6 +66,9 @@ const int kNoFD = -1;
 class EventBase::FunctionRunner
     : public NotificationQueue<std::pair<void (*)(void*), void*>>::Consumer {
  public:
+  // It disallows copy and move, but allows default ctor
+  FunctionRunner& operator=(FunctionRunner&&) = delete;
+  
   void messageAvailable(std::pair<void (*)(void*), void*>&& msg) {
 
     // In libevent2, internal events do not break the loop.


### PR DESCRIPTION
EventBase::FunctionRunner disallows copy construction,

copy assignment, move construction, and move assignment.

But it allows default construction for classes which inherit

from it, to construct base subobject for derived classes.


Test Plan:

All folly/tests, make check for 37 tests, passed.