### PR TITLE
Fix a few typos all over the code

### DIFF
--- a/folly/Benchmark.h
+++ b/folly/Benchmark.h
@@ -375,7 +375,7 @@ void doNotOptimizeAway(T&& datum) {
   BENCHMARK_NAMED_PARAM(name, param, param)
 
 /**
- * Same as BENCHMARK_PARAM, but allows to return the actual number of
+ * Same as BENCHMARK_PARAM, but allows one to return the actual number of
  * iterations that have been run.
  */
 #define BENCHMARK_PARAM_MULTI(name, param)                              \
@@ -415,7 +415,7 @@ void doNotOptimizeAway(T&& datum) {
   }
 
 /**
- * Same as BENCHMARK_NAMED_PARAM, but allows to return the actual number
+ * Same as BENCHMARK_NAMED_PARAM, but allows one to return the actual number
  * of iterations that have been run.
  */
 #define BENCHMARK_NAMED_PARAM_MULTI(name, param_name, ...)              \
@@ -460,7 +460,7 @@ void doNotOptimizeAway(T&& datum) {
     __VA_ARGS__)
 
 /**
- * Same as BENCHMARK_RELATIVE, but allows to return the actual number
+ * Same as BENCHMARK_RELATIVE, but allows one to return the actual number
  * of iterations that have been run.
  */
 #define BENCHMARK_RELATIVE_MULTI(name, ...)                     \
@@ -477,7 +477,7 @@ void doNotOptimizeAway(T&& datum) {
   BENCHMARK_RELATIVE_NAMED_PARAM(name, param, param)
 
 /**
- * Same as BENCHMARK_RELATIVE_PARAM, but allows to return the actual
+ * Same as BENCHMARK_RELATIVE_PARAM, but allows one to return the actual
  * number of iterations that have been run.
  */
 #define BENCHMARK_RELATIVE_PARAM_MULTI(name, param)                     \
@@ -497,7 +497,7 @@ void doNotOptimizeAway(T&& datum) {
   }
 
 /**
- * Same as BENCHMARK_RELATIVE_NAMED_PARAM, but allows to return the
+ * Same as BENCHMARK_RELATIVE_NAMED_PARAM, but allows one to return the
  * actual number of iterations that have been run.
  */
 #define BENCHMARK_RELATIVE_NAMED_PARAM_MULTI(name, param_name, ...)     \

--- a/folly/experimental/Bits.h
+++ b/folly/experimental/Bits.h
@@ -66,7 +66,7 @@ struct BitsTraits<Unaligned<T>, typename std::enable_if<
   }
 };
 
-// Special version that allows to disable address sanitizer on demand.
+// Special version that allows one to disable address sanitizer on demand.
 template <class T>
 struct BitsTraits<UnalignedNoASan<T>, typename std::enable_if<
     (std::is_integral<T>::value)>::type> {

--- a/folly/experimental/fibers/AddTasks.h
+++ b/folly/experimental/fibers/AddTasks.h
@@ -29,8 +29,8 @@ class TaskIterator;
 
 /**
  * Schedules several tasks and immediately returns an iterator, that
- * allow to traverse tasks in the order of their completion. All results and
- * exptions thrown are stored alongside with the task id and are
+ * allow one to traverse tasks in the order of their completion. All results
+ * and exceptions thrown are stored alongside with the task id and are
  * accessible via iterator.
  *
  * @param first Range of tasks to be scheduled

--- a/folly/experimental/fibers/Baton.h
+++ b/folly/experimental/fibers/Baton.h
@@ -28,8 +28,8 @@ class FiberManager;
 /**
  * @class Baton
  *
- * Primitive which allows to put current Fiber to sleep and wake it from another
- * Fiber/thread.
+ * Primitive which allows one to put current Fiber to sleep and wake it from
+ * another Fiber/thread.
  */
 class Baton {
  public:

--- a/folly/io/async/test/UndelayedDestruction.h
+++ b/folly/io/async/test/UndelayedDestruction.h
@@ -76,7 +76,7 @@ class UndelayedDestruction : public TDD {
    * The caller is responsible for ensuring that the object is only destroyed
    * where it is safe to do so.  (i.e., when the destructor guard count is 0).
    *
-   * The exact conditions for meeting this may be dependant upon your class
+   * The exact conditions for meeting this may be dependent upon your class
    * semantics.  Typically you are only guaranteed that it is safe to destroy
    * the object directly from the event loop (e.g., directly from a
    * EventBase::LoopCallback), or when the event loop is stopped.


### PR DESCRIPTION
These are pretty trivial. Debian's lint tool (lintian) warns about those
in its verbose mode, and since we saw them when packaging for Debian, we
thought of fixing them and forwarding them upstream.