### PR TITLE
Add a compatibility shim for working with libevent on MSVC

### DIFF
--- a/folly/EventPortability.cpp
+++ b/folly/EventPortability.cpp
@@ -1,0 +1,51 @@
+/*
+* Copyright 2015 Facebook, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifdef _MSC_VER
+#include <folly/EventPortability.h>
+
+#include <fcntl.h>
+#include <io.h>
+#include <functional>
+
+namespace folly { namespace event_portability {
+
+// The indirect manner of casting to/from evutil_socket_t is done so
+// that we can still compile if we've adjusted evutil_socket_t to be
+// defined as a structure to break any places that are incorrectly
+// using the API. (ABI-wise, they are actually the exact same)
+
+void event_set(struct event* e, evutil_socket_t fd, short s, void(*f)(int, short, void*), void* b) {
+  // We need to dynamically wrap a function pointer, so we get this fun :(
+  auto fp = std::function<void(evutil_socket_t, short, void*)>([&](evutil_socket_t a, short b, void* c) {
+    f(_open_osfhandle(*(intptr_t*)&a, O_RDWR | O_BINARY), b, c);
+  });
+  auto fp2 = fp.target<void(evutil_socket_t, short, void*)>();
+  ::event_set(e, fd, s, fp2, b);
+}
+
+void event_set(struct event* e, int fd, short s, void(*f)(int, short, void*), void* b) {
+  intptr_t fh;
+  if (fd == -1)
+    fh = (intptr_t)INVALID_HANDLE_VALUE;
+  else
+    fh = _get_osfhandle(fd);
+  event_set(e, *(evutil_socket_t*)&fh, s, f, b);
+}
+
+}}
+
+#endif

--- a/folly/EventPortability.h
+++ b/folly/EventPortability.h
@@ -1,0 +1,31 @@
+/*
+* Copyright 2015 Facebook, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+#pragma once
+
+#ifdef _MSC_VER
+
+#include <event2/event_compat.h>
+
+namespace folly { namespace event_portability {
+
+void event_set(struct event* e, evutil_socket_t fd, short s, void(*f)(int, short, void*), void* b);
+void event_set(struct event* e, int fd, short s, void(*f)(int, short, void*), void* b);
+
+}}
+
+using namespace folly::event_portability;
+
+#endif

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -73,6 +73,7 @@ nobase_follyinclude_HEADERS = \
 	Exception.h \
 	ExceptionWrapper.h \
 	Executor.h \
+	EventPortability.h \
 	EvictingCacheMap.h \
 	experimental/AutoTimer.h \
 	experimental/Bits.h \
@@ -312,6 +313,7 @@ libfolly_la_SOURCES = \
 	Bits.cpp \
 	detail/CacheLocality.cpp \
 	dynamic.cpp \
+	EventPortability.cpp \
 	File.cpp \
 	FileUtil.cpp \
 	FingerprintTables.cpp \

--- a/folly/io/async/AsyncSignalHandler.cpp
+++ b/folly/io/async/AsyncSignalHandler.cpp
@@ -18,6 +18,7 @@
 #include <folly/io/async/EventBase.h>
 
 #include <folly/Conv.h>
+#include <folly/EventPortability.h>
 
 using std::make_pair;
 using std::pair;

--- a/folly/io/async/AsyncTimeout.cpp
+++ b/folly/io/async/AsyncTimeout.cpp
@@ -23,6 +23,8 @@
 #include <folly/io/async/EventUtil.h>
 #include <folly/io/async/Request.h>
 
+#include <folly/EventPortability.h>
+
 #include <assert.h>
 #include <glog/logging.h>
 

--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -20,6 +20,7 @@
 
 #include <folly/io/async/EventBase.h>
 
+#include <folly/EventPortability.h>
 #include <folly/ThreadName.h>
 #include <folly/io/async/NotificationQueue.h>
 

--- a/folly/io/async/EventHandler.cpp
+++ b/folly/io/async/EventHandler.cpp
@@ -21,6 +21,8 @@
 #include <folly/io/async/EventHandler.h>
 #include <folly/io/async/EventBase.h>
 
+#include <folly/EventPortability.h>
+
 #include <assert.h>
 
 namespace folly {


### PR DESCRIPTION
MSVC builds of libevent expect `evutil_socket_t` to be `HANDLE` values, but Folly, HHVM, and Thrift all use them as file descriptors.
This adds a shim for the only method that needs it, `event_set`, and includes it where it's needed in Folly.
The shim is only enabled under MSVC, but it's safe to include the header from any platform.