### PR TITLE
Handle some scoping issues in Conv.h under MSVC

### DIFF
--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -815,7 +815,7 @@ typename std::enable_if<sizeof...(Ts) >= 3
     typename detail::last_element<Ts...>::type
   >::type>::value>::type
 toAppend(const Ts&... vs) {
-  detail::toAppendStrImpl(vs...);
+  ::folly::detail::toAppendStrImpl(vs...);
 }
 
 /**
@@ -834,7 +834,7 @@ typename std::enable_if<
     typename detail::last_element<Ts...>::type
   >::type>::value>::type
 toAppendFit(const Ts&... vs) {
-  detail::reserveInTarget(vs...);
+  ::folly::detail::reserveInTarget(vs...);
   toAppend(vs...);
 }
 


### PR DESCRIPTION
No idea why these are the only two places it complains about, but it does.
This just explicitly scopes them.