### PR TITLE
SmoothLoopTime has a "constexpr get" member

### DIFF
--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -497,7 +497,7 @@ class EventBase : private boost::noncopyable,
 
     void addSample(int64_t idle, int64_t busy);
 
-    double get() const {
+    constexpr double get() const {
       return value_;
     }
 
@@ -506,6 +506,7 @@ class EventBase : private boost::noncopyable,
     }
 
    private:
+    constexpr SmoothLoopTime() noexcept;
     double  expCoeff_;
     double  value_;
     int64_t oldBusyLeftover_;


### PR DESCRIPTION
The member function "double SmoothLoopTime::get() const;" 

may compute during compilation.


Test Plan:

All folly/tests, make check for 37 tests, passed.