### PR TITLE
Exclude the FB_DEC_TYPE section in dynamic-inl.h under MSVC

### DIFF
--- a/folly/dynamic-inl.h
+++ b/folly/dynamic-inl.h
@@ -569,6 +569,7 @@ template<class T> struct dynamic::TypeInfo {
   static Type const type;
 };
 
+#ifndef _MSC_VER
 #define FB_DEC_TYPE(T)                                      \
   template<> char const dynamic::TypeInfo<T>::name[];       \
   template<> dynamic::Type const dynamic::TypeInfo<T>::type
@@ -582,6 +583,7 @@ FB_DEC_TYPE(int64_t);
 FB_DEC_TYPE(dynamic::ObjectImpl);
 
 #undef FB_DEC_TYPE
+#endif
 
 template<class T>
 T dynamic::asImpl() const {


### PR DESCRIPTION
I have no idea what this section is intended to do, MSVC produces a bunch of errors if it's included, and both Folly and HHVM build just fine with it excluded, so exclude it for MSVC.