### PR TITLE
Added FOLLY_ALIGNED(), to allow aligning on MSVC as well

### DIFF
--- a/folly/Arena.h
+++ b/folly/Arena.h
@@ -132,6 +132,7 @@ class Arena {
   typedef boost::intrusive::slist_member_hook<
     boost::intrusive::tag<Arena>> BlockLink;
 
+  FOLLY_ALIGNED(alignof(MaxAlign))
   struct Block {
     BlockLink link;
 
@@ -150,9 +151,7 @@ class Arena {
    private:
     Block() = default;
     ~Block() = default;
-  } __attribute__((__aligned__));
-  // This should be alignas(std::max_align_t) but neither alignas nor
-  // max_align_t are supported by gcc 4.6.2.
+  };
 
  public:
   static constexpr size_t kDefaultMinBlockSize = 4096 - sizeof(Block);

--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -986,7 +986,7 @@ namespace detail {
 // still not overflow uint16_t.
 constexpr int32_t OOR = 10000;
 
-__attribute__((__aligned__(16))) constexpr uint16_t shift1[] = {
+FOLLY_ALIGNED(16) constexpr uint16_t shift1[] = {
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  // 0-9
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  10
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  20
@@ -1015,7 +1015,7 @@ __attribute__((__aligned__(16))) constexpr uint16_t shift1[] = {
   OOR, OOR, OOR, OOR, OOR, OOR                       // 250
 };
 
-__attribute__((__aligned__(16))) constexpr uint16_t shift10[] = {
+FOLLY_ALIGNED(16) constexpr uint16_t shift10[] = {
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  // 0-9
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  10
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  20
@@ -1044,7 +1044,7 @@ __attribute__((__aligned__(16))) constexpr uint16_t shift10[] = {
   OOR, OOR, OOR, OOR, OOR, OOR                       // 250
 };
 
-__attribute__((__aligned__(16))) constexpr uint16_t shift100[] = {
+FOLLY_ALIGNED(16) constexpr uint16_t shift100[] = {
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  // 0-9
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  10
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  20
@@ -1073,7 +1073,7 @@ __attribute__((__aligned__(16))) constexpr uint16_t shift100[] = {
   OOR, OOR, OOR, OOR, OOR, OOR                       // 250
 };
 
-__attribute__((__aligned__(16))) constexpr uint16_t shift1000[] = {
+FOLLY_ALIGNED(16) constexpr uint16_t shift1000[] = {
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  // 0-9
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  10
   OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR, OOR,  //  20

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -63,6 +63,14 @@ struct MaxAlign { char c; } __attribute__((__aligned__));
 // compiler specific attribute translation
 // msvc should come first, so if clang is in msvc mode it gets the right defines
 
+#ifdef _MSC_VER
+# define FOLLY_ALIGNED(size) __declspec(align(size))
+#elif defined(__clang__) || defined(__GNUC__)
+# define FOLLY_ALIGNED(size) __attribute__((__aligned__(size)))
+#else
+# error Cannot define FOLLY_ALIGNED on this platform
+#endif
+
 // NOTE: this will only do checking in msvc with versions that support /analyze
 #if _MSC_VER
 # ifdef _USE_ATTRIBUTES_FOR_SAL

--- a/folly/SmallLocks.h
+++ b/folly/SmallLocks.h
@@ -294,7 +294,7 @@ struct PicoSpinLock {
 #define FOLLY_CACHE_LINE_SIZE 64
 
 template <class T, size_t N>
-struct SpinLockArray {
+struct FOLLY_ALIGNED(alignof(MaxAlign)) SpinLockArray {
   T& operator[](size_t i) {
     return data_[i].lock;
   }
@@ -324,7 +324,7 @@ struct SpinLockArray {
 
   char padding_[FOLLY_CACHE_LINE_SIZE];
   std::array<PaddedSpinLock, N> data_;
-} __attribute__((__aligned__));
+};
 
 //////////////////////////////////////////////////////////////////////
 

--- a/folly/detail/CacheLocality.h
+++ b/folly/detail/CacheLocality.h
@@ -127,7 +127,7 @@ struct CacheLocality {
 
 /// An attribute that will cause a variable or field to be aligned so that
 /// it doesn't have false sharing with anything at a smaller memory address.
-#define FOLLY_ALIGN_TO_AVOID_FALSE_SHARING __attribute__((__aligned__(128)))
+#define FOLLY_ALIGN_TO_AVOID_FALSE_SHARING FOLLY_ALIGNED(128)
 
 /// Holds a function pointer to the VDSO implementation of getcpu(2),
 /// if available


### PR DESCRIPTION
This adds `FOLLY_ALIGNED` to `Portability.h`, and adjusts the places that were previously using the raw aligned attribute to use this instead.