### PR TITLE
Fix homebrew script to manually set path to El Capitan OpenSSL bottle

### DIFF
--- a/folly/build/bootstrap-osx-homebrew.sh
+++ b/folly/build/bootstrap-osx-homebrew.sh
@@ -19,7 +19,7 @@ brewget autoconf automake libtool
 brewget glog gflags boost libevent double-conversion
 
 autoreconf -i
-./configure
+./configure CXXFLAGS="$CXXFLAGS -I/usr/local/opt/openssl/include" LDFLAGS="$LDFLAGS -L/usr/local/opt/openssl/lib"
 
 pushd test
 test -e gtest-1.7.0.zip || {


### PR DESCRIPTION
Fix #332 - Add path to deprecated OpenSSL library to CXX and LD FLAGS that are passed to configure by bootstrap-osx-homebrew.sh