### PR TITLE
SmoothLoopTime has a "constexpr constructor"

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -485,10 +485,13 @@ class EventBase : private boost::noncopyable,
 
   class SmoothLoopTime {
    public:
+#if __cplusplus >= 201402L
+    constexpr
+#endif  // __cplusplus
     explicit SmoothLoopTime(uint64_t timeInterval)
-      : expCoeff_(-1.0/timeInterval)
-      , value_(0.0)
-      , oldBusyLeftover_(0) {
+      : expCoeff_{-1.0/timeInterval}
+      , value_{0.0}
+      , oldBusyLeftover_{0} {
       VLOG(11) << "expCoeff_ " << expCoeff_ << " " << __PRETTY_FUNCTION__;
     }
 


### PR DESCRIPTION
The constructor "explicit SmoothLoopTime::SmoothLoopTime(uint64_t);" 

may construct during compilation, for c++14.


Test Plan:

all folly/tests, make check for 37 tests, passed.