### PR TITLE
Use .string() not .native() when working with boost::filesystem

### DIFF
--- a/folly/experimental/NestedCommandLineApp.cpp
+++ b/folly/experimental/NestedCommandLineApp.cpp
@@ -30,7 +30,7 @@ namespace {
 // Guess the program name as basename(executable)
 std::string guessProgramName() {
   try {
-    return fs::executable_path().filename().native();
+    return fs::executable_path().filename().string();
   } catch (const std::exception&) {
     return "UNKNOWN";
   }
@@ -181,7 +181,7 @@ auto NestedCommandLineApp::findCommand(const std::string& name) const
 
 int NestedCommandLineApp::run(int argc, const char* const argv[]) {
   if (programName_.empty()) {
-    programName_ = fs::path(argv[0]).filename().native();
+    programName_ = fs::path(argv[0]).filename().string();
   }
   return run(std::vector<std::string>(argv + 1, argv + argc));
 }

--- a/folly/experimental/io/HugePages.cpp
+++ b/folly/experimental/io/HugePages.cpp
@@ -77,7 +77,7 @@ HugePageSizeVec readRawHugePageSizes() {
   HugePageSizeVec vec;
   fs::path path("/sys/kernel/mm/hugepages");
   for (fs::directory_iterator it(path); it != fs::directory_iterator(); ++it) {
-    std::string filename(it->path().filename().native());
+    std::string filename(it->path().filename().string());
     if (boost::regex_match(filename, match, regex)) {
       StringPiece numStr(filename.data() + match.position(1), match.length(1));
       vec.emplace_back(to<size_t>(numStr) * 1024);
@@ -178,7 +178,7 @@ HugePageSizeVec readHugePageSizes() {
       // Store mount point
       fs::path path(parts[1].begin(), parts[1].end());
       struct stat st;
-      const int ret = stat(path.c_str(), &st);
+      const int ret = stat(path.string().c_str(), &st);
       if (ret == -1 && errno == ENOENT) {
         return;
       }


### PR DESCRIPTION
Because .native() produces a wstring under MSVC.