### PR TITLE
DestructorGuard(DelayedDestruction*) and copy ctor can go constexpr

### DIFF
--- a/folly/io/async/DelayedDestruction.h
+++ b/folly/io/async/DelayedDestruction.h
@@ -85,12 +85,18 @@ class DelayedDestruction : private boost::noncopyable {
   class DestructorGuard {
    public:
 
-    explicit DestructorGuard(DelayedDestruction* dd) : dd_(dd) {
+#if __cplusplus >= 201402L
+    constexpr
+#endif  // __cplusplus
+    explicit DestructorGuard(DelayedDestruction* dd) : dd_{dd} {
       ++dd_->guardCount_;
       assert(dd_->guardCount_ > 0); // check for wrapping
     }
 
-    DestructorGuard(const DestructorGuard& dg) : dd_(dg.dd_) {
+#if __cplusplus >= 201402L
+    constexpr
+#endif  // __cplusplus
+    DestructorGuard(const DestructorGuard& dg) : dd_{dg.dd_} {
       ++dd_->guardCount_;
       assert(dd_->guardCount_ > 0); // check for wrapping
     }


### PR DESCRIPTION
 We may construct DestructorGuard(DelayedDestruction*) and

DestructorGuard(const DestructorGuard&) during compilation,

by marking them constexpr, for c++14.


All folly/tests, make check for 37 tests, passed.