### PR TITLE
Switch a couple of uses of __thread to FOLLY_TLS

### DIFF
--- a/folly/experimental/fibers/FiberManager.cpp
+++ b/folly/experimental/fibers/FiberManager.cpp
@@ -28,7 +28,7 @@
 
 namespace folly { namespace fibers {
 
-__thread FiberManager* FiberManager::currentFiberManager_ = nullptr;
+FOLLY_TLS FiberManager* FiberManager::currentFiberManager_ = nullptr;
 
 FiberManager::FiberManager(std::unique_ptr<LoopController> loopController,
                            Options options) :

--- a/folly/experimental/fibers/FiberManager.h
+++ b/folly/experimental/fibers/FiberManager.h
@@ -290,7 +290,7 @@ class FiberManager : public ::folly::Executor {
    * When we are inside FiberManager loop this points to FiberManager. Otherwise
    * it's nullptr
    */
-  static __thread FiberManager* currentFiberManager_;
+  static FOLLY_TLS FiberManager* currentFiberManager_;
 
   /**
    * runInMainContext implementation for non-void functions.


### PR DESCRIPTION
Because MSVC doesn't support `__thread`, and `FOLLY_TLS` is already setup to use the MSVC syntax when needed.