### PR TITLE
Fix for clang

### DIFF
--- a/folly/DynamicConverter.h
+++ b/folly/DynamicConverter.h
@@ -55,7 +55,7 @@ BOOST_MPL_HAS_XXX_TRAIT_DEF(iterator);
 BOOST_MPL_HAS_XXX_TRAIT_DEF(mapped_type);
 
 template <typename T> struct class_is_container {
-  typedef std::reverse_iterator<T*> some_iterator;
+  typedef std::reverse_iterator<typename T::iterator> some_iterator;
   enum { value = has_value_type<T>::value &&
                  has_iterator<T>::value &&
               std::is_constructible<T, some_iterator, some_iterator>::value };


### PR DESCRIPTION
Roughly described in https://github.com/facebook/hhvm/issues/5344.

And this is for compilation fix, so without  https://github.com/191919/mcrouter/commit/6d6731456894e5ee288bbdf146108f9f45b3750e, clang could compile mcrouter.
