### PR TITLE
Add MSVC support to Singleton's fatalHelper

### DIFF
--- a/folly/Singleton.cpp
+++ b/folly/Singleton.cpp
@@ -45,7 +45,7 @@ struct FatalHelper {
   std::vector<detail::TypeDescriptor> leakedSingletons_;
 };
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(_MSC_VER)
 // OS X doesn't support constructor priorities.
 FatalHelper fatalHelper;
 #else


### PR DESCRIPTION
MSVC doesn't support constructor priorities, so use the same code as OSX.