### PR TITLE
Add support for recent libevent versions.

### DIFF
--- a/folly/io/async/EventUtil.h
+++ b/folly/io/async/EventUtil.h
@@ -22,6 +22,14 @@
 
 #include <event.h>  // libevent
 
+#if LIBEVENT_VERSION_NUMBER > 0x02010101
+#define ev_pri ev_evcallback.evcb_pri
+#define ev_flags ev_evcallback.evcb_flags
+#define ev_closure ev_evcallback.evcb_closure
+#define ev_callback ev_evcallback.evcb_callback
+#define ev_arg ev_evcallback.evcb_arg
+#endif
+
 namespace folly {
 
 /**


### PR DESCRIPTION
Add a workaround to support recent versions of libevent.

Here is the relevant libevent commit that introduced the change: https://github.com/libevent/libevent/commit/cba59e53253bb396f192e40a002c6dd9835df51c#diff-4d5f6c7a554e6cab25684fe7194e7ba5