### PR TITLE
Enable GroupVarint on PPC64

### DIFF
--- a/folly/GroupVarint.h
+++ b/folly/GroupVarint.h
@@ -23,7 +23,7 @@
 
 #include <folly/Portability.h>
 
-#if FOLLY_X64 || defined(__i386__)
+#if FOLLY_X64 || defined(__i386__) || FOLLY_PPC64
 #define HAVE_GROUP_VARINT 1
 
 #include <cstdint>
@@ -617,5 +617,5 @@ typedef GroupVarintDecoder<uint64_t> GroupVarint64Decoder;
 
 }  // namespace folly
 
-#endif /* FOLLY_X64 || defined(__i386__) */
+#endif /* FOLLY_X64 || defined(__i386__) || FOLLY_PPC64 */
 #endif /* FOLLY_GROUPVARINT_H_ */

--- a/folly/build/generate_varint_tables.py
+++ b/folly/build/generate_varint_tables.py
@@ -54,13 +54,16 @@ def generate(f):
     f.write("""
 #include <folly/Portability.h>
 
-#if (FOLLY_X64 || defined(__i386__)) && (FOLLY_SSE >= 2)
 #include <stdint.h>
+
+#if (FOLLY_X64 || defined(__i386__)) && (FOLLY_SSE >= 2)
 #include <x86intrin.h>
+#endif
 
 namespace folly {
 namespace detail {
 
+#if (FOLLY_X64 || defined(__i386__)) && (FOLLY_SSE >= 2)
 extern const __m128i groupVarintSSEMasks[] = {
 """)
 
@@ -82,6 +85,7 @@ extern const __m128i groupVarintSSEMasks[] = {
             "static_cast<int64_t>(0x{3:08x}{2:08x})}},\n".format(*vals))
 
     f.write("};\n"
+            "#endif /*#if (FOLLY_X64 || defined(__i386__)) && (FOLLY_SSE >= 2)*/\n"
             "\n"
             "extern const uint8_t groupVarintLengths[] = {\n")
 
@@ -98,7 +102,6 @@ extern const __m128i groupVarintSSEMasks[] = {
 
 }  // namespace detail
 }  // namespace folly
-#endif /* (FOLLY_X64 || defined(__i386__)) && (FOLLY_SSE >= 2) */
 """)
 
 def main():

--- a/folly/build/generate_varint_tables.py
+++ b/folly/build/generate_varint_tables.py
@@ -85,9 +85,9 @@ extern const __m128i groupVarintSSEMasks[] = {
             "static_cast<int64_t>(0x{3:08x}{2:08x})}},\n".format(*vals))
 
     f.write("};\n"
-            "#endif /*#if (FOLLY_X64 || defined(__i386__)) && (FOLLY_SSE >= 2)*/\n"
-            "\n"
-            "extern const uint8_t groupVarintLengths[] = {\n")
+        "#endif /*#if (FOLLY_X64 || defined(__i386__)) && (FOLLY_SSE >= 2)*/\n"
+        "\n"
+        "extern const uint8_t groupVarintLengths[] = {\n")
 
     # Also compute total encoded lengths, including key byte
     for i in range(0, 256):


### PR DESCRIPTION
This PR is necessary for both Folly and HHVM to compile on PPC64 (https://github.com/PPC64/hhvm) and other platforms that are not compatible with SSE instructions.

It also removes GroupVarint32 tables generator dependency on x86 platform.