### PR TITLE
DelayedDestruction() can go noexcept

### DIFF
--- a/folly/io/async/DelayedDestruction.h
+++ b/folly/io/async/DelayedDestruction.h
@@ -123,7 +123,7 @@ class DelayedDestruction : private boost::noncopyable {
     (void)delayed; // prevent unused variable warnings
   }
 
-  DelayedDestruction()
+  DelayedDestruction() noexcept
     : guardCount_(0)
     , destroyPending_(false) {}
 


### PR DESCRIPTION
Initializations, guardCount_{0} and destroyPending_{false},

are trivial, and far from throwing anything.

For esoteric cases, we might not like to handle any exception(s)

out of DelayedDestruction().

All folly/tests, make check for 37 tests, passed.