### PR TITLE
Remove `unsigned char v = static_cast<unsigned char>(v);`

### DIFF
--- a/folly/String-inl.h
+++ b/folly/String-inl.h
@@ -203,7 +203,6 @@ void uriUnescape(StringPiece str, String& out, UriEscapeMode mode) {
   // this is faster than calling push_back repeatedly.
   while (p != str.end()) {
     char c = *p;
-    unsigned char v = static_cast<unsigned char>(v);
     switch (c) {
     case '%':
       {


### PR DESCRIPTION
MSVC spotted this very suspicious line when I was running it with /analyze, and complained about using an unitialized variable. This variable isn't used anywhere in the function, and is initializing itself with itself. I have no idea how this compiled in the first place, but apparently it does.
This removes the line in question.