### PR TITLE
Adjust Format-inl.h to work with MSVC

### DIFF
--- a/folly/Format-inl.h
+++ b/folly/Format-inl.h
@@ -471,7 +471,12 @@ class FormatValue<
 
       valBufBegin = valBuf + 3;  // room for sign and base prefix
       int len = snprintf(valBufBegin, (valBuf + valBufSize) - valBufBegin,
-                         "%ju", static_cast<uintmax_t>(uval));
+#ifdef _MSC_VER
+                         "%ju",
+#else
+                         "%'ju",
+#endif
+                         static_cast<uintmax_t>(uval));
       // valBufSize should always be big enough, so this should never
       // happen.
       assert(len < valBuf + valBufSize - valBufBegin);

--- a/folly/Format-inl.h
+++ b/folly/Format-inl.h
@@ -471,7 +471,7 @@ class FormatValue<
 
       valBufBegin = valBuf + 3;  // room for sign and base prefix
       int len = snprintf(valBufBegin, (valBuf + valBufSize) - valBufBegin,
-                         "%'ju", static_cast<uintmax_t>(uval));
+                         "%ju", static_cast<uintmax_t>(uval));
       // valBufSize should always be big enough, so this should never
       // happen.
       assert(len < valBuf + valBufSize - valBufBegin);
@@ -741,9 +741,7 @@ class TryFormatValue {
 
 template <class T>
 class TryFormatValue<
-  T,
-  typename std::enable_if<
-      0 < sizeof(FormatValue<typename std::decay<T>::type>)>::type>
+  T, typename FormatValue<typename std::decay<T>::type>::type>
   {
  public:
   template <class FormatCallback>


### PR DESCRIPTION
This adjusts a format string to be sane, I don't think `'` is a valid format specifier to begin with, and MSVC2015 added a warning for invalid specifiers, which this triggers.
This also adjusts a use of `std::enable_if` to eliminate the `enable_if` entirely, because MSVC doesn't like it when you try to do a sizeof check on a type like this. (I haven't checked, but I wouldn't be surprised if MSVC were just returning `-1` for the size here, either way, the new way it's written should still have the desired effect)