### PR TITLE
Porting Folly to PPC64

### DIFF
--- a/folly/DiscriminatedPtr.h
+++ b/folly/DiscriminatedPtr.h
@@ -34,8 +34,8 @@
 #include <folly/Portability.h>
 #include <folly/detail/DiscriminatedPtrDetail.h>
 
-#if !FOLLY_X64
-# error "DiscriminatedPtr is x64-specific code."
+#if !FOLLY_X64 && !FOLLY_PPC64
+# error "DiscriminatedPtr is x64 and ppc64 specific code."
 #endif
 
 namespace folly {

--- a/folly/Hash.h
+++ b/folly/Hash.h
@@ -220,7 +220,8 @@ inline uint32_t fnv32(const char* s,
 inline uint32_t fnv32_buf(const void* buf,
                           size_t n,
                           uint32_t hash = FNV_32_HASH_START) {
-  const char* char_buf = reinterpret_cast<const char*>(buf);
+  // forcing signed char, since other platforms can use unsigned
+  const signed char* char_buf = reinterpret_cast<const signed char*>(buf);
 
   for (size_t i = 0; i < n; ++i) {
     hash += (hash << 1) + (hash << 4) + (hash << 7) +
@@ -249,7 +250,8 @@ inline uint64_t fnv64(const char* s,
 inline uint64_t fnv64_buf(const void* buf,
                           size_t n,
                           uint64_t hash = FNV_64_HASH_START) {
-  const char* char_buf = reinterpret_cast<const char*>(buf);
+  // forcing signed char, since other platforms can use unsigned
+  const signed char* char_buf = reinterpret_cast<const signed char*>(buf);
 
   for (size_t i = 0; i < n; ++i) {
     hash += (hash << 1) + (hash << 4) + (hash << 5) + (hash << 7) +
@@ -271,7 +273,8 @@ inline uint64_t fnv64(const std::string& str,
 #define get16bits(d) (*((const uint16_t*) (d)))
 
 inline uint32_t hsieh_hash32_buf(const void* buf, size_t len) {
-  const char* s = reinterpret_cast<const char*>(buf);
+  // forcing signed char, since other platforms can use unsigned
+  const signed char* s = reinterpret_cast<const signed char*>(buf);
   uint32_t hash = static_cast<uint32_t>(len);
   uint32_t tmp;
   size_t rem;

--- a/folly/PackedSyncPtr.h
+++ b/folly/PackedSyncPtr.h
@@ -19,8 +19,8 @@
 
 #include <folly/Portability.h>
 
-#if !FOLLY_X64
-# error "PackedSyncPtr is x64-specific code."
+#if !FOLLY_X64 && !FOLLY_PPC64
+# error "PackedSyncPtr is x64 and ppc64 specific code."
 #endif
 
 /*

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -128,6 +128,12 @@ struct MaxAlign { char c; } __attribute__((__aligned__));
 # define FOLLY_A64 0
 #endif
 
+#if defined (__powerpc64__)
+# define FOLLY_PPC64 1
+#else
+# define FOLLY_PPC64 0
+#endif
+
 // packing is very ugly in msvc
 #ifdef _MSC_VER
 # define FOLLY_PACK_ATTR /**/
@@ -337,6 +343,8 @@ inline void asm_volatile_pause() {
   asm volatile ("pause");
 #elif FOLLY_A64
   asm volatile ("wfe");
+#elif FOLLY_PPC64
+  asm volatile("or 31,31,31");
 #endif
 }
 inline void asm_pause() {
@@ -346,6 +354,8 @@ inline void asm_pause() {
   asm ("pause");
 #elif FOLLY_A64
   asm ("wfe");
+#elif FOLLY_PPC64
+  asm ("or 31,31,31");
 #endif
 }
 

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -404,6 +404,8 @@ AC_SUBST([AM_LDFLAGS])
 
 AM_CONDITIONAL([HAVE_STD_THREAD], [test "$ac_cv_header_features" = "yes"])
 AM_CONDITIONAL([HAVE_X86_64], [test "$build_cpu" = "x86_64"])
+AM_CONDITIONAL([HAVE_PPC64], [test "$build_cpu" = "powerpc64le"])
+AM_CONDITIONAL([RUN_ARCH_SPECIFIC_TESTS], [test "$build_cpu" = "x86_64" || test "$build_cpu" = "powerpc64le"])
 AM_CONDITIONAL([HAVE_LINUX], [test "$build_os" == "linux-gnu"])
 AM_CONDITIONAL([HAVE_WEAK_SYMBOLS],
                [test "$folly_cv_prog_cc_weak_symbols" = "yes"])

--- a/folly/detail/AtomicHashUtils.h
+++ b/folly/detail/AtomicHashUtils.h
@@ -26,6 +26,15 @@
      if (counter < 10000) continue;               \
      pthread_yield();                             \
    }
+#elif FOLLY_PPC64
+#define FOLLY_SPIN_WAIT(condition)              \
+  for (int counter = 0; condition; ++counter) { \
+    if (counter < 10000) {                      \
+      asm volatile("or 31,31,31");              \
+      continue;                                 \
+    }                                           \
+    pthread_yield();                            \
+  }
 #else
 #define FOLLY_SPIN_WAIT(condition)              \
   for (int counter = 0; condition; ++counter) { \

--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -30,7 +30,7 @@ spin_lock_test_SOURCES = SpinLockTest.cpp
 spin_lock_test_LDADD = libgtestmain.la $(top_builddir)/libfolly.la
 TESTS += spin_lock_test
 
-if HAVE_X86_64
+if RUN_ARCH_SPECIFIC_TESTS
 small_locks_test_SOURCES = SmallLocksTest.cpp
 small_locks_test_LDADD = libgtestmain.la $(top_builddir)/libfolly.la
 TESTS += small_locks_test
@@ -48,9 +48,11 @@ discriminated_ptr_test_SOURCES = DiscriminatedPtrTest.cpp
 discriminated_ptr_test_LDADD = libgtestmain.la $(top_builddir)/libfolly.la
 TESTS += discriminated_ptr_test
 
+if !HAVE_PPC64
 cpuid_test_SOURCES = CpuIdTest.cpp
 cpuid_test_LDADD = libgtestmain.la $(top_builddir)/libfolly.la
 TESTS += cpuid_test
+endif
 endif
 
 sorted_vector_types_test_SOURCES = sorted_vector_test.cpp


### PR DESCRIPTION
This patch adds PPC64 specific code in order to support this architecture and be able to be used by HHVM.