### PR TITLE
DestructorGuard disallows copy, move, and default ctor

### DIFF
--- a/folly/io/async/DelayedDestruction.h
+++ b/folly/io/async/DelayedDestruction.h
@@ -85,6 +85,9 @@ class DelayedDestruction : private boost::noncopyable {
   class DestructorGuard {
    public:
 
+    // It disallows copy, move, and default ctor
+    DestructorGuard(DestructorGuard&&) = delete;
+    
     explicit DestructorGuard(DelayedDestruction* dd) : dd_(dd) {
       ++dd_->guardCount_;
       assert(dd_->guardCount_ > 0); // check for wrapping


### PR DESCRIPTION
DestructorGuard disallows copy construction,

copy assignment, move construction, move assignment, and default

construction.


Test Plan:

All folly/tests, make check for 37 tests, passed.