### PR TITLE
Remove double-conversion as a source dep in OS X script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ autom4te.cache
 build-aux
 libtool
 folly/test/gtest-1.6.0
+folly/test/gtest-1.6.0.zip
 folly/folly-config.h
 folly/test/*_benchmark
 folly/test/*_test

--- a/folly/bootstrap-osx-homebrew.sh
+++ b/folly/bootstrap-osx-homebrew.sh
@@ -10,27 +10,13 @@ brewget() {
 }
 
 # tool dependencies: autotools and scons (for double-conversion)
-brewget autoconf automake libtool scons
+brewget autoconf automake libtool
 
 # dependencies
-brewget glog gflags boost libevent
-
-# Install the double-conversion library.
-# NB their install target installs the libs but not the headers, hence the
-# CPPFLAGS
-test -d double-conversion ||
-    git clone https://github.com/google/double-conversion.git
-pushd double-conversion
-make
-# fool libtool into using static linkage
-# (this won't work if you've already installed libdouble-conversion into a
-# default search path)
-rm -f libdouble-conversion*dylib
-DOUBLE_CONVERSION_HOME=$(pwd)
-popd
+brewget glog gflags boost libevent double-conversion
 
 autoreconf -i
-./configure CPPFLAGS=-I"$DOUBLE_CONVERSION_HOME" LDFLAGS=-L"$DOUBLE_CONVERSION_HOME"
+./configure
 
 pushd test
 test -e gtest-1.7.0.zip || {


### PR DESCRIPTION
double-conversion was recently added to homebrew, making it the last
folly dependency to do so. this diff modifies the existing OS X
bootstrap tool to account for that. I also added an rm for the gtest
wget, so there wasn't a leftover zip file in your repo. alternatively,
we could remove that and add it to the gitignore.