### PR TITLE
Fix the size of the enum in FBString.h under MSVC

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -810,7 +810,7 @@ private:
     MediumLarge ml_;
   };
 
-  enum {
+  enum : size_t {
     lastChar = sizeof(MediumLarge) - 1,
     maxSmallSize = lastChar / sizeof(Char),
     maxMediumSize = 254 / sizeof(Char),            // coincides with the small


### PR DESCRIPTION
MSVC defaults enum sizes to int, so explicitly use `size_t` as the base to have it correctly sized.