### PR TITLE
Keep Makefile.am from double-installing detail/Clock.h

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -423,7 +423,6 @@ libfolly_la_SOURCES += \
 endif
 
 if !HAVE_LINUX
-nobase_follyinclude_HEADERS += detail/Clock.h
 libfollybase_la_SOURCES += detail/Clock.cpp
 endif
 


### PR DESCRIPTION
On non-Linux systems, the autotools-based build system conditionally appends `detail/Clock.h` to `libfollybase_la_SOURCES` – even though that file is in there statically no matter what (as per [line 46](https://github.com/facebook/folly/blob/master/folly/Makefile.am#L46)), which causes the `install` command to error out trying to install the file twice, during `make install`… this patch takes out the conditional append.