### PR TITLE
Add detection of MSVC RTTI

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -280,7 +280,7 @@ inline size_t malloc_usable_size(void* ptr) {
 #endif
 
 // RTTI may not be enabled for this compilation unit.
-#if defined(__GXX_RTTI) || defined(__cpp_rtti)
+#if defined(__GXX_RTTI) || defined(__cpp_rtti) || defined(_CPPRTTI)
 # define FOLLY_HAS_RTTI 1
 #endif
 


### PR DESCRIPTION
This adds MSVC support to the detection of FOLLY_HAS_RTTI.