### PR TITLE
"Consumer();" might be constexpr and noexcept

### DIFF
--- a/folly/io/async/NotificationQueue.h
+++ b/folly/io/async/NotificationQueue.h
@@ -64,10 +64,10 @@ class NotificationQueue {
    public:
     enum : uint16_t { kDefaultMaxReadAtOnce = 10 };
 
-    Consumer()
-      : queue_(nullptr),
-        destroyedFlagPtr_(nullptr),
-        maxReadAtOnce_(kDefaultMaxReadAtOnce) {}
+    // It disallows copy, move, and default ctor
+    Consumer(Consumer&&) = delete;
+    
+    Consumer() = default;
 
     virtual ~Consumer();
 
@@ -187,9 +187,9 @@ class NotificationQueue {
     }
     void init(EventBase* eventBase, NotificationQueue* queue);
 
-    NotificationQueue* queue_;
-    bool* destroyedFlagPtr_;
-    uint32_t maxReadAtOnce_;
+    NotificationQueue* queue_{nullptr};
+    bool* destroyedFlagPtr_{nullptr};
+    uint32_t maxReadAtOnce_{kDefaultMaxReadAtOnce};
     EventBase* base_;
     bool active_{false};
   };


### PR DESCRIPTION
We shouldn't come in the way of compiler when it can

decide whether Consumer(); is constexpr and noexcept.

We don't declare and define Consumer();, but we ask for

that from compiler using "Consumer() = default" and

brace-initialize the data members appropriately.

Test Plan:

All folly/tests, make check for 37 tests, passed.