### PR TITLE
Don't warn if pthread_atfork isn't avaliable on MSVC

### DIFF
--- a/folly/detail/ThreadLocalDetail.h
+++ b/folly/detail/ThreadLocalDetail.h
@@ -212,7 +212,7 @@ struct StaticMeta {
                          /*parent*/ &StaticMeta::onForkParent,
                          /*child*/ &StaticMeta::onForkChild);
     checkPosixError(ret, "pthread_atfork failed");
-#elif !__ANDROID__
+#elif !__ANDROID__ && !_MSC_VER
     // pthread_atfork is not part of the Android NDK at least as of n9d. If
     // something is trying to call native fork() directly at all with Android's
     // process management model, this is probably the least of the problems.

--- a/folly/detail/ThreadLocalDetail.h
+++ b/folly/detail/ThreadLocalDetail.h
@@ -212,7 +212,7 @@ struct StaticMeta {
                          /*parent*/ &StaticMeta::onForkParent,
                          /*child*/ &StaticMeta::onForkChild);
     checkPosixError(ret, "pthread_atfork failed");
-#elif !__ANDROID__ && !_MSC_VER
+#elif !__ANDROID__ && !defined(_MSC_VER)
     // pthread_atfork is not part of the Android NDK at least as of n9d. If
     // something is trying to call native fork() directly at all with Android's
     // process management model, this is probably the least of the problems.


### PR DESCRIPTION
Because we don't even have `fork` to begin with under MSVC.