### PR TITLE
Funtions can be considered to be noexcept

### DIFF
--- a/folly/ThreadCachedInt.h
+++ b/folly/ThreadCachedInt.h
@@ -141,7 +141,7 @@ class ThreadCachedInt : boost::noncopyable {
     explicit IntCache(ThreadCachedInt& parent)
         : parent_(&parent), val_(0), numUpdates_(0), reset_(false) {}
 
-    void increment(IntT inc) {
+    void increment(IntT inc) noexcept {
       if (LIKELY(!reset_.load(std::memory_order_acquire))) {
         // This thread is the only writer to val_, so it's fine do do
         // a relaxed load and do the addition non-atomically.
@@ -160,7 +160,7 @@ class ThreadCachedInt : boost::noncopyable {
       }
     }
 
-    void flush() const {
+    void flush() const noexcept {
       parent_->target_.fetch_add(val_, std::memory_order_release);
       val_.store(0, std::memory_order_release);
       numUpdates_ = 0;


### PR DESCRIPTION
Almost all calls inside these functions are noexcept.

So we can safely mark them noexcept, which compiler might like.

Consider the function

void ThreadCachedInt::IntCache::increment(IntT inc);.

We might not like to handle unlikely exception out of 

one trivial integral addition and one integer increment.

Other than that, it doesn't call anything which isn't noexcept.

Consider the function

void ThreadCachedInt::IntCache::flush() const;.

We might not like to handle unlikely exception out of 

one trivial integer assignment.

Other than that, it doesn't call anything which isn't noexcept.

Test Plan:

All folly/tests, make check for 37 tests, passed.