### PR TITLE
IntCache(ThreadCachedInt&) can be marked constexpr and noexcept

### DIFF
--- a/folly/ThreadCachedInt.h
+++ b/folly/ThreadCachedInt.h
@@ -138,8 +138,8 @@ class ThreadCachedInt : boost::noncopyable {
     mutable uint32_t numUpdates_;
     std::atomic<bool> reset_;
 
-    explicit IntCache(ThreadCachedInt& parent)
-        : parent_(&parent), val_(0), numUpdates_(0), reset_(false) {}
+    constexpr explicit IntCache(ThreadCachedInt& parent) noexcept
+        : parent_{&parent}, val_{0}, numUpdates_{0}, reset_{false} {}
 
     void increment(IntT inc) {
       if (LIKELY(!reset_.load(std::memory_order_acquire))) {


### PR DESCRIPTION
ThreadCachedInt::IntCache::IntCache(ThreadCachedInt&) can be marked

constexpr and noexcept. Because initializations val_{0} and reset_{false}

are constexpr and noexcept. And initializations parent_{&parent} and

numUpdates_{0} are trivial.

Test Plan:

All folly/tests, make check for 37 tests, passed.