### PR TITLE
Support setThreadName under MSVC

### DIFF
--- a/folly/ThreadName.h
+++ b/folly/ThreadName.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <thread>
 #include <pthread.h>
 #include <folly/Range.h>
 
@@ -27,6 +28,12 @@ namespace folly {
 #if __GLIBC_PREREQ(2, 12)
 # define FOLLY_HAS_PTHREAD_SETNAME_NP
 #endif
+#endif
+
+#ifdef _MSC_VER
+inline bool setThreadName(std::thread::native_handle_type id, StringPiece name) {
+  return false;
+}
 #endif
 
 inline bool setThreadName(pthread_t id, StringPiece name) {


### PR DESCRIPTION
Wangle tries to set a thread's name by passing an `std::thread`'s handle, which, under MSVC, is not a `pthread_t`, so we need to add an additional overload to return that we couldn't set it.
I originally tried doing this as a template enabled only if `std::thread::native_handle_type` wasn't `pthread_t`, but I just couldn't quite get it to work right, so I gave up and just special cased MSVC.