### PR TITLE
Add EOS checking to 'parseLeadingNumber' function.

### DIFF
--- a/folly/detail/CacheLocality.cpp
+++ b/folly/detail/CacheLocality.cpp
@@ -84,7 +84,7 @@ static size_t parseLeadingNumber(const std::string& line) {
   auto raw = line.c_str();
   char *end;
   unsigned long val = strtoul(raw, &end, 10);
-  if (end == raw || (*end != ',' && *end != '-' && *end != '\n')) {
+  if (end == raw || (*end != ',' && *end != '-' && *end != '\n' && *end != 0)) {
     throw std::runtime_error(to<std::string>(
         "error parsing list '", line, "'").c_str());
   }


### PR DESCRIPTION
parseLeadingNumber does not contain EOS validation and raise an exception when '/sys/devices/system/cpu/cpu0/index0/shared_cpu_list' contains only one number like '0'.