### PR TITLE
temporary is not needed

### DIFF
--- a/folly/io/async/AsyncSignalHandler.cpp
+++ b/folly/io/async/AsyncSignalHandler.cpp
@@ -40,7 +40,7 @@ AsyncSignalHandler::~AsyncSignalHandler() {
 
 void AsyncSignalHandler::registerSignalHandler(int signum) {
   pair<SignalEventMap::iterator, bool> ret =
-    signalEvents_.insert(make_pair(signum, event()));
+    signalEvents_.emplace(signum, event());
   if (!ret.second) {
     // This signal has already been registered
     throw std::runtime_error(folly::to<string>(


### PR DESCRIPTION
Directly pass arguments to constructor.

Test Plan:

All folly/tests, make check for 37 tests, passed.