### PR TITLE
ThreadCachedInt disallows copy, move, and default ctor

### DIFF
--- a/folly/ThreadCachedInt.h
+++ b/folly/ThreadCachedInt.h
@@ -25,8 +25,6 @@
 
 #include <atomic>
 
-#include <boost/noncopyable.hpp>
-
 #include <folly/Likely.h>
 #include <folly/ThreadLocal.h>
 
@@ -38,10 +36,13 @@ namespace folly {
 // ThreadCachedInt's you should considering breaking up the Tag space even
 // further.
 template <class IntT, class Tag=IntT>
-class ThreadCachedInt : boost::noncopyable {
+class ThreadCachedInt {
   struct IntCache;
 
  public:
+  // It disallows copy, move, and default ctor
+  ThreadCachedInt(ThreadCachedInt&&) = delete;
+  
   explicit ThreadCachedInt(IntT initialVal = 0, uint32_t cacheSize = 1000)
     : target_(initialVal), cacheSize_(cacheSize) {
   }


### PR DESCRIPTION
ThreadCachedInt disallows copy construction,

copy assignment, move construction, move assignment, and default

construction.

ThreadCachedInt needn't inherit from boost::noncopyable

anymore, thus, maybe, it's little more readable and simple.

Test Plan:

All folly/tests, make check for 37 tests, passed.