### PR TITLE
Declare missing environ variable

### DIFF
--- a/folly/experimental/TestUtil.cpp
+++ b/folly/experimental/TestUtil.cpp
@@ -28,6 +28,10 @@
 #include <folly/FileUtil.h>
 #include <folly/String.h>
 
+#ifndef _MSC_VER
+extern char** environ;
+#endif
+
 namespace folly {
 namespace test {
 


### PR DESCRIPTION
Declaring `extern char** environ` in `experimental/TestUtil.cpp` fixes a compilation issue on OS X 10.10.