### PR TITLE
void dampen(double) can be computed during compilation

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -501,6 +501,9 @@ class EventBase : private boost::noncopyable,
       return value_;
     }
 
+#if __cplusplus >= 201402L
+    constexpr
+#endif  // __cplusplus
     void dampen(double factor) {
       value_ *= factor;
     }


### PR DESCRIPTION
If we're compiling for c++14, void is a literal in c++14,

void SmoothLoopTime::dampen(double) can be computed during

compilation.

Test Plan:

All folly/tests, make check for 37 tests, passed.