### PR TITLE
Disable VDSO on MSVC

### DIFF
--- a/folly/detail/CacheLocality.cpp
+++ b/folly/detail/CacheLocality.cpp
@@ -16,8 +16,10 @@
 
 #include <folly/detail/CacheLocality.h>
 
+#ifndef _MSC_VER
 #define _GNU_SOURCE 1 // for RTLD_NOLOAD
 #include <dlfcn.h>
+#endif
 #include <fstream>
 
 #include <folly/Conv.h>
@@ -204,6 +206,9 @@ CacheLocality CacheLocality::uniform(size_t numCpus) {
 /// Resolves the dynamically loaded symbol __vdso_getcpu, returning null
 /// on failure
 static Getcpu::Func loadVdsoGetcpu() {
+#ifdef _MSC_VER
+  return nullptr;
+#else
   void* h = dlopen("linux-vdso.so.1", RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
   if (h == nullptr) {
     return nullptr;
@@ -219,6 +224,7 @@ static Getcpu::Func loadVdsoGetcpu() {
   }
 
   return func;
+#endif
 }
 
 Getcpu::Func Getcpu::vdsoFunc() {


### PR DESCRIPTION
MSVC will never be able to load VDSO, and doesn't even have dlopen, so just return `nullptr`, and let the fallback mechanisms handle it from there.