### PR TITLE
Add and implement a couple of fallback defines for MSVC - What was missed

### DIFF
--- a/folly/AtomicLinkedList.h
+++ b/folly/AtomicLinkedList.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <folly/Portability.h>
 
 namespace folly {
 
@@ -67,7 +68,11 @@ class AtomicLinkedList {
   }
 
   bool empty() const {
+#ifdef MSVC_NO_NONVOID_ATOMIC_IF
+    return head_.load() == nullptr;
+#else
     return head_ == nullptr;
+#endif
   }
 
   /**

--- a/folly/AtomicLinkedList.h
+++ b/folly/AtomicLinkedList.h
@@ -19,7 +19,6 @@
 
 #include <atomic>
 #include <cassert>
-#include <folly/Portability.h>
 
 namespace folly {
 
@@ -68,11 +67,7 @@ class AtomicLinkedList {
   }
 
   bool empty() const {
-#ifdef MSVC_NO_NONVOID_ATOMIC_IF
     return head_.load() == nullptr;
-#else
-    return head_ == nullptr;
-#endif
   }
 
   /**

--- a/folly/Format-inl.h
+++ b/folly/Format-inl.h
@@ -774,9 +774,7 @@ class TryFormatValue {
 
 template <class T>
 class TryFormatValue<
-  T,
-  typename std::enable_if<
-      0 < sizeof(FormatValue<typename std::decay<T>::type>)>::type>
+  T, typename FormatValue<typename std::decay<T>::type>::type>
   {
  public:
   template <class FormatCallback>

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -334,6 +334,25 @@ inline size_t malloc_usable_size(void* ptr) {
 # define FOLLY_HAS_RTTI 1
 #endif
 
+#if defined(_MSC_VER) && _MSC_FULL_VER <= 190023026 // 2015 RTM or below
+// MSVC2015's initial release produces errors if you try
+// to do `if (std::atomic<char*>)`, while `if (std::atomic<void*>)`
+// works just fine.
+// Bug Report: https://connect.microsoft.com/VisualStudio/feedback/details/1464842
+# define MSVC_NO_NONVOID_ATOMIC_IF 1
+// 2015 RTM doesn't support in-class initialization of static constexpr members.
+// Attempting to do this produces an error informing you that this is not yet supported.
+# define MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION 1
+// 2015 RTM doesn't like it when you try to cast anything other than NULL to a
+// pointer type in anything but the root constexpr scope, so we move a couple
+// of initial values around to make it still work for MSVC. See AtomicHashArray::Config
+//
+// I believe this is a deliberate limitation of MSVC, and is unlikely to change,
+// but, in case it does, this will allow us to easily find where the code that can
+// be removed is.
+# define MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS 1
+#endif
+
 #ifdef _MSC_VER
 # include <intrin.h>
 #endif

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -343,14 +343,6 @@ inline size_t malloc_usable_size(void* ptr) {
 // 2015 RTM doesn't support in-class initialization of static constexpr members.
 // Attempting to do this produces an error informing you that this is not yet supported.
 # define MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION 1
-// 2015 RTM doesn't like it when you try to cast anything other than NULL to a
-// pointer type in anything but the root constexpr scope, so we move a couple
-// of initial values around to make it still work for MSVC. See AtomicHashArray::Config
-//
-// I believe this is a deliberate limitation of MSVC, and is unlikely to change,
-// but, in case it does, this will allow us to easily find where the code that can
-// be removed is.
-# define MSVC_NO_CONSTEXPR_EASY_POINTER_CASTS 1
 #endif
 
 #ifdef _MSC_VER

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -334,17 +334,6 @@ inline size_t malloc_usable_size(void* ptr) {
 # define FOLLY_HAS_RTTI 1
 #endif
 
-#if defined(_MSC_VER) && _MSC_FULL_VER <= 190023026 // 2015 RTM or below
-// MSVC2015's initial release produces errors if you try
-// to do `if (std::atomic<char*>)`, while `if (std::atomic<void*>)`
-// works just fine.
-// Bug Report: https://connect.microsoft.com/VisualStudio/feedback/details/1464842
-# define MSVC_NO_NONVOID_ATOMIC_IF 1
-// 2015 RTM doesn't support in-class initialization of static constexpr members.
-// Attempting to do this produces an error informing you that this is not yet supported.
-# define MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION 1
-#endif
-
 #ifdef _MSC_VER
 # include <intrin.h>
 #endif

--- a/folly/Singleton-inl.h
+++ b/folly/Singleton-inl.h
@@ -116,7 +116,7 @@ void SingletonHolder<T>::destroyInstance() {
   instance_.reset();
   if (destroy_baton_) {
     auto wait_result = destroy_baton_->timed_wait(
-      std::chrono::steady_clock::now() + kDestroyWaitTime);
+      std::chrono::steady_clock::now() + kSingletonHolderBaseDestroyWaitTime);
     if (!wait_result) {
       print_destructor_stack_trace_->store(true);
       LOG(ERROR) << "Singleton of type " << type_.name() << " has a "

--- a/folly/Singleton.cpp
+++ b/folly/Singleton.cpp
@@ -22,7 +22,11 @@ namespace folly {
 
 namespace detail {
 
+#ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
+const std::chrono::seconds SingletonHolderBase::kDestroyWaitTime{5};
+#else
 constexpr std::chrono::seconds SingletonHolderBase::kDestroyWaitTime;
+#endif
 
 }
 

--- a/folly/Singleton.cpp
+++ b/folly/Singleton.cpp
@@ -20,16 +20,6 @@
 
 namespace folly {
 
-namespace detail {
-
-#ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
-const std::chrono::seconds SingletonHolderBase::kDestroyWaitTime{5};
-#else
-constexpr std::chrono::seconds SingletonHolderBase::kDestroyWaitTime;
-#endif
-
-}
-
 namespace {
 
 struct FatalHelper {

--- a/folly/Singleton.h
+++ b/folly/Singleton.h
@@ -198,14 +198,12 @@ class SingletonHolderBase {
   virtual TypeDescriptor type() = 0;
   virtual bool hasLiveInstance() = 0;
   virtual void destroyInstance() = 0;
-
- protected:
-#ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
-  static const std::chrono::seconds kDestroyWaitTime;
-#else
-  static constexpr std::chrono::seconds kDestroyWaitTime{5};
-#endif
 };
+
+// This is out here rather than in the class because, as of MSVC 2015's
+// initial release, in-class initialization of static non-scalar constexpr
+// members is not implemented. It works just fine outside of a class though.
+constexpr std::chrono::seconds kSingletonHolderBaseDestroyWaitTime{ 5 };
 
 // An actual instance of a singleton, tracking the instance itself,
 // its state as described above, and the create and teardown

--- a/folly/Singleton.h
+++ b/folly/Singleton.h
@@ -200,7 +200,11 @@ class SingletonHolderBase {
   virtual void destroyInstance() = 0;
 
  protected:
+#ifdef MSVC_NO_STATIC_INCLASS_CONSTEXPR_INITIALIZATION
+  static const std::chrono::seconds kDestroyWaitTime;
+#else
   static constexpr std::chrono::seconds kDestroyWaitTime{5};
+#endif
 };
 
 // An actual instance of a singleton, tracking the instance itself,


### PR DESCRIPTION
When #264 was merged, some confusion appears to have occurred over whether the defines were needed for the final release of VS 2015. They are needed, so this adds them.

This also adds the change that was excluded when #297 was merged.