### PR TITLE
Adjust Format-inl.h to work with MSVC

### DIFF
--- a/folly/Format-inl.h
+++ b/folly/Format-inl.h
@@ -471,7 +471,12 @@ class FormatValue<
 
       valBufBegin = valBuf + 3;  // room for sign and base prefix
       int len = snprintf(valBufBegin, (valBuf + valBufSize) - valBufBegin,
-                         "%ju", static_cast<uintmax_t>(uval));
+#ifdef _MSC_VER
+                         "%ju",
+#else
+                         "%'ju",
+#endif
+                         static_cast<uintmax_t>(uval));
       // valBufSize should always be big enough, so this should never
       // happen.
       assert(len < valBuf + valBufSize - valBufBegin);

--- a/folly/Format-inl.h
+++ b/folly/Format-inl.h
@@ -470,13 +470,21 @@ class FormatValue<
                   "' specifier");
 
       valBufBegin = valBuf + 3;  // room for sign and base prefix
-      int len = snprintf(valBufBegin, (valBuf + valBufSize) - valBufBegin,
 #ifdef _MSC_VER
-                         "%ju",
+      char valBuf2[valBufSize];
+      snprintf(valBuf2, valBufSize, "%ju", static_cast<uintmax_t>(uval));
+      int len = GetNumberFormat(
+        LOCALE_USER_DEFAULT,
+        0,
+        valBuf2,
+        nullptr,
+        valBufBegin,
+        (int)((valBuf + valBufSize) - valBufBegin)
+      );
 #else
-                         "%'ju",
+      int len = snprintf(valBufBegin, (valBuf + valBufSize) - valBufBegin,
+                         "%'ju", static_cast<uintmax_t>(uval));
 #endif
-                         static_cast<uintmax_t>(uval));
       // valBufSize should always be big enough, so this should never
       // happen.
       assert(len < valBuf + valBufSize - valBufBegin);

--- a/folly/Format-inl.h
+++ b/folly/Format-inl.h
@@ -471,7 +471,7 @@ class FormatValue<
 
       valBufBegin = valBuf + 3;  // room for sign and base prefix
       int len = snprintf(valBufBegin, (valBuf + valBufSize) - valBufBegin,
-                         "%'ju", static_cast<uintmax_t>(uval));
+                         "%ju", static_cast<uintmax_t>(uval));
       // valBufSize should always be big enough, so this should never
       // happen.
       assert(len < valBuf + valBufSize - valBufBegin);
@@ -741,9 +741,7 @@ class TryFormatValue {
 
 template <class T>
 class TryFormatValue<
-  T,
-  typename std::enable_if<
-      0 < sizeof(FormatValue<typename std::decay<T>::type>)>::type>
+  T, typename FormatValue<typename std::decay<T>::type>::type>
   {
  public:
   template <class FormatCallback>


### PR DESCRIPTION
Originally #247, which was closed before being merged, this doesn't change the behavior of the formatting function now.