### PR TITLE
Member funtions may be computeted during compilation

### DIFF
--- a/folly/io/async/NotificationQueue.h
+++ b/folly/io/async/NotificationQueue.h
@@ -127,7 +127,7 @@ class NotificationQueue {
      * messages from.  Returns nullptr if the consumer is not currently
      * consuming events from any queue.
      */
-    NotificationQueue* getCurrentQueue() const {
+    constexpr NotificationQueue* getCurrentQueue() const noexcept {
       return queue_;
     }
 
@@ -141,14 +141,20 @@ class NotificationQueue {
      * A limit of 0 means no limit will be enforced.  If unset, the limit
      * defaults to kDefaultMaxReadAtOnce (defined to 10 above).
      */
-    void setMaxReadAtOnce(uint32_t maxAtOnce) {
+#if __cplusplus >= 201402L
+    constexpr
+#endif  // __cplusplus
+    void setMaxReadAtOnce(uint32_t maxAtOnce) noexcept {
       maxReadAtOnce_ = maxAtOnce;
     }
-    uint32_t getMaxReadAtOnce() const {
+    constexpr uint32_t getMaxReadAtOnce() const noexcept {
       return maxReadAtOnce_;
     }
 
-    EventBase* getEventBase() {
+#if __cplusplus >= 201402L
+    constexpr
+#endif  // __cplusplus
+    EventBase* getEventBase() noexcept {
       return base_;
     }
 


### PR DESCRIPTION
The following member functions might take advantage of compile

time computation, and also become noexcept.

NotificationQueue* NotificationQueue::Consumer::getCurrentQueue() const;

void NotificationQueue::Consumer::setMaxReadAtOnce(uint32_t);

uint32_t NotificationQueue::Consumer::getMaxReadAtOnce() const;

EventBase* NotificationQueue::Consumer::getEventBase();

Test Plan:

All folly/tests, make check for 37 tests, passed.