### PR TITLE
Use strerror_s on MSVC

### DIFF
--- a/folly/String.cpp
+++ b/folly/String.cpp
@@ -330,7 +330,7 @@ fbstring errnoStr(int err) {
 
   // https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man3/strerror_r.3.html
   // http://www.kernel.org/doc/man-pages/online/pages/man3/strerror.3.html
-#if defined(_WIN32) && defined(__MINGW32__)
+#if defined(_WIN32) && (defined(__MINGW32__) || defined(_MSC_VER))
   // mingw64 has no strerror_r, but Windows has strerror_s, which C11 added
   // as well. So maybe we should use this across all platforms (together
   // with strerrorlen_s). Note strerror_r and _s have swapped args.


### PR DESCRIPTION
Support for this under mingw was already present, this just uses that for MSVC as well.