### PR TITLE
Adjust a literal in AtomicHashMap.h to be correctly sized

### DIFF
--- a/folly/AtomicHashMap.h
+++ b/folly/AtomicHashMap.h
@@ -385,7 +385,7 @@ class AtomicHashMap : boost::noncopyable {
   static const uint32_t  kSubMapIndexShift_  = 32 - kNumSubMapBits_ - 1;
   static const uint32_t  kSubMapIndexMask_   = (1 << kSubMapIndexShift_) - 1;
   static const uint32_t  kNumSubMaps_        = 1 << kNumSubMapBits_;
-  static const uintptr_t kLockedPtr_         = 0x88ul << 48; // invalid pointer
+  static const uintptr_t kLockedPtr_         = 0x88ULL << 48; // invalid pointer
 
   struct SimpleRetT { uint32_t i; size_t j; bool success;
     SimpleRetT(uint32_t ii, size_t jj, bool s) : i(ii), j(jj), success(s) {}


### PR DESCRIPTION
Noticed because of a warning emitted by MSVC, this fixees the literal for `kLockedPtr_` to correctly be 64-bits under MSVC, rather than 32-bit.