### PR TITLE
fix for Boost >= 1.56

### DIFF
--- a/folly/m4/ax_boost_context.m4
+++ b/folly/m4/ax_boost_context.m4
@@ -69,8 +69,16 @@ AC_DEFUN([AX_BOOST_CONTEXT],
 			CXXFLAGS_SAVE=$CXXFLAGS
 
 			AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-				[[@%:@include <boost/context/all.hpp>]],
-				[[boost::context::fcontext_t* fc = boost::context::make_fcontext(0, 0, 0);]])],
+				[[@%:@include <boost/context/all.hpp>
+#include <boost/version.hpp>
+]],
+				[[#if BOOST_VERSION >= 105600
+  boost::context::fcontext_t fc = boost::context::make_fcontext(0, 0, 0);
+#else
+  boost::context::fcontext_t* fc = boost::context::make_fcontext(0, 0, 0);
+#endif
+]]
+				)],
 				ax_cv_boost_context=yes, ax_cv_boost_context=no)
 				CXXFLAGS=$CXXFLAGS_SAVE
 			AC_LANG_POP([C++])


### PR DESCRIPTION
Fix for [issues #205](http://example.net/)
Folly still continue to build and work on earlier boost versions(boost < 1.56).

**boost::context::make_fcontext() change history:**
* __1.55:__    fcontext_t * make_fcontext( void * sp, std::size_t size, void(* fn)(intptr_t) );
* __1.56:__    fcontext_t make_fcontext(void* sp,std::size_t size,void(*fn)(intptr_t));

**boost doc:**
http://www.boost.org/doc/libs/1_55_0/libs/context/doc/html/context/context/boost_fcontext.html
http://www.boost.org/doc/libs/1_56_0/libs/context/doc/html/context/context/boost_fcontext.html