### PR TITLE
DestructorGuard(DelayedDestruction*) and copy ctor can go noexcept

### DIFF
--- a/folly/io/async/DelayedDestruction.h
+++ b/folly/io/async/DelayedDestruction.h
@@ -85,12 +85,12 @@ class DelayedDestruction : private boost::noncopyable {
   class DestructorGuard {
    public:
 
-    explicit DestructorGuard(DelayedDestruction* dd) : dd_(dd) {
+    explicit DestructorGuard(DelayedDestruction* dd) noexcept : dd_(dd) {
       ++dd_->guardCount_;
       assert(dd_->guardCount_ > 0); // check for wrapping
     }
 
-    DestructorGuard(const DestructorGuard& dg) : dd_(dg.dd_) {
+    DestructorGuard(const DestructorGuard& dg) noexcept : dd_(dg.dd_) {
       ++dd_->guardCount_;
       assert(dd_->guardCount_ > 0); // check for wrapping
     }


### PR DESCRIPTION
Constructions, DestructorGuard(DelayedDestruction*) and

DestructorGuard(const DestructorGuard&), are trivial.

We might not like to handle any exception(s)

out of the constructions.


All folly/tests, make check for 37 tests, passed.