### PR TITLE
Add support for MSVC in asm_pause in Portability.h

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -284,17 +284,25 @@ inline size_t malloc_usable_size(void* ptr) {
 # define FOLLY_HAS_RTTI 1
 #endif
 
+#ifdef _MSC_VER
+# include <intrin.h>
+#endif
+
 namespace folly {
 
 inline void asm_volatile_pause() {
-#if defined(__i386__) || FOLLY_X64
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+  ::_mm_pause();
+#elif defined(__i386__) || FOLLY_X64
   asm volatile ("pause");
 #elif FOLLY_A64
   asm volatile ("wfe");
 #endif
 }
 inline void asm_pause() {
-#if defined(__i386__) || FOLLY_X64
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
+  ::_mm_pause();
+#elif defined(__i386__) || FOLLY_X64
   asm ("pause");
 #elif FOLLY_A64
   asm ("wfe");


### PR DESCRIPTION
This implements support for `asm_volatile_pause` and `asm_pause`, as defined in `Portability.h`, for MSVC.
This is needed because MSVC x64 doesn't support inline assembly.