### PR TITLE
Building instructions for MAC OS X (MacPorts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In the folly directory, run
   sudo make install
 ```
 
-OS X
+OS X (Homebrew)
 ----
 There is a bootstrap script if you use Homebrew (http://brew.sh/). At the time
 of writing (OS X Yosemite 10.10.1) the default compiler (clang) has some
@@ -79,6 +79,48 @@ of by the bootstrap script.)
   ./bootstrap-osx-homebrew.sh
   make
   make check
+```
+
+OS X (MacPorts)
+----
+Install the required packages from MacPorts:
+
+```
+  sudo port install \
+    autoconf \
+    automake \
+    boost \
+    gflags \
+    git \
+    google-glog \
+    libevent \
+    libtool \
+    lz4 \
+    lzma \
+    scons \
+    snappy \
+    zlib
+```
+
+Download and install double-conversion:
+
+```
+  git clone https://github.com/google/double-conversion.git
+  cd double-conversion
+  cmake -DBUILD_SHARED_LIBS=ON .
+  make
+  sudo make install
+```
+
+Download and install folly with the parameters listed below:
+
+```
+  git clone https://github.com/facebook/folly.git
+  cd folly/folly
+  autoreconf -ivf
+  ./configure CPPFLAGS="-I/opt/local/include" LDFLAGS="-L/opt/local/lib"
+  make
+  sudo make install
 ```
 
 Other Linux distributions


### PR DESCRIPTION
Tested on Mac OS X 10.10.3 and MacPorts 2.3.3.