### PR TITLE
Using emplace_back to avoid temporary

### DIFF
--- a/folly/Padded.h
+++ b/folly/Padded.h
@@ -426,7 +426,7 @@ class Adaptor {
 
   void push_back(value_type x) {
     if (lastCount_ == Node::kElementCount) {
-      c_.push_back(Node());
+      c_.emplace_back();
       lastCount_ = 0;
     }
     c_.back().data()[lastCount_++] = std::move(x);

--- a/folly/io/async/test/AsyncSocketTest2.cpp
+++ b/folly/io/async/test/AsyncSocketTest2.cpp
@@ -1574,28 +1574,28 @@ class TestAcceptCallback : public AsyncServerSocket::AcceptCallback {
 
   void connectionAccepted(int fd, const folly::SocketAddress& clientAddr)
       noexcept {
-    events_.push_back(EventInfo(fd, clientAddr));
+    events_.emplace_back(fd, clientAddr);
 
     if (connectionAcceptedFn_) {
       connectionAcceptedFn_(fd, clientAddr);
     }
   }
   void acceptError(const std::exception& ex) noexcept {
-    events_.push_back(EventInfo(ex.what()));
+    events_.emplace_back(ex.what());
 
     if (acceptErrorFn_) {
       acceptErrorFn_(ex);
     }
   }
   void acceptStarted() noexcept {
-    events_.push_back(EventInfo(TYPE_START));
+    events_.emplace_back(TYPE_START);
 
     if (acceptStartedFn_) {
       acceptStartedFn_();
     }
   }
   void acceptStopped() noexcept {
-    events_.push_back(EventInfo(TYPE_STOP));
+    events_.emplace_back(TYPE_STOP);
 
     if (acceptStoppedFn_) {
       acceptStoppedFn_();

--- a/folly/io/async/test/EventBaseTest.cpp
+++ b/folly/io/async/test/EventBaseTest.cpp
@@ -155,7 +155,7 @@ class TestHandler : public EventHandler {
       bytesWritten = writeUntilFull(fd_);
     }
 
-    log.push_back(EventRecord(events, bytesRead, bytesWritten));
+    log.emplace_back(events, bytesRead, bytesWritten);
   }
 
   struct EventRecord {
@@ -648,7 +648,7 @@ class PartialReadHandler : public TestHandler {
   virtual void handlerReady(uint16_t events) noexcept {
     assert(events == EventHandler::READ);
     ssize_t bytesRead = readFromFD(fd_, readLength_);
-    log.push_back(EventRecord(events, bytesRead, 0));
+    log.emplace_back(events, bytesRead, 0);
   }
 
  private:
@@ -713,7 +713,7 @@ class PartialWriteHandler : public TestHandler {
   virtual void handlerReady(uint16_t events) noexcept {
     assert(events == EventHandler::WRITE);
     ssize_t bytesWritten = writeToFD(fd_, writeLength_);
-    log.push_back(EventRecord(events, 0, bytesWritten));
+    log.emplace_back(events, 0, bytesWritten);
   }
 
  private:
@@ -934,7 +934,7 @@ class ReschedulingTimeout : public AsyncTimeout {
   }
 
   virtual void timeoutExpired() noexcept {
-    timestamps.push_back(TimePoint());
+    timestamps.emplace_back();
     reschedule();
   }
 

--- a/folly/io/async/test/HHWheelTimerTest.cpp
+++ b/folly/io/async/test/HHWheelTimerTest.cpp
@@ -37,14 +37,14 @@ class TestTimeout : public HHWheelTimer::Callback {
   }
 
   void timeoutExpired() noexcept override {
-    timestamps.push_back(TimePoint());
+    timestamps.emplace_back();
     if (fn) {
       fn();
     }
   }
 
   void callbackCanceled() noexcept override {
-    canceledTimestamps.push_back(TimePoint());
+    canceledTimestamps.emplace_back();
     if (fn) {
       fn();
     }

--- a/folly/test/small_vector_test.cpp
+++ b/folly/test/small_vector_test.cpp
@@ -159,7 +159,7 @@ struct TestBasicGuarantee {
   {
     throwCounter = 1000;
     for (int i = 0; i < prepopulate; ++i) {
-      vec.push_back(Thrower());
+      vec.emplace_back();
     }
   }
 
@@ -203,7 +203,7 @@ TEST(small_vector, BasicGuarantee) {
     (TestBasicGuarantee(prepop))( // parens or a mildly vexing parse :(
       1,
       [&] (folly::small_vector<Thrower,3>& v) {
-        v.push_back(Thrower());
+        v.emplace_back();
       }
     );
 
@@ -232,9 +232,9 @@ TEST(small_vector, BasicGuarantee) {
     3,
     [&] (folly::small_vector<Thrower,3>& v) {
       std::vector<Thrower> b;
-      b.push_back(Thrower());
-      b.push_back(Thrower());
-      b.push_back(Thrower());
+      b.emplace_back();
+      b.emplace_back();
+      b.emplace_back();
 
       /*
        * Apparently if you do the following initializer_list instead
@@ -251,7 +251,7 @@ TEST(small_vector, BasicGuarantee) {
     [&] (folly::small_vector<Thrower,3>& v) {
       std::vector<Thrower> b;
       for (int i = 0; i < 6; ++i) {
-        b.push_back(Thrower());
+        b.emplace_back();
       }
 
       v.insert(v.begin() + 1, b.begin(), b.end());

--- a/folly/test/sorted_vector_test.cpp
+++ b/folly/test/sorted_vector_test.cpp
@@ -280,7 +280,7 @@ TEST(SortedVectorTypes, GrowthPolicy) {
 
   std::list<CountCopyCtor> v;
   for (int i = 0; i < 20; ++i) {
-    v.push_back(CountCopyCtor(20 + i));
+    v.emplace_back(20 + i);
   }
   a.insert(v.begin(), v.end());
   check_invariant(a);

--- a/folly/wangle/concurrent/PriorityLifoSemMPMCQueue.h
+++ b/folly/wangle/concurrent/PriorityLifoSemMPMCQueue.h
@@ -27,7 +27,7 @@ class PriorityLifoSemMPMCQueue : public BlockingQueue<T> {
   explicit PriorityLifoSemMPMCQueue(uint8_t numPriorities, size_t capacity) {
     queues_.reserve(numPriorities);
     for (int8_t i = 0; i < numPriorities; i++) {
-      queues_.push_back(MPMCQueue<T>(capacity));
+      queues_.emplace_back(capacity);
     }
   }
 


### PR DESCRIPTION
Directly pass the arguments to respective constructors.
Instead of first making temporary and then pass that.

Test Plan:

All folly/tests, make check for 37 tests, passed.