### PR TITLE
Funtions can be noexcept

### DIFF
--- a/folly/ThreadCachedInt.h
+++ b/folly/ThreadCachedInt.h
@@ -57,7 +57,7 @@ class ThreadCachedInt : boost::noncopyable {
 
   // Quickly grabs the current value which may not include some cached
   // increments.
-  IntT readFast() const {
+  IntT readFast() const noexcept {
     return target_.load(std::memory_order_relaxed);
   }
 
@@ -74,7 +74,7 @@ class ThreadCachedInt : boost::noncopyable {
   }
 
   // Quickly reads and resets current value (doesn't reset cached increments).
-  IntT readFastAndReset() {
+  IntT readFastAndReset() noexcept {
     return target_.exchange(0, std::memory_order_release);
   }
 
@@ -93,11 +93,11 @@ class ThreadCachedInt : boost::noncopyable {
     return ret;
   }
 
-  void setCacheSize(uint32_t newSize) {
+  void setCacheSize(uint32_t newSize) noexcept {
     cacheSize_.store(newSize, std::memory_order_release);
   }
 
-  uint32_t getCacheSize() const {
+  uint32_t getCacheSize() const noexcept {
     return cacheSize_.load();
   }
 


### PR DESCRIPTION
The following funtions don't call anything which isn't noexcept.

So we can safely mark them noexcept, which compiler might like.

IntT ThreadCachedInt::readFast() const;

IntT ThreadCachedInt::readFastAndReset();

void ThreadCachedInt::setCacheSize(uint32_t);

uint32_t ThreadCachedInt::getCacheSize() const; 

Test Plan:

All folly/tests, make check for 37 tests, passed.