### PR TITLE
Use event_pending to check if an event is pending or registered under MSVC

### DIFF
--- a/folly/io/async/EventHandler.cpp
+++ b/folly/io/async/EventHandler.cpp
@@ -169,12 +169,16 @@ void EventHandler::setEventBase(EventBase* eventBase) {
 }
 
 bool EventHandler::isPending() const {
+#ifdef _MSC_VER
+  return event_pending(&event_, EV_READ, nullptr) != 0;
+#else
   if (event_ref_flags(&event_) & EVLIST_ACTIVE) {
     if (event_.ev_res & EV_READ) {
       return true;
     }
   }
   return false;
+#endif
 }
 
 } // folly

--- a/folly/io/async/EventUtil.h
+++ b/folly/io/async/EventUtil.h
@@ -50,12 +50,17 @@ FOLLY_LIBEVENT_DEF_ACCESSORS(flags)
 class EventUtil {
  public:
   static bool isEventRegistered(const struct event* ev) {
+#ifdef _MSC_VER
+    return event_pending(ev,
+      EV_TIMEOUT | EV_READ | EV_WRITE | EV_SIGNAL, nullptr) != 0;
+#else
     // If any of these flags are set, the event is registered.
     enum {
       EVLIST_REGISTERED = (EVLIST_INSERTED | EVLIST_ACTIVE |
                            EVLIST_TIMEOUT | EVLIST_SIGNAL)
     };
     return (event_ref_flags(ev) & EVLIST_REGISTERED);
+#endif
   }
 };
 


### PR DESCRIPTION
I've only made this change for MSVC because I don't know if it will work the same way as it does under MSVC.

Under MSVC at least, `isEventRegistered` was returning `true` when it shouldn't have been, prompting me to ask in the IRC channel for libevent, and, after asking a few times over a few days, I finally got a response that said that `event_pending` is the correct way to be doing this, so that's what MSVC will now use.

I do know that this does now work correctly under MSVC, but I'm not sure about anything else.