### PR TITLE
Handle less_than_impl and greater_than_impl under MSVC

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -312,6 +312,13 @@ struct is_negative_impl<T, false> {
   constexpr static bool check(T) { return false; }
 };
 
+// folly::to integral specializations can end up generating code
+// inside what are really static ifs (not executed because of the templated
+// types) that violate -Wsign-compare so suppress them in order to not prevent
+// all calling code from using it.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+
 template <typename RHS, RHS rhs, typename LHS>
 bool less_than_impl(LHS const lhs) {
   return
@@ -319,6 +326,8 @@ bool less_than_impl(LHS const lhs) {
     rhs <= std::numeric_limits<LHS>::min() ? false :
     lhs < rhs;
 }
+
+#pragma GCC diagnostic pop
 
 template <typename RHS, RHS rhs, typename LHS>
 bool greater_than_impl(LHS const lhs) {

--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -312,6 +312,36 @@ struct is_negative_impl<T, false> {
   constexpr static bool check(T) { return false; }
 };
 
+// Early versions of MSVC choke on the template
+// constraints.
+#if _MSC_FULL_VER <= 200022816 // 2015 RC or below
+
+FOLLY_PUSH_WARNING
+// Sign comparison
+FOLLY_MSVC_DISABLE_WARNING(4804)
+template <typename RHS, RHS rhs, typename LHS>
+bool less_than_impl(LHS const lhs) {
+    if (rhs <= std::numeric_limits<LHS>::max() && rhs > std::numeric_limits<LHS>::min())
+        return lhs < rhs;
+    else if (rhs > std::numeric_limits<LHS>::max())
+        return true;
+    else // if (rhs <= std::numeric_limits<LHS>::min())
+        return false;
+}
+
+template <typename RHS, RHS rhs, typename LHS>
+bool greater_than_impl(LHS const lhs) {
+    if (rhs <= std::numeric_limits<LHS>::max() && rhs >= std::numeric_limits<LHS>::min())
+        return lhs > rhs;
+    else if (rhs > std::numeric_limits<LHS>::max())
+        return false;
+    else // if (rhs < std::numeric_limits<LHS>::min())
+        return true;
+}
+FOLLY_POP_WARNING
+
+#else
+
 // folly::to integral specializations can end up generating code
 // inside what are really static ifs (not executed because of the templated
 // types) that violate -Wsign-compare so suppress them in order to not prevent
@@ -382,6 +412,8 @@ bool greater_than_impl(
 ) {
   return true;
 }
+
+#endif
 
 } // namespace detail {
 


### PR DESCRIPTION
MSVC chokes on the template constraints of these functions, so use a single implementation that will be const-folded by the optimizer instead.