### PR TITLE
Add and implement a couple of fallback defines for MSVC

### DIFF
--- a/folly/AtomicHashArray.h
+++ b/folly/AtomicHashArray.h
@@ -128,28 +128,19 @@ class AtomicHashArray : boost::noncopyable {
     int    entryCountThreadCacheSize;
     size_t capacity; // if positive, overrides maxLoadFactor
 
-#ifdef MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS
   private:
     static constexpr KeyT k_emptyKey = (KeyT)-1;
     static constexpr KeyT k_lockedKey = (KeyT)-2;
     static constexpr KeyT k_erasedKey = (KeyT)-3;
+    
   public:
-#endif
-
-    constexpr Config() :
-#ifdef MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS
-      emptyKey(k_emptyKey),
-      lockedKey(k_lockedKey),
-      erasedKey(k_erasedKey),
-#else
-      emptyKey((KeyT)-1),
-      lockedKey((KeyT)-2),
-      erasedKey((KeyT)-3),
-#endif
-      maxLoadFactor(0.8),
-      growthFactor(-1),
-      entryCountThreadCacheSize(1000),
-      capacity(0) {}
+    constexpr Config() : emptyKey(k_emptyKey),
+                         lockedKey(k_lockedKey),
+                         erasedKey(k_erasedKey),
+                         maxLoadFactor(0.8),
+                         growthFactor(-1),
+                         entryCountThreadCacheSize(1000),
+                         capacity(0) {}
   };
 
   static const Config defaultConfig;

--- a/folly/AtomicHashArray.h
+++ b/folly/AtomicHashArray.h
@@ -128,13 +128,28 @@ class AtomicHashArray : boost::noncopyable {
     int    entryCountThreadCacheSize;
     size_t capacity; // if positive, overrides maxLoadFactor
 
-    constexpr Config() : emptyKey((KeyT)-1),
-                         lockedKey((KeyT)-2),
-                         erasedKey((KeyT)-3),
-                         maxLoadFactor(0.8),
-                         growthFactor(-1),
-                         entryCountThreadCacheSize(1000),
-                         capacity(0) {}
+#ifdef MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS
+  private:
+    static constexpr KeyT k_emptyKey = (KeyT)-1;
+    static constexpr KeyT k_lockedKey = (KeyT)-2;
+    static constexpr KeyT k_erasedKey = (KeyT)-3;
+  public:
+#endif
+
+    constexpr Config() :
+#ifdef MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS
+      emptyKey(k_emptyKey),
+      lockedKey(k_lockedKey),
+      erasedKey(k_erasedKey),
+#else
+      emptyKey((KeyT)-1),
+      lockedKey((KeyT)-2),
+      erasedKey((KeyT)-3),
+#endif
+      maxLoadFactor(0.8),
+      growthFactor(-1),
+      entryCountThreadCacheSize(1000),
+      capacity(0) {}
   };
 
   static const Config defaultConfig;

--- a/folly/AtomicLinkedList.h
+++ b/folly/AtomicLinkedList.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <folly/Portability.h>
 
 namespace folly {
 
@@ -63,11 +64,19 @@ class AtomicLinkedList {
    * Note: list must be empty on destruction.
    */
   ~AtomicLinkedList() {
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+    assert(head_.load() == nullptr);
+#else
     assert(head_ == nullptr);
+#endif
   }
 
   bool empty() const {
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+    return head_.load() == nullptr;
+#else
     return head_ == nullptr;
+#endif
   }
 
   /**

--- a/folly/AtomicLinkedList.h
+++ b/folly/AtomicLinkedList.h
@@ -64,11 +64,7 @@ class AtomicLinkedList {
    * Note: list must be empty on destruction.
    */
   ~AtomicLinkedList() {
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
-    assert(head_.load() == nullptr);
-#else
-    assert(head_ == nullptr);
-#endif
+    assert(empty());
   }
 
   bool empty() const {

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -293,14 +293,6 @@ inline size_t malloc_usable_size(void* ptr) {
 // 2015 RTM doesn't support in-class initialization of static constexpr members.
 // Attempting to do this produces an error informing you that this is not yet supported.
 # define MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION 1
-// 2015 RTM doesn't like it when you try to cast anything other than NULL to a
-// pointer type in anything but the root constexpr scope, so we move a couple
-// of initial values around to make it still work for MSVC. See AtomicHashArray::Config
-//
-// I believe this is a deliberate limitation of MSVC, and is unlikely to change,
-// but, in case it does, this will allow us to easily find where the code that can
-// be removed is.
-# define MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS 1
 #endif
 
 namespace folly {

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -284,6 +284,25 @@ inline size_t malloc_usable_size(void* ptr) {
 # define FOLLY_HAS_RTTI 1
 #endif
 
+#if defined(_MSC_VER) && _MSC_FULL_VER <= 190023026 // 2015 RTM or below
+// MSVC2015's initial release produces errors if you try
+// to do `if (std::atomic<char*>)`, while `if (std::atomic<void*>)`
+// works just fine.
+// Bug Report: https://connect.microsoft.com/VisualStudio/feedback/details/1464842
+# define MSVC_NO_NONVOID_ATOMIC_IF 1
+// 2015 RTM doesn't support in-class initialization of static constexpr members.
+// Attempting to do this produces an error informing you that this is not yet supported.
+# define MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION 1
+// 2015 RTM doesn't like it when you try to cast anything other than NULL to a
+// pointer type in anything but the root constexpr scope, so we move a couple
+// of initial values around to make it still work for MSVC. See AtomicHashArray::Config
+//
+// I believe this is a deliberate limitation of MSVC, and is unlikely to change,
+// but, in case it does, this will allow us to easily find where the code that can
+// be removed is.
+# define MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS 1
+#endif
+
 namespace folly {
 
 inline void asm_volatile_pause() {

--- a/folly/Singleton.cpp
+++ b/folly/Singleton.cpp
@@ -22,7 +22,11 @@ namespace folly {
 
 namespace detail {
 
+#ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
+const std::chrono::seconds SingletonHolderBase::kDestroyWaitTime{5};
+#else
 constexpr std::chrono::seconds SingletonHolderBase::kDestroyWaitTime;
+#endif
 
 }
 

--- a/folly/Singleton.h
+++ b/folly/Singleton.h
@@ -195,7 +195,11 @@ class SingletonHolderBase {
   virtual void destroyInstance() = 0;
 
  protected:
+#ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
+  static const std::chrono::seconds kDestroyWaitTime;
+#else
   static constexpr std::chrono::seconds kDestroyWaitTime{5};
+#endif
 };
 
 // An actual instance of a singleton, tracking the instance itself,


### PR DESCRIPTION
Specifically, this defines `MSVC_NO_NONVOID_ATOMIC_IF`, `MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION`, and `MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS` if the current version of MSVC is the 2015 RTM or below.
This also implements the places that needed these defines.