### PR TITLE
Switch a local from long to size_t for MSVC

### DIFF
--- a/folly/IndexedMemPool.h
+++ b/folly/IndexedMemPool.h
@@ -130,7 +130,7 @@ struct IndexedMemPool : boost::noncopyable {
     , globalHead_(TaggedPtr{})
   {
     const size_t needed = sizeof(Slot) * (actualCapacity_ + 1);
-    long pagesize = sysconf(_SC_PAGESIZE);
+    size_t pagesize = sysconf(_SC_PAGESIZE);
     mmapLength_ = ((needed - 1) & ~(pagesize - 1)) + pagesize;
     assert(needed <= mmapLength_ && mmapLength_ < needed + pagesize);
     assert((mmapLength_ % pagesize) == 0);


### PR DESCRIPTION
Because MSVC would try to calculate the mmapLength as a long value, which isn't correct, and MSVC issues multiple warnings if you try to do it.