### PR TITLE
Fix a parse error in detail/ThreadLocalDetail.h under MSVC

### DIFF
--- a/folly/detail/ThreadLocalDetail.h
+++ b/folly/detail/ThreadLocalDetail.h
@@ -450,7 +450,7 @@ struct StaticMeta {
 
 #ifdef FOLLY_TLD_USE_FOLLY_TLS
 template <class Tag>
-FOLLY_TLS ThreadEntry StaticMeta<Tag>::threadEntry_{nullptr, 0,
+FOLLY_TLS ThreadEntry StaticMeta<Tag>::threadEntry_ = {nullptr, 0,
                                                     nullptr, nullptr};
 #endif
 template <class Tag> StaticMeta<Tag>* StaticMeta<Tag>::inst_ = nullptr;


### PR DESCRIPTION
I have no idea why this specific declaration would error, or if there is a difference in meaning, but this fixes MSVC's absurd parser error.