### PR TITLE
The last few fixes for MSVC

### DIFF
--- a/folly/EvictingCacheMap.h
+++ b/folly/EvictingCacheMap.h
@@ -407,6 +407,7 @@ class EvictingCacheMap : private boost::noncopyable {
   struct Node
     : public boost::intrusive::unordered_set_base_hook<link_mode>,
       public boost::intrusive::list_base_hook<link_mode> {
+    template<class TKey, class TValue>
     Node(const TKey& key, TValue&& value)
         : pr(std::make_pair(key, std::move(value))) {
     }

--- a/folly/Fingerprint.h
+++ b/folly/Fingerprint.h
@@ -74,7 +74,7 @@ class Fingerprint {
  public:
   Fingerprint() {
     // Use a non-zero starting value. We'll use (1 << (BITS-1))
-    fp_[0] = 1UL << 63;
+    fp_[0] = 1ULL << 63;
     for (int i = 1; i < size(); i++)
       fp_[i] = 0;
   }

--- a/folly/Format.h
+++ b/folly/Format.h
@@ -131,6 +131,7 @@ class BaseFormatter {
   typename std::enable_if<K == valueCount, int>::type
   getSizeArgFrom(size_t i, const FormatArg& arg) const {
     arg.error("argument index out of range, max=", i);
+    return 0;
   }
 
   template <class T>
@@ -145,6 +146,7 @@ class BaseFormatter {
                           std::is_same<T, bool>::value, int>::type
   getValue(const FormatValue<T>&, const FormatArg& arg) const {
     arg.error("dynamic field width argument must be integral");
+    return 0;
   }
 
   template <size_t K>

--- a/folly/Singleton.h
+++ b/folly/Singleton.h
@@ -440,7 +440,8 @@ class Singleton {
   // Generally your program life cycle should be fine with calling
   // get() repeatedly rather than saving the reference, and then not
   // call get() during process shutdown.
-  static T* get() __attribute__ ((__deprecated__("Replaced by try_get"))) {
+  FOLLY_DEPRECATED("Replaced by try_get")
+  static T* get() {
     return getEntry().get();
   }
 

--- a/folly/experimental/TestUtil.cpp
+++ b/folly/experimental/TestUtil.cpp
@@ -180,6 +180,7 @@ std::string CaptureFD::readIncremental() {
   return std::string(buf.get(), size);
 }
 
+#ifndef _MSC_VER
 static std::map<std::string, std::string> getEnvVarMap() {
   std::map<std::string, std::string> data;
   for (auto it = environ; *it != nullptr; ++it) {
@@ -209,6 +210,7 @@ EnvVarSaver::~EnvVarSaver() {
     PCHECK(0 == setenv(kvp.first.c_str(), kvp.second.c_str(), (int)true));
   }
 }
+#endif
 
 }  // namespace test
 }  // namespace folly

--- a/folly/experimental/TestUtil.h
+++ b/folly/experimental/TestUtil.h
@@ -192,6 +192,7 @@ private:
   off_t readOffset_;  // for incremental reading
 };
 
+#ifndef _MSC_VER
 class EnvVarSaver {
 public:
   EnvVarSaver();
@@ -199,6 +200,7 @@ public:
 private:
   std::map<std::string, std::string> saved_;
 };
+#endif
 
 }  // namespace test
 }  // namespace folly

--- a/folly/futures/Future.h
+++ b/folly/futures/Future.h
@@ -62,7 +62,7 @@ class Future {
 
   template <class T2 = T, typename =
             typename std::enable_if<
-              std::is_same<Unit, T2>::value>::type>
+              std::is_same<Unit, T>::value>::type>
   Future();
 
   ~Future();

--- a/folly/io/async/AsyncTransport.h
+++ b/folly/io/async/AsyncTransport.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <sys/uio.h>
 
+#include <folly/io/IOBuf.h>
 #include <folly/io/async/DelayedDestruction.h>
 #include <folly/io/async/EventBase.h>
 #include <folly/io/async/AsyncSocketBase.h>
@@ -37,7 +38,6 @@ namespace folly {
 
 class AsyncSocketException;
 class EventBase;
-class IOBuf;
 class SocketAddress;
 
 /*

--- a/folly/json.cpp
+++ b/folly/json.cpp
@@ -663,7 +663,7 @@ void escapeString(StringPiece input,
         // checking that utf8 encodings are valid
         char32_t v = decodeUtf8(q, e, opts.skip_invalid_utf8);
         if (opts.skip_invalid_utf8 && v == U'\ufffd') {
-          out.append("\ufffd");
+          out.append(u8"\ufffd");
           p = q;
           continue;
         }


### PR DESCRIPTION
I didn't want to deal with creating separate PRs for each of these, so this is one still small, PR instead.

And no, I can't get rid of T2 in Future.h, nor can I check T2 against Unit. I don't know why, but MSVC just doesn't like it.