### PR TITLE
ThreadCachedInt(IntT, uint32_t) can be marked constexpr and noexcept

### DIFF
--- a/folly/ThreadCachedInt.h
+++ b/folly/ThreadCachedInt.h
@@ -42,8 +42,9 @@ class ThreadCachedInt : boost::noncopyable {
   struct IntCache;
 
  public:
-  explicit ThreadCachedInt(IntT initialVal = 0, uint32_t cacheSize = 1000)
-    : target_(initialVal), cacheSize_(cacheSize) {
+  constexpr explicit ThreadCachedInt(IntT initialVal = 0,
+                                       uint32_t cacheSize = 1000) noexcept :
+      target_{initialVal}, cacheSize_{cacheSize} {
   }
 
   void increment(IntT inc) {


### PR DESCRIPTION
ThreadCachedInt(IntT, uint32_t) can be marked constexpr and noexcept.

Because initializations target_{initialVal} and cacheSize_{cacheSize}

are constexpr and noexcept, ThreadCachedInt(IntT, uint32_t) doesn't have to do

anything else. Therefore, there seems no reason why

ThreadCachedInt(IntT, uint32_t) shouldn't be constexpr and noexcept.

Constructions std::atomic<IntT>(IntT) and std::atomic<uint32_t>(uint32_t)

are constexpr and noexcept.

Test Plan:

All folly/tests, make check for 37 tests, passed.