### PR TITLE
Needless temporary gone

### DIFF
--- a/folly/Subprocess.cpp
+++ b/folly/Subprocess.cpp
@@ -819,7 +819,7 @@ void Subprocess::closeParentFd(int childFd) {
 std::vector<Subprocess::ChildPipe> Subprocess::takeOwnershipOfPipes() {
   std::vector<Subprocess::ChildPipe> pipes;
   for (auto& p : pipes_) {
-    pipes.emplace_back(ChildPipe{p.childFd, std::move(p.pipe)});
+    pipes.emplace_back(p.childFd, std::move(p.pipe));
   }
   pipes_.clear();
   return pipes;

--- a/folly/Subprocess.h
+++ b/folly/Subprocess.h
@@ -714,6 +714,7 @@ class Subprocess {
    * No, you may NOT call this from a communicate() callback.
    */
   struct ChildPipe {
+	ChildPipe(int fd, folly::File&& ppe) : childFd(fd), pipe(std::move(ppe)) {}
     int childFd;
     folly::File pipe;  // Owns the parent FD
   };

--- a/folly/experimental/JSONSchema.cpp
+++ b/folly/experimental/JSONSchema.cpp
@@ -381,8 +381,8 @@ struct PropertiesValidator final : IValidator {
       for (const auto& pair : patternProperties->items()) {
         if (pair.first.isString()) {
           patternPropertyValidators_.emplace_back(
-              make_pair(boost::regex(pair.first.getString().toStdString()),
-                        SchemaValidator::make(context, pair.second)));
+              boost::regex(pair.first.getString().toStdString()),
+              SchemaValidator::make(context, pair.second));
         }
       }
     }
@@ -466,9 +466,8 @@ struct DependencyValidator final : IValidator {
         propertyDep_.emplace_back(std::move(p));
       }
       if (pair.second.isObject()) {
-        schemaDep_.emplace_back(
-            make_pair(pair.first.getString(),
-                      SchemaValidator::make(context, pair.second)));
+        schemaDep_.emplace_back(pair.first.getString(),
+                                SchemaValidator::make(context, pair.second));
       }
     }
   }

--- a/folly/experimental/fibers/SimpleLoopController.h
+++ b/folly/experimental/fibers/SimpleLoopController.h
@@ -77,7 +77,7 @@ class SimpleLoopController : public LoopController {
   }
 
   void timedSchedule(std::function<void()> func, TimePoint time) override {
-    scheduledFuncs_.push_back({time, std::move(func)});
+    scheduledFuncs_.emplace_back(time, std::move(func));
   }
 
  private:

--- a/folly/experimental/fibers/test/FibersTest.cpp
+++ b/folly/experimental/fibers/test/FibersTest.cpp
@@ -581,7 +581,7 @@ TEST(FiberManager, forEach) {
           std::vector<std::pair<size_t, int>> results;
           forEach(funcs.begin(), funcs.end(),
             [&results](size_t id, int result) {
-              results.push_back(std::make_pair(id, result));
+              results.emplace_back(id, result);
             });
           EXPECT_EQ(3, results.size());
           EXPECT_TRUE(pendingFibers.empty());

--- a/folly/experimental/test/EventCountTest.cpp
+++ b/folly/experimental/test/EventCountTest.cpp
@@ -68,7 +68,7 @@ void randomPartition(Random& random, T key, int n,
     int m = std::min(n, 1000);
     std::uniform_int_distribution<uint32_t> u(1, m);
     int cut = u(random);
-    out.push_back(std::make_pair(key, cut));
+    out.emplace_back(key, cut);
     n -= cut;
   }
 }

--- a/folly/futures/Future-inl.h
+++ b/folly/futures/Future-inl.h
@@ -698,7 +698,7 @@ collectN(InputIterator first, InputIterator last, size_t n) {
       auto c = ++ctx->completed;
       if (c <= n) {
         assert(ctx->v.size() < n);
-        ctx->v.push_back(std::make_pair(i, std::move(t)));
+        ctx->v.emplace_back(i, std::move(t));
         if (c == n) {
           ctx->p.setTry(Try<V>(std::move(ctx->v)));
         }

--- a/folly/io/async/SSLContext.h
+++ b/folly/io/async/SSLContext.h
@@ -81,6 +81,8 @@ class SSLContext {
   };
 
   struct NextProtocolsItem {
+	NextProtocolsItem(int wt, const std::list<std::string>& ptcls)
+		: weight(wt), protocols(ptcls) {}
     int weight;
     std::list<std::string> protocols;
   };

--- a/folly/io/async/test/EventBaseTest.cpp
+++ b/folly/io/async/test/EventBaseTest.cpp
@@ -1106,7 +1106,7 @@ struct RunInThreadArg {
 };
 
 void runInThreadTestFunc(RunInThreadArg* arg) {
-  arg->data->values.push_back(make_pair(arg->thread, arg->value));
+  arg->data->values.emplace_back(arg->thread, arg->value);
   RunInThreadData* data = arg->data;
   delete arg;
 

--- a/folly/test/DeterministicSchedule.cpp
+++ b/folly/test/DeterministicSchedule.cpp
@@ -247,7 +247,7 @@ Futex<DeterministicAtomic>::futexWaitImpl(
   futexLock.lock();
   if (data == expected) {
     auto& queue = futexQueues[this];
-    queue.push_back(std::make_pair(waitMask, &awoken));
+    queue.emplace_back(waitMask, &awoken);
     auto ours = queue.end();
     ours--;
     while (!awoken) {

--- a/folly/test/DynamicTest.cpp
+++ b/folly/test/DynamicTest.cpp
@@ -52,17 +52,15 @@ TEST(Dynamic, ObjectBasics) {
   EXPECT_EQ(*newObject.keys().begin(), newObject.items().begin()->first);
   EXPECT_EQ(*newObject.values().begin(), newObject.items().begin()->second);
   std::vector<std::pair<folly::fbstring, dynamic>> found;
-  found.push_back(std::make_pair(
-     newObject.keys().begin()->asString(),
-     *newObject.values().begin()));
+  found.emplace_back(newObject.keys().begin()->asString(),
+                     *newObject.values().begin());
 
   EXPECT_EQ(*boost::next(newObject.keys().begin()),
             boost::next(newObject.items().begin())->first);
   EXPECT_EQ(*boost::next(newObject.values().begin()),
             boost::next(newObject.items().begin())->second);
-  found.push_back(std::make_pair(
-      boost::next(newObject.keys().begin())->asString(),
-      *boost::next(newObject.values().begin())));
+  found.emplace_back(boost::next(newObject.keys().begin())->asString(),
+                     *boost::next(newObject.values().begin()));
 
   std::sort(found.begin(), found.end());
 

--- a/folly/wangle/ssl/SSLContextConfig.h
+++ b/folly/wangle/ssl/SSLContextConfig.h
@@ -31,6 +31,10 @@ struct SSLContextConfig {
   ~SSLContextConfig() {}
 
   struct CertificateInfo {
+	CertificateInfo(const std::string& crtPath,
+                    const std::string& kyPath,
+                    const std::string& passwdPath)
+        : certPath(crtPath), keyPath(kyPath), passwordPath(passwdPath) {}
     std::string certPath;
     std::string keyPath;
     std::string passwordPath;
@@ -49,7 +53,7 @@ struct SSLContextConfig {
   void addCertificate(const std::string& certPath,
                       const std::string& keyPath,
                       const std::string& passwordPath) {
-    certificates.emplace_back(CertificateInfo{certPath, keyPath, passwordPath});
+    certificates.emplace_back(certPath, keyPath, passwordPath);
   }
 
   /**
@@ -58,7 +62,7 @@ struct SSLContextConfig {
    */
   void setNextProtocols(const std::list<std::string>& inNextProtocols) {
     nextProtocols.clear();
-    nextProtocols.push_back({1, inNextProtocols});
+    nextProtocols.emplace_back(1, inNextProtocols);
   }
 
   typedef std::function<bool(char const* server_name)> SNINoMatchFn;

--- a/folly/wangle/ssl/SSLSessionCacheManager.cpp
+++ b/folly/wangle/ssl/SSLSessionCacheManager.cpp
@@ -251,8 +251,7 @@ SSL_SESSION* SSLSessionCacheManager::getSession(SSL* ssl,
             SSLUtil::hexlify(sessionId);
           std::unique_ptr<DelayedDestruction::DestructorGuard> dg(
             new DelayedDestruction::DestructorGuard(sslSocket));
-          pit->second.waiters.push_back(
-            std::make_pair(sslSocket, std::move(dg)));
+          pit->second.waiters.emplace_back(sslSocket, std::move(dg));
           *copyflag = SSL_SESSION_CB_WOULD_BLOCK;
           return nullptr;
         }


### PR DESCRIPTION
Summary:
We might be doing:
					1) Create a temporary
					2) Copy/Move out of it
					3) Destroy that temporary.
Which isn't needed in many places.
And copy/move elision doesn't work for a temporary
bound to a reference.

We can forward arguments, directly.

To get the work done three constructors were added.

Test Plan:

All folly/tests, make check for 37 tests, passed.