### PR TITLE
Implement a generalized mechansim for pushing/poping warnings

### DIFF
--- a/folly/Bits.h
+++ b/folly/Bits.h
@@ -448,14 +448,15 @@ class BitIterator
    * Construct a BitIterator that points at a given bit offset (default 0)
    * in iter.
    */
-  #pragma GCC diagnostic push // bitOffset shadows a member
-  #pragma GCC diagnostic ignored "-Wshadow"
+  FOLLY_PUSH_WARNING
+  // bitOffset shadows a member
+  FOLLY_GCC_DISABLE_WARNING(shadow)
   explicit BitIterator(const BaseIter& iter, size_t bitOffset=0)
     : bititerator_detail::BitIteratorBase<BaseIter>::type(iter),
       bitOffset_(bitOffset) {
     assert(bitOffset_ < bitsPerBlock());
   }
-  #pragma GCC diagnostic pop
+  FOLLY_POP_WARNING
 
   size_t bitOffset() const {
     return bitOffset_;

--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -81,8 +81,8 @@
 #endif
 
 // Ignore shadowing warnings within this file, so includers can use -Wshadow.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
+FOLLY_PUSH_WARNING
+FOLLY_GCC_DISABLE_WARNING(shadow)
 
 // FBString cannot use throw when replacing std::string, though it may still
 // use std::__throw_*
@@ -2520,7 +2520,7 @@ FOLLY_FBSTRING_HASH
 
 #endif // _LIBSTDCXX_FBSTRING
 
-#pragma GCC diagnostic pop
+FOLLY_POP_WARNING
 
 #undef FBSTRING_DISABLE_ADDRESS_SANITIZER
 #undef throw

--- a/folly/IndexedMemPool.h
+++ b/folly/IndexedMemPool.h
@@ -24,11 +24,12 @@
 #include <sys/mman.h>
 #include <boost/noncopyable.hpp>
 #include <folly/AtomicStruct.h>
+#include <folly/Portability.h>
 #include <folly/detail/CacheLocality.h>
 
 // Ignore shadowing warnings within this file, so includers can use -Wshadow.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wshadow"
+FOLLY_PUSH_WARNING
+FOLLY_GCC_DISABLE_WARNING(shadow)
 
 namespace folly {
 
@@ -465,5 +466,6 @@ struct IndexedMemPoolRecycler {
 
 } // namespace folly
 
-# pragma GCC diagnostic pop
+FOLLY_POP_WARNING
+
 #endif

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -141,6 +141,26 @@ struct MaxAlign { char c; } __attribute__((__aligned__));
 # define FOLLY_PACK_POP /**/
 #endif
 
+// Generalize warning push/pop.
+#if defined(_MSC_VER)
+# define FOLLY_PUSH_WARNING __pragma(warning(push))
+# define FOLLY_POP_WARNING __pragma(warning(pop))
+// Disable the GCC warnings.
+# define FOLLY_GCC_DISABLE_WARNING(warningName)
+# define FOLLY_MSVC_DISABLE_WARNING(warningNumber) __pragma(warning(disable: warningNumber))
+#elif defined(__clang__) || defined(__GNUC__)
+# define FOLLY_PUSH_WARNING _Pragma("GCC diagnostic push")
+# define FOLLY_POP_WARNING _Pragma("GCC diagnostic pop")
+# define FOLLY_GCC_DISABLE_WARNING(warningName) _Pragma("GCC diagnostic ignored \"-W ## warningName\"")
+// Disable the MSVC warnings.
+# define FOLLY_MSVC_DISABLE_WARNING(warningNumber)
+#else
+# define FOLLY_PUSH_WARNING
+# define FOLLY_POP_WARNING
+# define FOLLY_GCC_DISABLE_WARNING(warningName)
+# define FOLLY_MSVC_DISABLE_WARNING(warningNumber)
+#endif
+
 // portable version check
 #ifndef __GNUC_PREREQ
 # if defined __GNUC__ && defined __GNUC_MINOR__

--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -316,8 +316,9 @@ struct is_negative_impl<T, false> {
 // inside what are really static ifs (not executed because of the templated
 // types) that violate -Wsign-compare so suppress them in order to not prevent
 // all calling code from using it.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsign-compare"
+FOLLY_PUSH_WARNING
+FOLLY_GCC_DISABLE_WARNING(sign-compare)
+FOLLY_MSVC_DISABLE_WARNING(4804)
 
 template <typename RHS, RHS rhs, typename LHS>
 bool less_than_impl(
@@ -350,7 +351,7 @@ bool less_than_impl(
   return false;
 }
 
-#pragma GCC diagnostic pop
+FOLLY_POP_WARNING
 
 template <typename RHS, RHS rhs, typename LHS>
 bool greater_than_impl(


### PR DESCRIPTION
This is based on the design used in libGlog.
This replaces a few of the uses of `#pragma GCC diagnostic push/pop`, but does not replace all of them.