### PR TITLE
Handle platforms where pthread_t is a structure

### DIFF
--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -818,6 +818,14 @@ toAppend(const Ts&... vs) {
   ::folly::detail::toAppendStrImpl(vs...);
 }
 
+#ifdef _MSC_VER
+// Special case pid_t on windows.
+template<class Tgt>
+void toAppend(const pid_t a, Tgt* res) {
+  toAppend((uint64_t)a, res);
+}
+#endif
+
 /**
  * Special version of the call that preallocates exaclty as much memory
  * as need for arguments to be stored in target. This means we are

--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -819,7 +819,10 @@ toAppend(const Ts&... vs) {
 }
 
 #ifdef _MSC_VER
-// Special case pid_t on windows.
+// Special case pid_t on MSVC, because it's a void* rather than an
+// integral type. We can't do a global special case because this is already
+// dangerous enough (as most pointers will implicitly convert to a void*)
+// just doing it for MSVC.
 template<class Tgt>
 void toAppend(const pid_t a, Tgt* res) {
   toAppend((uint64_t)a, res);

--- a/folly/Hash.h
+++ b/folly/Hash.h
@@ -23,6 +23,10 @@
 #include <utility>
 #include <tuple>
 
+#ifdef _MSC_VER
+#include <pthread.h>
+#endif
+
 #include <folly/ApplyTuple.h>
 #include <folly/SpookyHashV1.h>
 #include <folly/SpookyHashV2.h>
@@ -89,6 +93,14 @@ size_t hash_combine_generic(const T& t, const Ts&... ts) {
 // strings or pairs
 class StdHasher {
  public:
+#ifdef _MSC_VER
+  // std::hash doesn't support structs, but, on windows,
+  // pthread_t is a struct, so combine the hash of the
+  // two members.
+  static size_t hash(const pthread_t& t) {
+    return hash_combine_generic<StdHasher>(t.p, t.x);
+  }
+#endif
   template <typename T>
   static size_t hash(const T& t) {
     return std::hash<T>()(t);

--- a/folly/Hash.h
+++ b/folly/Hash.h
@@ -23,10 +23,6 @@
 #include <utility>
 #include <tuple>
 
-#ifdef _MSC_VER
-#include <pthread.h>
-#endif
-
 #include <folly/ApplyTuple.h>
 #include <folly/SpookyHashV1.h>
 #include <folly/SpookyHashV2.h>
@@ -93,14 +89,6 @@ size_t hash_combine_generic(const T& t, const Ts&... ts) {
 // strings or pairs
 class StdHasher {
  public:
-#ifdef _MSC_VER
-  // std::hash doesn't support structs, but, on windows,
-  // pthread_t is a struct, so combine the hash of the
-  // two members.
-  static size_t hash(const pthread_t& t) {
-    return hash_combine_generic<StdHasher>(t.p, t.x);
-  }
-#endif
   template <typename T>
   static size_t hash(const T& t) {
     return std::hash<T>()(t);

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -335,6 +335,66 @@ inline size_t malloc_usable_size(void* ptr) {
 #endif
 
 #ifdef _MSC_VER
+#include <pthread.h>
+// We implement a sane comparison operand for
+// pthread_t and an integer so that it may be
+// compared agains 0.
+
+inline bool operator ==(pthread_t ptA, unsigned int b)
+{
+  if (ptA.p == NULL) {
+    return b == 0;
+  }
+  return pthread_getw32threadid_np(ptA) == b;
+}
+
+inline bool operator !=(pthread_t ptA, unsigned int b)
+{
+  if (ptA.p == NULL) {
+    return b != 0;
+  }
+  return pthread_getw32threadid_np(ptA) != b;
+}
+
+inline bool operator ==(pthread_t ptA, pthread_t ptB)
+{
+  return pthread_equal(ptA, ptB) != 0;
+}
+
+inline bool operator !=(pthread_t ptA, pthread_t ptB)
+{
+  return pthread_equal(ptA, ptB) == 0;
+}
+
+#define pthread_t_init (pthread_t{NULL, 0})
+
+inline int pthread_attr_getstack(
+  pthread_attr_t* attr,
+  void** stackaddr,
+  size_t* stacksize) {
+  pthread_attr_getstackaddr(attr, stackaddr);
+  pthread_attr_getstacksize(attr, stacksize);
+  return 0;
+}
+
+inline int pthread_attr_setstack(
+  pthread_attr_t* attr,
+  void* stackaddr,
+  size_t stacksize) {
+  pthread_attr_setstackaddr(attr, stackaddr);
+  pthread_attr_setstacksize(attr, stacksize);
+  return 0;
+}
+
+inline int pthread_attr_getguardsize(pthread_attr_t* attr, size_t* guardsize) {
+  *guardsize = 0;
+  return 0;
+}
+#else
+#define pthread_t_init ((pthread_t)0)
+#endif
+
+#ifdef _MSC_VER
 # include <intrin.h>
 #endif
 

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -341,14 +341,14 @@ inline size_t malloc_usable_size(void* ptr) {
 // compared against 0.
 
 inline bool operator ==(pthread_t ptA, unsigned int b) {
-  if (ptA.p == NULL) {
+  if (ptA.p == nullptr) {
     return b == 0;
   }
   return pthread_getw32threadid_np(ptA) == b;
 }
 
 inline bool operator !=(pthread_t ptA, unsigned int b) {
-  if (ptA.p == NULL) {
+  if (ptA.p == nullptr) {
     return b != 0;
   }
   return pthread_getw32threadid_np(ptA) != b;
@@ -370,16 +370,16 @@ inline bool operator !(pthread_t ptA) {
   return ptA == 0;
 }
 
-#define pthread_zero (pthread_t{NULL, 0})
-
 inline int pthread_attr_getstack(
   pthread_attr_t* attr,
   void** stackaddr,
   size_t* stacksize) {
-  if (pthread_attr_getstackaddr(attr, stackaddr) != 0)
+  if (pthread_attr_getstackaddr(attr, stackaddr) != 0) {
     return -1;
-  if (pthread_attr_getstacksize(attr, stacksize) != 0)
+  }
+  if (pthread_attr_getstacksize(attr, stacksize) != 0) {
     return -1;
+  }
   return 0;
 }
 
@@ -387,10 +387,12 @@ inline int pthread_attr_setstack(
   pthread_attr_t* attr,
   void* stackaddr,
   size_t stacksize) {
-  if (pthread_attr_setstackaddr(attr, stackaddr) != 0)
+  if (pthread_attr_setstackaddr(attr, stackaddr) != 0) {
     return -1;
-  if (pthread_attr_setstacksize(attr, stacksize) != 0)
+  }
+  if (pthread_attr_setstacksize(attr, stacksize) != 0) {
     return -1;
+  }
   return 0;
 }
 
@@ -408,9 +410,6 @@ struct hash<pthread_t> {
   }
 };
 }
-
-#else
-#define pthread_zero ((pthread_t)0)
 #endif
 
 #ifdef _MSC_VER

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -340,30 +340,30 @@ inline size_t malloc_usable_size(void* ptr) {
 // pthread_t and an integer so that it may be
 // compared agains 0.
 
-inline bool operator ==(pthread_t ptA, unsigned int b)
-{
+inline bool operator ==(pthread_t ptA, unsigned int b) {
   if (ptA.p == NULL) {
     return b == 0;
   }
   return pthread_getw32threadid_np(ptA) == b;
 }
 
-inline bool operator !=(pthread_t ptA, unsigned int b)
-{
+inline bool operator !=(pthread_t ptA, unsigned int b) {
   if (ptA.p == NULL) {
     return b != 0;
   }
   return pthread_getw32threadid_np(ptA) != b;
 }
 
-inline bool operator ==(pthread_t ptA, pthread_t ptB)
-{
+inline bool operator ==(pthread_t ptA, pthread_t ptB) {
   return pthread_equal(ptA, ptB) != 0;
 }
 
-inline bool operator !=(pthread_t ptA, pthread_t ptB)
-{
+inline bool operator !=(pthread_t ptA, pthread_t ptB) {
   return pthread_equal(ptA, ptB) == 0;
+}
+
+inline bool operator !(pthread_t ptA) {
+  return ptA == 0;
 }
 
 #define pthread_t_init (pthread_t{NULL, 0})

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -338,7 +338,7 @@ inline size_t malloc_usable_size(void* ptr) {
 #include <pthread.h>
 // We implement a sane comparison operand for
 // pthread_t and an integer so that it may be
-// compared agains 0.
+// compared against 0.
 
 inline bool operator ==(pthread_t ptA, unsigned int b) {
   if (ptA.p == NULL) {
@@ -362,18 +362,24 @@ inline bool operator !=(pthread_t ptA, pthread_t ptB) {
   return pthread_equal(ptA, ptB) == 0;
 }
 
+inline bool operator <(pthread_t ptA, pthread_t ptB) {
+  return ptA.p < ptB.p;
+}
+
 inline bool operator !(pthread_t ptA) {
   return ptA == 0;
 }
 
-#define pthread_t_init (pthread_t{NULL, 0})
+#define pthread_zero (pthread_t{NULL, 0})
 
 inline int pthread_attr_getstack(
   pthread_attr_t* attr,
   void** stackaddr,
   size_t* stacksize) {
-  pthread_attr_getstackaddr(attr, stackaddr);
-  pthread_attr_getstacksize(attr, stacksize);
+  if (pthread_attr_getstackaddr(attr, stackaddr) != 0)
+    return -1;
+  if (pthread_attr_getstacksize(attr, stacksize) != 0)
+    return -1;
   return 0;
 }
 
@@ -381,8 +387,10 @@ inline int pthread_attr_setstack(
   pthread_attr_t* attr,
   void* stackaddr,
   size_t stacksize) {
-  pthread_attr_setstackaddr(attr, stackaddr);
-  pthread_attr_setstacksize(attr, stacksize);
+  if (pthread_attr_setstackaddr(attr, stackaddr) != 0)
+    return -1;
+  if (pthread_attr_setstacksize(attr, stacksize) != 0)
+    return -1;
   return 0;
 }
 
@@ -390,8 +398,19 @@ inline int pthread_attr_getguardsize(pthread_attr_t* attr, size_t* guardsize) {
   *guardsize = 0;
   return 0;
 }
+
+#include <xstddef>
+namespace std {
+template <>
+struct hash<pthread_t> {
+  std::size_t operator()(const pthread_t& k) const {
+    return std::hash<void*>()(k.p) ^ (std::hash<unsigned int>()(k.x) << 1);
+  }
+};
+}
+
 #else
-#define pthread_t_init ((pthread_t)0)
+#define pthread_zero ((pthread_t)0)
 #endif
 
 #ifdef _MSC_VER

--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -144,7 +144,7 @@ static std::mutex libevent_mutex_;
 EventBase::EventBase(bool enableTimeMeasurement)
   : runOnceCallbacks_(nullptr)
   , stop_(false)
-  , loopThread_(pthread_t_init)
+  , loopThread_(pthread_zero)
   , queue_(nullptr)
   , fnRunner_(nullptr)
   , maxLatency_(0)
@@ -182,7 +182,7 @@ EventBase::EventBase(bool enableTimeMeasurement)
 EventBase::EventBase(event_base* evb, bool enableTimeMeasurement)
   : runOnceCallbacks_(nullptr)
   , stop_(false)
-  , loopThread_(pthread_t_init)
+  , loopThread_(pthread_zero)
   , evb_(evb)
   , queue_(nullptr)
   , fnRunner_(nullptr)
@@ -424,7 +424,7 @@ bool EventBase::loopBody(int flags) {
     return false;
   }
 
-  loopThread_.store(pthread_t_init, std::memory_order_release);
+  loopThread_.store(pthread_zero, std::memory_order_release);
 
   VLOG(5) << "EventBase(): Done with loop.";
   return true;

--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -144,7 +144,7 @@ static std::mutex libevent_mutex_;
 EventBase::EventBase(bool enableTimeMeasurement)
   : runOnceCallbacks_(nullptr)
   , stop_(false)
-  , loopThread_(0)
+  , loopThread_(pthread_t_init)
   , queue_(nullptr)
   , fnRunner_(nullptr)
   , maxLatency_(0)
@@ -182,7 +182,7 @@ EventBase::EventBase(bool enableTimeMeasurement)
 EventBase::EventBase(event_base* evb, bool enableTimeMeasurement)
   : runOnceCallbacks_(nullptr)
   , stop_(false)
-  , loopThread_(0)
+  , loopThread_(pthread_t_init)
   , evb_(evb)
   , queue_(nullptr)
   , fnRunner_(nullptr)
@@ -424,7 +424,7 @@ bool EventBase::loopBody(int flags) {
     return false;
   }
 
-  loopThread_.store(0, std::memory_order_release);
+  loopThread_.store(pthread_t_init, std::memory_order_release);
 
   VLOG(5) << "EventBase(): Done with loop.";
   return true;

--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -144,7 +144,7 @@ static std::mutex libevent_mutex_;
 EventBase::EventBase(bool enableTimeMeasurement)
   : runOnceCallbacks_(nullptr)
   , stop_(false)
-  , loopThread_(pthread_zero)
+  , loopThread_()
   , queue_(nullptr)
   , fnRunner_(nullptr)
   , maxLatency_(0)
@@ -182,7 +182,7 @@ EventBase::EventBase(bool enableTimeMeasurement)
 EventBase::EventBase(event_base* evb, bool enableTimeMeasurement)
   : runOnceCallbacks_(nullptr)
   , stop_(false)
-  , loopThread_(pthread_zero)
+  , loopThread_()
   , evb_(evb)
   , queue_(nullptr)
   , fnRunner_(nullptr)
@@ -424,7 +424,7 @@ bool EventBase::loopBody(int flags) {
     return false;
   }
 
-  loopThread_.store(pthread_zero, std::memory_order_release);
+  loopThread_.store({}, std::memory_order_release);
 
   VLOG(5) << "EventBase(): Done with loop.";
   return true;

--- a/folly/io/async/NotificationQueue.h
+++ b/folly/io/async/NotificationQueue.h
@@ -230,7 +230,7 @@ class NotificationQueue {
     : eventfd_(-1),
       pipeFds_{-1, -1},
       advisoryMaxQueueSize_(maxSize),
-      pid_(getpid()),
+      pid_((pid_t)getpid()),
       queue_() {
 
     RequestContext::saveContext();
@@ -426,7 +426,7 @@ class NotificationQueue {
    * code, and crash before signalling the parent process.
    */
   void checkPid() const {
-    CHECK_EQ(pid_, getpid());
+    CHECK_EQ(pid_, (pid_t)getpid());
   }
 
  private:

--- a/folly/io/async/SSLContext.cpp
+++ b/folly/io/async/SSLContext.cpp
@@ -652,6 +652,8 @@ static unsigned long callbackThreadID() {
   return static_cast<unsigned long>(
 #ifdef __APPLE__
     pthread_mach_thread_np(pthread_self())
+#elif _MSC_VER
+    pthread_getw32threadid_np(pthread_self())
 #else
     pthread_self()
 #endif


### PR DESCRIPTION
These platforms include MSVC, and I don't know of any others. This implements the changes needed for this to work properly on MSVC.