### PR TITLE
Added asm_volatile_memory

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -286,6 +286,14 @@ inline size_t malloc_usable_size(void* ptr) {
 
 namespace folly {
 
+inline void asm_volatile_memory() {
+#ifdef _MSC_VER
+  ::_ReadWriteBarrier();
+#elif defined(__clang__) || defined(__GNUC__)
+  asm volatile("" : : : "memory");
+#endif
+}
+
 inline void asm_volatile_pause() {
 #if defined(__i386__) || FOLLY_X64
   asm volatile ("pause");

--- a/folly/RWSpinLock.h
+++ b/folly/RWSpinLock.h
@@ -523,13 +523,13 @@ class RWTicketSpinLockT : boost::noncopyable {
  private: // Some x64-specific utilities for atomic access to ticket.
   template<class T> static T load_acquire(T* addr) {
     T t = *addr; // acquire barrier
-    asm volatile("" : : : "memory");
+    asm_volatile_memory();
     return t;
   }
 
   template<class T>
   static void store_release(T* addr, T v) {
-    asm volatile("" : : : "memory");
+    asm_volatile_memory();
     *addr = v; // release barrier
   }
 


### PR DESCRIPTION
This adds `asm_volatile_memory`, which goes along with the same style used by `asm_volatile_pause`.
This also switches the two places in `RWSpinLock.h` that were using inline assembly for this to use the new functions instead.