### PR TITLE
Handle some member accessibility issues with MSVC

### DIFF
--- a/folly/SharedMutex.h
+++ b/folly/SharedMutex.h
@@ -665,9 +665,15 @@ class SharedMutexImpl {
   // guarantees we won't have inter-L1 contention.  We give ourselves
   // a factor of 2 on the core count, which should hold us for a couple
   // processor generations.  deferredReaders[] is 2048 bytes currently.
+#ifdef _MSC_VER
+public:
+#endif
   static constexpr uint32_t kMaxDeferredReaders = 64;
   static constexpr uint32_t kDeferredSearchDistance = 2;
   static constexpr uint32_t kDeferredSeparationFactor = 4;
+#ifdef _MSC_VER
+private:
+#endif
 
   static_assert(!(kMaxDeferredReaders & (kMaxDeferredReaders - 1)),
                 "kMaxDeferredReaders must be a power of 2");
@@ -699,7 +705,13 @@ class SharedMutexImpl {
   // If any of those elements points to a SharedMutexImpl, then it
   // should be considered that there is a shared lock on that instance.
   // See kTokenless.
+#ifdef _MSC_VER
+public:
+#endif
   typedef Atom<uintptr_t> DeferredReaderSlot;
+#ifdef _MSC_VER
+private:
+#endif
   static DeferredReaderSlot deferredReaders
       [kMaxDeferredReaders *
        kDeferredSeparationFactor] FOLLY_ALIGN_TO_AVOID_FALSE_SHARING;

--- a/folly/stats/Histogram.h
+++ b/folly/stats/Histogram.h
@@ -438,7 +438,6 @@ class Histogram {
    */
   void toTSV(std::ostream& out, bool skipEmptyBuckets = true) const;
 
- private:
   struct CountFromBucket {
     uint64_t operator()(const Bucket& bucket) const {
       return bucket.count;
@@ -462,6 +461,7 @@ class Histogram {
     }
   };
 
+ private:
   detail::HistogramBuckets<ValueType, Bucket> buckets_;
 };
 


### PR DESCRIPTION
MSVC has some odd accessibility rules, so this makes a couple of things public rather than private. The pieces in SharedMutex are conditionally defined for MSVC, the Histogram change is done for all compilers.