### PR TITLE
Handle MSVC in FBString.h

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -2370,6 +2370,9 @@ operator<<(
       os.setstate(std::ios_base::badbit | std::ios_base::failbit);
     }
   }
+#elif defined(_MSC_VER)
+  // MSVC doesn't define __ostream_insert
+  os.write(str.data(), str.size());
 #else
   std::__ostream_insert(os, str.data(), str.size());
 #endif


### PR DESCRIPTION
Specifically, MSVC doesn't define `std::__ostream_insert`, so just write to the stream instead.