### PR TITLE
We might avoid temporary

### DIFF
--- a/folly/wangle/acceptor/LoadShedConfiguration.cpp
+++ b/folly/wangle/acceptor/LoadShedConfiguration.cpp
@@ -20,11 +20,11 @@ void LoadShedConfiguration::addWhitelistAddr(folly::StringPiece input) {
   auto addr = input.str();
   size_t separator = addr.find_first_of('/');
   if (separator == string::npos) {
-    whitelistAddrs_.insert(SocketAddress(addr, 0));
+    whitelistAddrs_.emplace(addr, 0);
   } else {
     unsigned prefixLen = folly::to<unsigned>(addr.substr(separator + 1));
     addr.erase(separator);
-    whitelistNetworks_.insert(NetworkAddress(SocketAddress(addr, 0), prefixLen));
+    whitelistNetworks_.emplace(SocketAddress(addr, 0), prefixLen);
   }
 }
 

--- a/folly/wangle/acceptor/NetworkAddress.h
+++ b/folly/wangle/acceptor/NetworkAddress.h
@@ -28,6 +28,15 @@ public:
       unsigned prefixLen):
     addr_(addr), prefixLen_(prefixLen) {}
 
+ /**
+   * Create a NetworkAddress for an addr/prefixLen
+   * @param addr         IPv4 or IPv6 address of the network, we can move it
+   * @param prefixLen    Prefix length, in bits
+   */
+  NetworkAddress(folly::SocketAddress&& addr,
+      unsigned prefixLen):
+    addr_{std::move(addr)}, prefixLen_{prefixLen} {}
+
   /** Get the network address */
   const folly::SocketAddress& getAddress() const {
     return addr_;


### PR DESCRIPTION
Directly pass arguments to constructor.

We need constructor which moves folly::SocketAddress

The constructor NetworkAddress(const folly::SocketAddress&&, unsigned)

is a help when we move folly::SocketAddress.

For example when we pass folly::SocketAddress using

emplace or emplace_back members of containers.

Test Plan:

All folly/tests, make check for 37 tests, passed.