### PR TITLE
Get *=default*ed default constructors

### DIFF
--- a/folly/Arena.h
+++ b/folly/Arena.h
@@ -148,8 +148,8 @@ class Arena {
     }
 
    private:
-    Block() { }
-    ~Block() { }
+    Block() = default;
+    ~Block() = default;
   } __attribute__((__aligned__));
   // This should be alignas(std::max_align_t) but neither alignas nor
   // max_align_t are supported by gcc 4.6.2.

--- a/folly/AtomicHashArray.h
+++ b/folly/AtomicHashArray.h
@@ -232,7 +232,7 @@ class AtomicHashArray : boost::noncopyable {
 
   struct SimpleRetT { size_t idx; bool success;
     SimpleRetT(size_t i, bool s) : idx(i), success(s) {}
-    SimpleRetT() {}
+    SimpleRetT() = default;
   };
 
   template <class T>
@@ -277,7 +277,7 @@ class AtomicHashArray : boost::noncopyable {
   AtomicHashArray(size_t capacity, KeyT emptyKey, KeyT lockedKey,
                   KeyT erasedKey, double maxLoadFactor, size_t cacheSize);
 
-  ~AtomicHashArray() {}
+  ~AtomicHashArray() = default;
 
   inline void unlockCell(value_type* const cell, KeyT newKey) {
     cellKeyPtr(*cell)->store(newKey, std::memory_order_release);

--- a/folly/AtomicHashMap.h
+++ b/folly/AtomicHashMap.h
@@ -389,7 +389,7 @@ class AtomicHashMap : boost::noncopyable {
 
   struct SimpleRetT { uint32_t i; size_t j; bool success;
     SimpleRetT(uint32_t ii, size_t jj, bool s) : i(ii), j(jj), success(s) {}
-    SimpleRetT() {}
+    SimpleRetT() = default;
   };
 
   template <class T>

--- a/folly/ExceptionWrapper.h
+++ b/folly/ExceptionWrapper.h
@@ -434,7 +434,7 @@ class try_and_catch<LastException, Exceptions...> :
 template<>
 class try_and_catch<> : public exception_wrapper {
  public:
-  try_and_catch() {}
+  try_and_catch() = default;
 
  protected:
   template <typename F>

--- a/folly/GroupVarint.h
+++ b/folly/GroupVarint.h
@@ -512,7 +512,7 @@ class GroupVarintDecoder {
   typedef GroupVarint<T> Base;
   typedef T type;
 
-  GroupVarintDecoder() { }
+  GroupVarintDecoder() = default;
 
   explicit GroupVarintDecoder(StringPiece data,
                               size_t maxCount = (size_t)-1)

--- a/folly/MPMCPipeline.h
+++ b/folly/MPMCPipeline.h
@@ -176,7 +176,7 @@ template <class In, class... Stages> class MPMCPipeline {
    * Default-construct pipeline. Useful to move-assign later,
    * just like MPMCQueue, see MPMCQueue.h for more details.
    */
-  MPMCPipeline() { }
+  MPMCPipeline() = default;
 
   /**
    * Construct a pipeline with N+1 queue sizes.

--- a/folly/MemoryMapping.h
+++ b/folly/MemoryMapping.h
@@ -53,7 +53,7 @@ class MemoryMapping : boost::noncopyable {
    * likely become inaccessible) when the MemoryMapping object is destroyed.
    */
   struct Options {
-    Options() { }
+    Options() {}
 
     // Convenience methods; return *this for chaining.
     Options& setPageSize(off_t v) { pageSize = v; return *this; }

--- a/folly/Singleton.h
+++ b/folly/Singleton.h
@@ -188,7 +188,7 @@ class TypeDescriptorHasher {
 // SingletonHolders.
 class SingletonHolderBase {
  public:
-  virtual ~SingletonHolderBase() {}
+  virtual ~SingletonHolderBase() = default;
 
   virtual TypeDescriptor type() = 0;
   virtual bool hasLiveInstance() = 0;

--- a/folly/SmallLocks.h
+++ b/folly/SmallLocks.h
@@ -295,7 +295,7 @@ struct SpinLockArray {
 
  private:
   struct PaddedSpinLock {
-    PaddedSpinLock() : lock() { }
+    PaddedSpinLock() : lock() {}
     T lock;
     char padding[FOLLY_CACHE_LINE_SIZE - sizeof(T)];
   };

--- a/folly/SocketAddress.h
+++ b/folly/SocketAddress.h
@@ -32,7 +32,7 @@ namespace folly {
 
 class SocketAddress {
  public:
-  SocketAddress() {}
+  SocketAddress() = default;
 
   /**
    * Construct a SocketAddress from a hostname and port.

--- a/folly/Subprocess.h
+++ b/folly/Subprocess.h
@@ -208,7 +208,7 @@ class SubprocessError : public std::exception {};
 class CalledProcessError : public SubprocessError {
  public:
   explicit CalledProcessError(ProcessReturnCode rc);
-  ~CalledProcessError() throw() { }
+  ~CalledProcessError() throw() = default;
   const char* what() const throw() FOLLY_OVERRIDE { return what_.c_str(); }
   ProcessReturnCode returnCode() const { return returnCode_; }
  private:
@@ -222,7 +222,7 @@ class CalledProcessError : public SubprocessError {
 class SubprocessSpawnError : public SubprocessError {
  public:
   SubprocessSpawnError(const char* executable, int errCode, int errnoValue);
-  ~SubprocessSpawnError() throw() {}
+  ~SubprocessSpawnError() throw() = default;
   const char* what() const throw() FOLLY_OVERRIDE { return what_.c_str(); }
   int errnoValue() const { return errnoValue_; }
 

--- a/folly/ThreadLocal.h
+++ b/folly/ThreadLocal.h
@@ -59,7 +59,7 @@ template<class T, class Tag> class ThreadLocalPtr;
 template<class T, class Tag=void>
 class ThreadLocal {
  public:
-  ThreadLocal() { }
+  ThreadLocal() = default;
 
   T* get() const {
     T* ptr = tlp_.get();

--- a/folly/experimental/EliasFanoCoding.h
+++ b/folly/experimental/EliasFanoCoding.h
@@ -51,7 +51,7 @@
 namespace folly { namespace compression {
 
 struct EliasFanoCompressedList {
-  EliasFanoCompressedList() { }
+  EliasFanoCompressedList() = default;
 
   void free() {
     ::free(const_cast<unsigned char*>(lower.data()));

--- a/folly/experimental/JSONSchema.cpp
+++ b/folly/experimental/JSONSchema.cpp
@@ -59,7 +59,7 @@ Optional<SchemaError> makeError(Args&&... args) {
 struct ValidationContext;
 
 struct IValidator {
-  virtual ~IValidator() {}
+  virtual ~IValidator() = default;
 
  private:
   friend struct ValidationContext;
@@ -102,7 +102,7 @@ struct SchemaValidatorContext final {
  * Root validator for a schema.
  */
 struct SchemaValidator final : IValidator, public Validator {
-  SchemaValidator() {}
+  SchemaValidator() = default;
   void loadSchema(SchemaValidatorContext& context, const dynamic& schema);
 
   Optional<SchemaError> validate(ValidationContext&,
@@ -1011,7 +1011,7 @@ folly::Singleton<Validator> schemaValidator([]() {
 });
 }
 
-Validator::~Validator() {}
+Validator::~Validator() = default;
 
 std::unique_ptr<Validator> makeValidator(const dynamic& schema) {
   auto v = make_unique<SchemaValidator>();

--- a/folly/experimental/StringKeyedUnorderedMap.h
+++ b/folly/experimental/StringKeyedUnorderedMap.h
@@ -59,7 +59,7 @@ public:
   typedef typename Base::size_type size_type;
   typedef typename Base::difference_type difference_type;
 
-  explicit StringKeyedUnorderedMap() {}
+  explicit StringKeyedUnorderedMap() = default;
 
   explicit StringKeyedUnorderedMap(
     size_type n,

--- a/folly/gen/Base-inl.h
+++ b/folly/gen/Base-inl.h
@@ -158,7 +158,7 @@ class RangeSource : public GenImpl<typename Range<Iterator>::reference,
                                    RangeSource<Iterator>> {
   Range<Iterator> range_;
  public:
-  RangeSource() {}
+  RangeSource() = default;
   explicit RangeSource(Range<Iterator> range)
     : range_(std::move(range))
   {}
@@ -382,7 +382,7 @@ template<class Predicate>
 class Map : public Operator<Map<Predicate>> {
   Predicate pred_;
  public:
-  Map() {}
+  Map() = default;
 
   explicit Map(Predicate pred)
     : pred_(std::move(pred))
@@ -448,7 +448,7 @@ template<class Predicate>
 class Filter : public Operator<Filter<Predicate>> {
   Predicate pred_;
  public:
-  Filter() {}
+  Filter() = default;
   explicit Filter(Predicate pred)
     : pred_(std::move(pred))
   { }
@@ -512,7 +512,7 @@ template<class Predicate>
 class Until : public Operator<Until<Predicate>> {
   Predicate pred_;
  public:
-  Until() {}
+  Until() = default;
   explicit Until(Predicate pred)
     : pred_(std::move(pred))
   {}
@@ -850,7 +850,7 @@ class Order : public Operator<Order<Selector, Comparer>> {
   Selector selector_;
   Comparer comparer_;
  public:
-  Order() {}
+  Order() = default;
 
   explicit Order(Selector selector)
     : selector_(std::move(selector))
@@ -984,7 +984,7 @@ template<class Selector>
 class Distinct : public Operator<Distinct<Selector>> {
   Selector selector_;
  public:
-  Distinct() {}
+  Distinct() = default;
 
   explicit Distinct(Selector selector)
     : selector_(std::move(selector))
@@ -1165,7 +1165,7 @@ class FoldLeft : public Operator<FoldLeft<Seed, Fold>> {
   Seed seed_;
   Fold fold_;
  public:
-  FoldLeft() {}
+  FoldLeft() = default;
   FoldLeft(Seed seed,
            Fold fold)
     : seed_(std::move(seed))
@@ -1193,7 +1193,7 @@ class FoldLeft : public Operator<FoldLeft<Seed, Fold>> {
  */
 class First : public Operator<First> {
  public:
-  First() { }
+  First() = default;
 
   template<class Source,
            class Value,
@@ -1226,7 +1226,7 @@ class First : public Operator<First> {
  */
 class Any : public Operator<Any> {
  public:
-  Any() { }
+  Any() = default;
 
   template<class Source,
            class Value>
@@ -1265,7 +1265,7 @@ template<class Predicate>
 class All : public Operator<All<Predicate>> {
   Predicate pred_;
  public:
-  All() {}
+  All() = default;
   explicit All(Predicate pred)
     : pred_(std::move(pred))
   { }
@@ -1302,7 +1302,7 @@ template<class Reducer>
 class Reduce : public Operator<Reduce<Reducer>> {
   Reducer reducer_;
  public:
-  Reduce() {}
+  Reduce() = default;
   explicit Reduce(Reducer reducer)
     : reducer_(std::move(reducer))
   {}
@@ -1335,7 +1335,7 @@ class Reduce : public Operator<Reduce<Reducer>> {
  */
 class Count : public Operator<Count> {
  public:
-  Count() { }
+  Count() = default;
 
   template<class Source,
            class Value>
@@ -1418,7 +1418,7 @@ class Min : public Operator<Min<Selector, Comparer>> {
   Selector selector_;
   Comparer comparer_;
  public:
-  Min() {}
+  Min() = default;
 
   explicit Min(Selector selector)
     : selector_(std::move(selector))
@@ -1494,7 +1494,7 @@ class Append : public Operator<Append<Collection>> {
 template<class Collection>
 class Collect : public Operator<Collect<Collection>> {
  public:
-  Collect() { }
+  Collect() = default;
 
   template<class Value,
            class Source,
@@ -1528,7 +1528,7 @@ template<template<class, class> class Container,
          template<class> class Allocator>
 class CollectTemplate : public Operator<CollectTemplate<Container, Allocator>> {
  public:
-  CollectTemplate() { }
+  CollectTemplate() = default;
 
   template<class Value,
            class Source,
@@ -1561,7 +1561,7 @@ class CollectTemplate : public Operator<CollectTemplate<Container, Allocator>> {
  */
 class Concat : public Operator<Concat> {
  public:
-  Concat() { }
+  Concat() = default;
 
   template<class Inner,
            class Source,
@@ -1619,7 +1619,7 @@ class Concat : public Operator<Concat> {
  */
 class RangeConcat : public Operator<RangeConcat> {
  public:
-  RangeConcat() { }
+  RangeConcat() = default;
 
   template<class Range,
            class Source,
@@ -1824,7 +1824,7 @@ class Cycle : public Operator<Cycle> {
  */
 class Dereference : public Operator<Dereference> {
  public:
-  Dereference() {}
+  Dereference() = default;
 
   template<class Value,
            class Source,
@@ -1883,7 +1883,7 @@ class Dereference : public Operator<Dereference> {
  */
 class Indirect : public Operator<Indirect> {
  public:
-  Indirect() {}
+  Indirect() = default;
 
   template <class Value,
             class Source,
@@ -1997,11 +1997,11 @@ class VirtualGen : public GenImpl<Value, VirtualGen<Value>> {
  * non-template operators, statically defined to avoid the need for anything but
  * the header.
  */
-static const detail::Sum sum;
+static const detail::Sum sum{};
 
-static const detail::Count count;
+static const detail::Count count{};
 
-static const detail::First first;
+static const detail::First first{};
 
 /**
  * Use directly for detecting any values, or as a function to detect values
@@ -2010,21 +2010,21 @@ static const detail::First first;
  *  auto nonempty = g | any;
  *  auto evens = g | any(even);
  */
-static const detail::Any any;
+static const detail::Any any{};
 
-static const detail::Min<Identity, Less> min;
+static const detail::Min<Identity, Less> min{};
 
-static const detail::Min<Identity, Greater> max;
+static const detail::Min<Identity, Greater> max{};
 
-static const detail::Order<Identity> order;
+static const detail::Order<Identity> order{};
 
-static const detail::Distinct<Identity> distinct;
+static const detail::Distinct<Identity> distinct{};
 
-static const detail::Map<Move> move;
+static const detail::Map<Move> move{};
 
-static const detail::Concat concat;
+static const detail::Concat concat{};
 
-static const detail::RangeConcat rconcat;
+static const detail::RangeConcat rconcat{};
 
 /**
  * Use directly for infinite sequences, or as a function to limit cycle count.
@@ -2032,11 +2032,11 @@ static const detail::RangeConcat rconcat;
  *  auto forever = g | cycle;
  *  auto thrice = g | cycle(3);
  */
-static const detail::Cycle cycle;
+static const detail::Cycle cycle{};
 
-static const detail::Dereference dereference;
+static const detail::Dereference dereference{};
 
-static const detail::Indirect indirect;
+static const detail::Indirect indirect{};
 
 inline detail::Take take(size_t count) {
   return detail::Take(count);

--- a/folly/gen/Core-inl.h
+++ b/folly/gen/Core-inl.h
@@ -304,7 +304,7 @@ class Composed : public Operator<Composed<First, Second>> {
   First first_;
   Second second_;
  public:
-  Composed() {}
+  Composed() = default;
 
   Composed(First first, Second second)
     : first_(std::move(first))

--- a/folly/gen/Parallel-inl.h
+++ b/folly/gen/Parallel-inl.h
@@ -385,7 +385,7 @@ class ChunkedRangeSource
   Range<Iterator> range_;
 
  public:
-  ChunkedRangeSource() {}
+  ChunkedRangeSource() = default;
   ChunkedRangeSource(int chunkSize, Range<Iterator> range)
       : chunkSize_(chunkSize), range_(std::move(range)) {}
 

--- a/folly/gen/ParallelMap-inl.h
+++ b/folly/gen/ParallelMap-inl.h
@@ -45,7 +45,7 @@ class PMap : public Operator<PMap<Predicate>> {
   Predicate pred_;
   size_t nThreads_;
  public:
-  PMap() {}
+  PMap() = default;
 
   PMap(Predicate pred, size_t nThreads)
     : pred_(std::move(pred)),

--- a/folly/io/async/AsyncSSLSocket.h
+++ b/folly/io/async/AsyncSSLSocket.h
@@ -83,7 +83,7 @@ class AsyncSSLSocket : public virtual AsyncSocket {
 
   class HandshakeCB {
    public:
-    virtual ~HandshakeCB() {}
+    virtual ~HandshakeCB() = default;
 
     /**
      * handshakeVer() is invoked during handshaking to give the

--- a/folly/io/async/AsyncServerSocket.h
+++ b/folly/io/async/AsyncServerSocket.h
@@ -66,7 +66,7 @@ class AsyncServerSocket : public DelayedDestruction
 
   class AcceptCallback {
    public:
-    virtual ~AcceptCallback() {}
+    virtual ~AcceptCallback() = default;
 
     /**
      * connectionAccepted() is called whenever a new client connection is
@@ -614,7 +614,7 @@ class AsyncServerSocket : public DelayedDestruction
     explicit RemoteAcceptor(AcceptCallback *callback)
       : callback_(callback) {}
 
-    ~RemoteAcceptor() {}
+    ~RemoteAcceptor() = default;
 
     void start(EventBase *eventBase, uint32_t maxAtOnce, uint32_t maxInQueue);
     void stop(EventBase* eventBase, AcceptCallback* callback);

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -91,7 +91,7 @@ class AsyncSocket::WriteRequest {
 
  protected:
   // protected destructor, to ensure callers use destroy()
-  virtual ~WriteRequest() {}
+  virtual ~WriteRequest() = default;
 
   AsyncSocket* socket_;         ///< parent socket
   WriteRequest* next_;          ///< pointer to next WriteRequest
@@ -193,7 +193,7 @@ class AsyncSocket::BytesWriteRequest : public AsyncSocket::WriteRequest {
   }
 
   // private destructor, to ensure callers use destroy()
-  virtual ~BytesWriteRequest() {}
+  virtual ~BytesWriteRequest() = default;
 
   const struct iovec* getOps() const {
     assert(opCount_ > opIndex_);

--- a/folly/io/async/AsyncSocket.h
+++ b/folly/io/async/AsyncSocket.h
@@ -67,7 +67,7 @@ class AsyncSocket : virtual public AsyncTransportWrapper {
 
   class ConnectCallback {
    public:
-    virtual ~ConnectCallback() {}
+    virtual ~ConnectCallback() = default;
 
     /**
      * connectSuccess() will be invoked when the connection has been

--- a/folly/io/async/AsyncTransport.h
+++ b/folly/io/async/AsyncTransport.h
@@ -318,7 +318,7 @@ class AsyncTransport : public DelayedDestruction, public AsyncSocketBase {
   virtual size_t getRawBytesReceived() const = 0;
 
  protected:
-  virtual ~AsyncTransport() {}
+  virtual ~AsyncTransport() = default;
 };
 
 // Transitional intermediate interface. This is deprecated.
@@ -329,7 +329,7 @@ class AsyncTransportWrapper : virtual public AsyncTransport {
 
   class ReadCallback {
    public:
-    virtual ~ReadCallback() {}
+    virtual ~ReadCallback() = default;
 
     /**
      * When data becomes available, getReadBuffer() will be invoked to get the
@@ -400,7 +400,7 @@ class AsyncTransportWrapper : virtual public AsyncTransport {
 
   class WriteCallback {
    public:
-    virtual ~WriteCallback() {}
+    virtual ~WriteCallback() = default;
 
     /**
      * writeSuccess() will be invoked when all of the data has been

--- a/folly/io/async/AsyncUDPServerSocket.h
+++ b/folly/io/async/AsyncUDPServerSocket.h
@@ -62,7 +62,7 @@ class AsyncUDPServerSocket : private AsyncUDPSocket::ReadCallback
       std::unique_ptr<folly::IOBuf> buf,
       bool truncated) noexcept = 0;
 
-    virtual ~Callback() {}
+    virtual ~Callback() = default;
   };
 
   /**

--- a/folly/io/async/AsyncUDPSocket.h
+++ b/folly/io/async/AsyncUDPSocket.h
@@ -74,7 +74,7 @@ class AsyncUDPSocket : public EventHandler {
      */
     virtual void onReadClosed() noexcept = 0;
 
-    virtual ~ReadCallback() {}
+    virtual ~ReadCallback() = default;
   };
 
   /**

--- a/folly/io/async/DelayedDestruction.h
+++ b/folly/io/async/DelayedDestruction.h
@@ -143,7 +143,7 @@ class DelayedDestruction : private boost::noncopyable {
    * shared_ptr using a DelayedDestruction::Destructor as the second argument
    * to the shared_ptr constructor.
    */
-  virtual ~DelayedDestruction() {}
+  virtual ~DelayedDestruction() = default;
 
   /**
    * Get the number of DestructorGuards currently protecting this object.

--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -45,7 +45,7 @@ class NotificationQueue;
 
 class EventBaseObserver {
  public:
-  virtual ~EventBaseObserver() {}
+  virtual ~EventBaseObserver() = default;
 
   virtual uint32_t getSampleRate() const = 0;
 
@@ -113,7 +113,7 @@ class EventBase : private boost::noncopyable,
    */
   class LoopCallback {
    public:
-    virtual ~LoopCallback() {}
+    virtual ~LoopCallback() = default;
 
     virtual void runLoopCallback() noexcept = 0;
     void cancelLoopCallback() {

--- a/folly/io/async/Request.h
+++ b/folly/io/async/Request.h
@@ -33,7 +33,7 @@ namespace folly {
 
 class RequestData {
  public:
-  virtual ~RequestData() {}
+  virtual ~RequestData() = default;
 };
 
 class RequestContext;

--- a/folly/io/async/SSLContext.h
+++ b/folly/io/async/SSLContext.h
@@ -42,7 +42,7 @@ namespace folly {
  */
 class PasswordCollector {
  public:
-  virtual ~PasswordCollector() {}
+  virtual ~PasswordCollector() = default;
   /**
    * Interface for customizing how to collect private key password.
    *

--- a/folly/io/async/TimeoutManager.h
+++ b/folly/io/async/TimeoutManager.h
@@ -41,7 +41,7 @@ class TimeoutManager {
     NORMAL
   };
 
-  virtual ~TimeoutManager() {}
+  virtual ~TimeoutManager() = default;
 
   /**
    * Attaches/detaches TimeoutManager to AsyncTimeout

--- a/folly/small_vector.h
+++ b/folly/small_vector.h
@@ -382,7 +382,7 @@ public:
   typedef std::reverse_iterator<iterator>       reverse_iterator;
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
-  explicit small_vector() {}
+  explicit small_vector() = default;
 
   small_vector(small_vector const& o) {
     auto n = o.size();

--- a/folly/wangle/acceptor/ConnectionCounter.h
+++ b/folly/wangle/acceptor/ConnectionCounter.h
@@ -31,7 +31,7 @@ class IConnectionCounter {
    * Decrement the count of client-side connections.
    */
   virtual void onConnectionRemoved() = 0;
-  virtual ~IConnectionCounter() {}
+  virtual ~IConnectionCounter() = default;
 };
 
 class SimpleConnectionCounter: public IConnectionCounter {
@@ -44,7 +44,7 @@ class SimpleConnectionCounter: public IConnectionCounter {
 
   void onConnectionAdded() override { numConnections_++; }
   void onConnectionRemoved() override { numConnections_--; }
-  virtual ~SimpleConnectionCounter() {}
+  virtual ~SimpleConnectionCounter() = default;
 
  protected:
   uint64_t maxConnections_{0};

--- a/folly/wangle/acceptor/ConnectionManager.h
+++ b/folly/wangle/acceptor/ConnectionManager.h
@@ -40,7 +40,7 @@ class ConnectionManager: public folly::DelayedDestruction,
    */
   class Callback {
   public:
-    virtual ~Callback() {}
+    virtual ~Callback() = default;
 
     /**
      * Invoked when the number of connections managed by the
@@ -189,7 +189,7 @@ class ConnectionManager: public folly::DelayedDestruction,
     DRAIN2 = 1,
   };
 
-  ~ConnectionManager() {}
+  ~ConnectionManager() = default;
 
   ConnectionManager(const ConnectionManager&) = delete;
   ConnectionManager& operator=(ConnectionManager&) = delete;

--- a/folly/wangle/acceptor/LoadShedConfiguration.h
+++ b/folly/wangle/acceptor/LoadShedConfiguration.h
@@ -39,9 +39,9 @@ class LoadShedConfiguration {
   typedef std::set<SocketAddress, AddressOnlyCompare> AddressSet;
   typedef std::set<NetworkAddress> NetworkSet;
 
-  LoadShedConfiguration() {}
+  LoadShedConfiguration() = default;
 
-  ~LoadShedConfiguration() {}
+  ~LoadShedConfiguration() = default;
 
   void addWhitelistAddr(folly::StringPiece);
 

--- a/folly/wangle/acceptor/ManagedConnection.h
+++ b/folly/wangle/acceptor/ManagedConnection.h
@@ -38,7 +38,7 @@ class ManagedConnection:
 
   class Callback {
   public:
-    virtual ~Callback() {}
+    virtual ~Callback() = default;
 
     /* Invoked when this connection becomes busy */
     virtual void onActivated(ManagedConnection& conn) = 0;

--- a/folly/wangle/bootstrap/ClientBootstrap.h
+++ b/folly/wangle/bootstrap/ClientBootstrap.h
@@ -94,7 +94,7 @@ class ClientBootstrap {
     return pipeline_.get();
   }
 
-  virtual ~ClientBootstrap() {}
+  virtual ~ClientBootstrap() = default;
 
  protected:
   std::unique_ptr<Pipeline,

--- a/folly/wangle/bootstrap/ServerBootstrap-inl.h
+++ b/folly/wangle/bootstrap/ServerBootstrap-inl.h
@@ -40,7 +40,7 @@ class ServerAcceptor
       pipeline_->setPipelineManager(this);
     }
 
-    ~ServerConnection() {}
+    ~ServerConnection() = default;
 
     void timeoutExpired() noexcept override {
     }

--- a/folly/wangle/bootstrap/ServerBootstrap.h
+++ b/folly/wangle/bootstrap/ServerBootstrap.h
@@ -45,7 +45,7 @@ class ServerBootstrap {
   ServerBootstrap(const ServerBootstrap& that) = delete;
   ServerBootstrap(ServerBootstrap&& that) = default;
 
-  ServerBootstrap() {}
+  ServerBootstrap() = default;
 
   ~ServerBootstrap() {
     stop();

--- a/folly/wangle/channel/Handler.h
+++ b/folly/wangle/channel/Handler.h
@@ -26,7 +26,7 @@ namespace folly { namespace wangle {
 template <class Context>
 class HandlerBase {
  public:
-  virtual ~HandlerBase() {}
+  virtual ~HandlerBase() = default;
 
   virtual void attachPipeline(Context* ctx) {}
   virtual void detachPipeline(Context* ctx) {}
@@ -55,7 +55,7 @@ class Handler : public HandlerBase<HandlerContext<Rout, Wout>> {
   typedef Win win;
   typedef Wout wout;
   typedef HandlerContext<Rout, Wout> Context;
-  virtual ~Handler() {}
+  virtual ~Handler() = default;
 
   virtual void read(Context* ctx, Rin msg) = 0;
   virtual void readEOF(Context* ctx) {
@@ -112,7 +112,7 @@ class InboundHandler : public HandlerBase<InboundHandlerContext<Rout>> {
   typedef Nothing win;
   typedef Nothing wout;
   typedef InboundHandlerContext<Rout> Context;
-  virtual ~InboundHandler() {}
+  virtual ~InboundHandler() = default;
 
   virtual void read(Context* ctx, Rin msg) = 0;
   virtual void readEOF(Context* ctx) {
@@ -139,7 +139,7 @@ class OutboundHandler : public HandlerBase<OutboundHandlerContext<Wout>> {
   typedef Win win;
   typedef Wout wout;
   typedef OutboundHandlerContext<Wout> Context;
-  virtual ~OutboundHandler() {}
+  virtual ~OutboundHandler() = default;
 
   virtual Future<void> write(Context* ctx, Win msg) = 0;
   virtual Future<void> close(Context* ctx) {

--- a/folly/wangle/channel/HandlerContext-inl.h
+++ b/folly/wangle/channel/HandlerContext-inl.h
@@ -20,7 +20,7 @@ namespace folly { namespace wangle {
 
 class PipelineContext {
  public:
-  virtual ~PipelineContext() {}
+  virtual ~PipelineContext() = default;
 
   virtual void attachPipeline() = 0;
   virtual void detachPipeline() = 0;
@@ -41,7 +41,7 @@ class PipelineContext {
 template <class In>
 class InboundLink {
  public:
-  virtual ~InboundLink() {}
+  virtual ~InboundLink() = default;
   virtual void read(In msg) = 0;
   virtual void readEOF() = 0;
   virtual void readException(exception_wrapper e) = 0;
@@ -52,7 +52,7 @@ class InboundLink {
 template <class Out>
 class OutboundLink {
  public:
-  virtual ~OutboundLink() {}
+  virtual ~OutboundLink() = default;
   virtual Future<void> write(Out msg) = 0;
   virtual Future<void> close() = 0;
 };
@@ -60,7 +60,7 @@ class OutboundLink {
 template <class P, class H, class Context>
 class ContextImplBase : public PipelineContext {
  public:
-  ~ContextImplBase() {}
+  ~ContextImplBase() = default;
 
   H* getHandler() {
     return handler_.get();
@@ -140,7 +140,7 @@ class ContextImpl
     this->impl_ = this;
   }
 
-  ~ContextImpl() {}
+  ~ContextImpl() = default;
 
   // HandlerContext overrides
   void fireRead(Rout msg) override {
@@ -289,7 +289,7 @@ class InboundContextImpl
     this->impl_ = this;
   }
 
-  ~InboundContextImpl() {}
+  ~InboundContextImpl() = default;
 
   // InboundHandlerContext overrides
   void fireRead(Rout msg) override {
@@ -389,7 +389,7 @@ class OutboundContextImpl
     this->impl_ = this;
   }
 
-  ~OutboundContextImpl() {}
+  ~OutboundContextImpl() = default;
 
   // OutboundHandlerContext overrides
   Future<void> fireWrite(Wout msg) override {

--- a/folly/wangle/channel/HandlerContext.h
+++ b/folly/wangle/channel/HandlerContext.h
@@ -27,7 +27,7 @@ class PipelineBase;
 template <class In, class Out>
 class HandlerContext {
  public:
-  virtual ~HandlerContext() {}
+  virtual ~HandlerContext() = default;
 
   virtual void fireRead(In msg) = 0;
   virtual void fireReadEOF() = 0;
@@ -65,7 +65,7 @@ class HandlerContext {
 template <class In>
 class InboundHandlerContext {
  public:
-  virtual ~InboundHandlerContext() {}
+  virtual ~InboundHandlerContext() = default;
 
   virtual void fireRead(In msg) = 0;
   virtual void fireReadEOF() = 0;
@@ -86,7 +86,7 @@ class InboundHandlerContext {
 template <class Out>
 class OutboundHandlerContext {
  public:
-  virtual ~OutboundHandlerContext() {}
+  virtual ~OutboundHandlerContext() = default;
 
   virtual Future<void> fireWrite(Out msg) = 0;
   virtual Future<void> fireClose() = 0;

--- a/folly/wangle/channel/Pipeline.h
+++ b/folly/wangle/channel/Pipeline.h
@@ -27,13 +27,13 @@ namespace folly { namespace wangle {
 
 class PipelineManager {
  public:
-  virtual ~PipelineManager() {}
+  virtual ~PipelineManager() = default;
   virtual void deletePipeline(PipelineBase* pipeline) = 0;
 };
 
 class PipelineBase {
  public:
-  virtual ~PipelineBase() {}
+  virtual ~PipelineBase() = default;
 
   void setPipelineManager(PipelineManager* manager) {
     manager_ = manager;
@@ -174,7 +174,7 @@ class PipelineFactory {
   virtual std::unique_ptr<Pipeline, folly::DelayedDestruction::Destructor>
   newPipeline(std::shared_ptr<AsyncSocket>) = 0;
 
-  virtual ~PipelineFactory() {}
+  virtual ~PipelineFactory() = default;
 };
 
 }

--- a/folly/wangle/concurrent/BlockingQueue.h
+++ b/folly/wangle/concurrent/BlockingQueue.h
@@ -23,7 +23,7 @@ namespace folly { namespace wangle {
 template <class T>
 class BlockingQueue {
  public:
-  virtual ~BlockingQueue() {}
+  virtual ~BlockingQueue() = default;
   virtual void add(T item) = 0;
   virtual void addWithPriority(T item, int8_t priority) {
     LOG_FIRST_N(WARNING, 1) <<

--- a/folly/wangle/concurrent/IOExecutor.h
+++ b/folly/wangle/concurrent/IOExecutor.h
@@ -40,7 +40,7 @@ namespace folly { namespace wangle {
 // IOThreadPoolExecutor will be created and returned.
 class IOExecutor : public virtual Executor {
  public:
-  virtual ~IOExecutor() {}
+  virtual ~IOExecutor() = default;
   virtual EventBase* getEventBase() = 0;
 };
 

--- a/folly/wangle/concurrent/ThreadFactory.h
+++ b/folly/wangle/concurrent/ThreadFactory.h
@@ -23,7 +23,7 @@ namespace folly { namespace wangle {
 
 class ThreadFactory {
  public:
-  virtual ~ThreadFactory() {}
+  virtual ~ThreadFactory() = default;
   virtual std::thread newThread(Func&& func) = 0;
 };
 

--- a/folly/wangle/concurrent/ThreadPoolExecutor.h
+++ b/folly/wangle/concurrent/ThreadPoolExecutor.h
@@ -129,7 +129,7 @@ class ThreadPoolExecutor : public virtual Executor {
         idle(true),
         taskStatsSubject(pool->taskStatsSubject_) {}
 
-    virtual ~Thread() {}
+    virtual ~Thread() = default;
 
     static std::atomic<uint64_t> nextId;
     uint64_t id;

--- a/folly/wangle/rx/Subscription.h
+++ b/folly/wangle/rx/Subscription.h
@@ -24,7 +24,7 @@ namespace folly { namespace wangle {
 template <class T>
 class Subscription {
  public:
-  Subscription() {}
+  Subscription() = default;
 
   Subscription(const Subscription&) = delete;
 

--- a/folly/wangle/service/Service.h
+++ b/folly/wangle/service/Service.h
@@ -33,7 +33,7 @@ template <typename Req, typename Resp = Req>
 class Service {
  public:
   virtual Future<Resp> operator()(Req request) = 0;
-  virtual ~Service() {}
+  virtual ~Service() = default;
 };
 
 /**
@@ -63,7 +63,7 @@ class Filter {
     Service<ReqB, RespB>* service, ReqA request) = 0;
   std::unique_ptr<Service<ReqA, RespA>> compose(
     Service<ReqB, RespB>* service);
-  virtual ~Filter() {}
+  virtual ~Filter() = default;
 };
 
 template <typename ReqA, typename RespA,

--- a/folly/wangle/ssl/SSLCacheProvider.h
+++ b/folly/wangle/ssl/SSLCacheProvider.h
@@ -33,7 +33,7 @@ public:
       folly::DelayedDestruction::DestructorGuard> guard;
   } CacheContext;
 
-  virtual ~SSLCacheProvider() {}
+  virtual ~SSLCacheProvider() = default;
 
   /**
    * Store a session in the external cache.

--- a/folly/wangle/ssl/SSLContextConfig.h
+++ b/folly/wangle/ssl/SSLContextConfig.h
@@ -27,8 +27,8 @@
 namespace folly {
 
 struct SSLContextConfig {
-  SSLContextConfig() {}
-  ~SSLContextConfig() {}
+  SSLContextConfig() = default;
+  ~SSLContextConfig() = default;
 
   struct CertificateInfo {
     std::string certPath;

--- a/folly/wangle/ssl/SSLContextManager.cpp
+++ b/folly/wangle/ssl/SSLContextManager.cpp
@@ -144,7 +144,7 @@ std::string flattenList(const std::list<std::string>& list) {
 
 }
 
-SSLContextManager::~SSLContextManager() {}
+SSLContextManager::~SSLContextManager() = default;
 
 SSLContextManager::SSLContextManager(
   EventBase* eventBase,


### PR DESCRIPTION
Summary: Defaulted (*=default*ed) default constructors are better

because they can be constexpr and/or noexcept when C++ Standard

thinks it is right to do so. And they remain user-declared rather

than user-provided. Regarding *=default*ed default constructor,

benifit is that the work might be done during compilation and we

might not need to worry about exception paths. And for destructors,

apart from that that =defaulted definition is in sync with defaulted

default constructor we might discover that in some cases "() {}" might

be ill-formed when "= default;" compiltion indicates so. If =defaulted

definition for destructor doesn't do any harm then why not go for it.

Test Plan:

All folly/tests, make check for 37 tests, passed.