### PR TITLE
Fix configure script bug on Mac OS X

### DIFF
--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -235,7 +235,7 @@ AC_CACHE_CHECK(
   [for c++11 atomic support without GNU Atomic library],
   [folly_cv_lib_libatomic],
   [AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM[
+    [AC_LANG_SOURCE[
       #include <atomic>
       int main() {
         struct Test { int val; };


### PR DESCRIPTION
Fix #330 Changed AC_LANG from PROGRAM to SOURCE to prevent double definition of main