### PR TITLE
Add MSVC support to futures/Deprecated.h

### DIFF
--- a/folly/futures/Deprecated.h
+++ b/folly/futures/Deprecated.h
@@ -15,4 +15,8 @@
  */
 
 #pragma once
-#define DEPRECATED __attribute__((__deprecated__))
+#ifdef _MSC_VER
+# define DEPRECATED __declspec(deprecated)
+#else
+# define DEPRECATED __attribute__((__deprecated__))
+#endif


### PR DESCRIPTION
It was originally unconditionally useing `__attribute__` syntax, so this makes it conditionally use the `__declspec` syntax.