### PR TITLE
ARM64 assembler fixes for Folly.

### DIFF
--- a/folly/MPMCQueue.h
+++ b/folly/MPMCQueue.h
@@ -646,7 +646,7 @@ struct TurnSequencer {
       // the first effectSpinCutoff tries are spins, after that we will
       // record ourself as a waiter and block with futexWait
       if (tries < effectiveSpinCutoff) {
-        asm volatile ("pause");
+	PAUSE();
         continue;
       }
 

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -273,4 +273,10 @@ inline size_t malloc_usable_size(void* ptr) {
 }
 #endif
 
+#if defined(__x86_64__)
+#define PAUSE() asm volatile ("pause")
+#elif defined(__aarch64__)
+#define PAUSE() asm volatile ("wfe")
+#endif
+
 #endif // FOLLY_PORTABILITY_H_

--- a/folly/RWSpinLock.h
+++ b/folly/RWSpinLock.h
@@ -587,7 +587,7 @@ class RWTicketSpinLockT : boost::noncopyable {
     int count = 0;
     QuarterInt val = __sync_fetch_and_add(&ticket.users, 1);
     while (val != load_acquire(&ticket.write)) {
-      asm volatile("pause");
+      PAUSE();
       if (UNLIKELY(++count > 1000)) sched_yield();
     }
   }
@@ -636,7 +636,7 @@ class RWTicketSpinLockT : boost::noncopyable {
     // need to let threads that already have a shared lock complete
     int count = 0;
     while (!LIKELY(try_lock_shared())) {
-      asm volatile("pause");
+      PAUSE();
       if (UNLIKELY((++count & 1023) == 0)) sched_yield();
     }
   }

--- a/folly/SmallLocks.h
+++ b/folly/SmallLocks.h
@@ -47,8 +47,8 @@
 #include <glog/logging.h>
 #include <folly/Portability.h>
 
-#if !FOLLY_X64
-# error "SmallLocks.h is currently x64-only."
+#if !FOLLY_X64 && !defined(__aarch64__)
+# error "SmallLocks.h is currently x64 and aarch64-only."
 #endif
 
 namespace folly {
@@ -72,7 +72,7 @@ namespace detail {
     void wait() {
       if (spinCount < kMaxActiveSpin) {
         ++spinCount;
-        asm volatile("pause");
+	PAUSE();
       } else {
         /*
          * Always sleep 0.5ms, assuming this will make the kernel put
@@ -217,6 +217,7 @@ struct PicoSpinLock {
   bool try_lock() const {
     bool ret = false;
 
+#if FOLLY_X64
 #define FB_DOBTS(size)                                  \
   asm volatile("lock; bts" #size " %1, (%2); setnc %0"  \
                : "=r" (ret)                             \
@@ -231,6 +232,9 @@ struct PicoSpinLock {
     }
 
 #undef FB_DOBTS
+#else
+    ret = __atomic_fetch_or(&lock_, 1 << Bit, __ATOMIC_SEQ_CST);
+#endif
 
     return ret;
   }
@@ -250,6 +254,7 @@ struct PicoSpinLock {
    * integer.
    */
   void unlock() const {
+#if FOLLY_X64
 #define FB_DOBTR(size)                          \
   asm volatile("lock; btr" #size " %0, (%1)"    \
                :                                \
@@ -267,6 +272,9 @@ struct PicoSpinLock {
     }
 
 #undef FB_DOBTR
+#else
+    __atomic_fetch_and(&lock_, ~(1 << Bit), __ATOMIC_SEQ_CST);
+#endif
   }
 };
 


### PR DESCRIPTION
Requesting a tracking branch. These fixes are required to compile and run hhvm on aarch64.