### PR TITLE
MSVC has std::underlying_type so use it when converting an enum to a string

### DIFF
--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -1477,7 +1477,7 @@ to(const Src & value) {
  * Enum to anything and back
  ******************************************************************************/
 
-#if defined(__clang__) || __GNUC_PREREQ(4, 7)
+#if defined(__clang__) || __GNUC_PREREQ(4, 7) || defined(_MSC_VER)
 // std::underlying_type became available by gcc 4.7.0
 
 template <class Tgt, class Src>


### PR DESCRIPTION
And because the `<` operator causes issues with them, at least, in the way this API is used by proxygen's original cpp implementation.