### PR TITLE
IntCache disallows copy, move, and default ctor

### DIFF
--- a/folly/ThreadCachedInt.h
+++ b/folly/ThreadCachedInt.h
@@ -138,6 +138,9 @@ class ThreadCachedInt : boost::noncopyable {
     mutable uint32_t numUpdates_;
     std::atomic<bool> reset_;
 
+    // It disallows copy, move, and default ctor
+    IntCache(IntCache&&) = delete;
+    
     explicit IntCache(ThreadCachedInt& parent)
         : parent_(&parent), val_(0), numUpdates_(0), reset_(false) {}
 


### PR DESCRIPTION
ThreadCachedInt::IntCache disallows copy construction,

copy assignment, move construction, move assignment, and default

construction.

Test Plan:

All folly/tests, make check for 37 tests, passed.