### PR TITLE
Fixes for upstream

### DIFF
--- a/folly/Checksum.cpp
+++ b/folly/Checksum.cpp
@@ -29,10 +29,11 @@ namespace detail {
   #define __has_builtin(x) 0
 #endif
 
-#if (__has_builtin(__builtin_ia32_crc32qi) && \
+#if __SSE4_2__ && \
+    ((__has_builtin(__builtin_ia32_crc32qi) && \
      __has_builtin(__builtin_ia32_crc32di)) || \
     (FOLLY_X64 && defined(__GNUC__) && defined(__GNUC_MINOR__) && \
-     (((__GNUC__ * 100) + __GNUC_MINOR__) >= 407))
+     (((__GNUC__ * 100) + __GNUC_MINOR__) >= 407)))
 
 // Fast SIMD implementation of CRC-32C for x86 with SSE 4.2
 uint32_t crc32c_hw(const uint8_t *data, size_t nbytes,

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -309,6 +309,7 @@ libfollybase_la_SOURCES = \
 
 libfolly_la_SOURCES = \
 	Bits.cpp \
+	Checksum.cpp \
 	detail/CacheLocality.cpp \
 	dynamic.cpp \
 	File.cpp \


### PR DESCRIPTION
Fixes compiling crc32c function on older hardware. (I believe this problem was introduced by 7ec1fc0e0e27ed56c1d18d33af9711a17e9ec750).

Also ensures is in final library since the API suggests it should be. This should correct a number of build problems for other projects like wdt and hhvm when they are compiled using a shared folly library rather than borrowing sources at compile time.