### PR TITLE
Add MSVC support to MaxAlign

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -54,7 +54,10 @@
 #endif
 
 // MaxAlign: max_align_t isn't supported by gcc
-#ifdef __GNUC__
+#ifdef _MSC_VER
+#include <cstddef>
+typedef std::max_align_t MaxAlign;
+#elif defined(__GNUC__)
 struct MaxAlign { char c; } __attribute__((__aligned__));
 #else /* !__GNUC__ */
 # error Cannot define MaxAlign on this platform


### PR DESCRIPTION
This adds MSVC support to the detection of `MaxAlign` in `Portability.h`.