### PR TITLE
Move various attributes before the declaration to be compatible with MSVC

### DIFF
--- a/folly/IndexedMemPool.h
+++ b/folly/IndexedMemPool.h
@@ -310,7 +310,7 @@ struct IndexedMemPool : boost::noncopyable {
 
   /// raw storage, only 1..min(size_,actualCapacity_) (inclusive) are
   /// actually constructed.  Note that slots_[0] is not constructed or used
-  Slot* FOLLY_ALIGN_TO_AVOID_FALSE_SHARING slots_;
+  FOLLY_ALIGN_TO_AVOID_FALSE_SHARING Slot* slots_;
 
   /// use AccessSpreader to find your list.  We use stripes instead of
   /// thread-local to avoid the need to grow or shrink on thread start
@@ -319,7 +319,7 @@ struct IndexedMemPool : boost::noncopyable {
 
   /// this is the head of a list of node chained by globalNext, that are
   /// themselves each the head of a list chained by localNext
-  AtomicStruct<TaggedPtr,Atom> FOLLY_ALIGN_TO_AVOID_FALSE_SHARING globalHead_;
+  FOLLY_ALIGN_TO_AVOID_FALSE_SHARING AtomicStruct<TaggedPtr,Atom> globalHead_;
 
   ///////////// private methods
 

--- a/folly/LifoSem.h
+++ b/folly/LifoSem.h
@@ -504,8 +504,8 @@ struct LifoSemBase : boost::noncopyable {
 
  private:
 
-  folly::AtomicStruct<LifoSemHead,Atom> head_
-      FOLLY_ALIGN_TO_AVOID_FALSE_SHARING;
+  FOLLY_ALIGN_TO_AVOID_FALSE_SHARING
+  folly::AtomicStruct<LifoSemHead,Atom> head_;
 
   char padding_[folly::detail::CacheLocality::kFalseSharingRange -
       sizeof(LifoSemHead)];

--- a/folly/SharedMutex.h
+++ b/folly/SharedMutex.h
@@ -700,9 +700,9 @@ class SharedMutexImpl {
   // should be considered that there is a shared lock on that instance.
   // See kTokenless.
   typedef Atom<uintptr_t> DeferredReaderSlot;
-  static DeferredReaderSlot deferredReaders
+  FOLLY_ALIGN_TO_AVOID_FALSE_SHARING static DeferredReaderSlot deferredReaders
       [kMaxDeferredReaders *
-       kDeferredSeparationFactor] FOLLY_ALIGN_TO_AVOID_FALSE_SHARING;
+       kDeferredSeparationFactor];
 
   // Performs an exclusive lock, waiting for state_ & waitMask to be
   // zero first

--- a/folly/futures/Future.h
+++ b/folly/futures/Future.h
@@ -287,19 +287,19 @@ class Future {
   /// by then), and it is active (active by default).
   ///
   /// Inactive Futures will activate upon destruction.
-  Future<T>& activate() & DEPRECATED {
+  DEPRECATED Future<T>& activate() & {
     core_->activate();
     return *this;
   }
-  Future<T>& deactivate() & DEPRECATED {
+  DEPRECATED Future<T>& deactivate() & {
     core_->deactivate();
     return *this;
   }
-  Future<T> activate() && DEPRECATED {
+  DEPRECATED Future<T> activate() && {
     core_->activate();
     return std::move(*this);
   }
-  Future<T> deactivate() && DEPRECATED {
+  DEPRECATED Future<T> deactivate() && {
     core_->deactivate();
     return std::move(*this);
   }

--- a/folly/futures/Promise.h
+++ b/folly/futures/Promise.h
@@ -53,7 +53,7 @@ public:
       p.setException(std::current_exception());
     }
     */
-  void setException(std::exception_ptr const&) DEPRECATED;
+  DEPRECATED void setException(std::exception_ptr const&);
 
   /** Fulfill the Promise with an exception type E, which can be passed to
     std::make_exception_ptr(). Useful for originating exceptions. If you

--- a/folly/futures/SharedPromise.h
+++ b/folly/futures/SharedPromise.h
@@ -64,7 +64,7 @@ public:
       p.setException(std::current_exception());
     }
     */
-  void setException(std::exception_ptr const&) DEPRECATED;
+  DEPRECATED void setException(std::exception_ptr const&);
 
   /** Fulfill the SharedPromise with an exception type E, which can be passed to
     std::make_exception_ptr(). Useful for originating exceptions. If you

--- a/folly/futures/Try.h
+++ b/folly/futures/Try.h
@@ -94,7 +94,7 @@ class Try {
    *
    * @param ep The exception_pointer. Will be rethrown.
    */
-  explicit Try(std::exception_ptr ep) DEPRECATED
+  DEPRECATED explicit Try(std::exception_ptr ep)
     : contains_(Contains::EXCEPTION) {
     try {
       std::rethrow_exception(ep);
@@ -254,7 +254,7 @@ class Try<void> {
    *
    * @param ep The exception_pointer. Will be rethrown.
    */
-  explicit Try(std::exception_ptr ep) DEPRECATED : hasValue_(false) {
+  DEPRECATED explicit Try(std::exception_ptr ep) : hasValue_(false) {
     try {
       std::rethrow_exception(ep);
     } catch (const std::exception& e) {

--- a/folly/futures/helpers.h
+++ b/folly/futures/helpers.h
@@ -85,7 +85,7 @@ auto makeFutureWith(F&& func)
 ///
 ///   auto f = makeFuture<string>(std::current_exception());
 template <class T>
-Future<T> makeFuture(std::exception_ptr const& e) DEPRECATED;
+DEPRECATED Future<T> makeFuture(std::exception_ptr const& e);
 
 /// Make a failed Future from an exception_wrapper.
 template <class T>


### PR DESCRIPTION
MSVC will just produce syntax errors if these are left where they currently are. GCC and LLVM support them in either location with the same meaning.