### PR TITLE
Implements make_unique_inherit for use with polymorphism

### DIFF
--- a/folly/Memory.h
+++ b/folly/Memory.h
@@ -65,6 +65,15 @@ make_unique(Args&&...) = delete;
 
 #endif
 
+// Allows 'make_unique' for the inherited class to use polymorphism
+template<typename A, typename B, typename... Args>
+typename std::enable_if<!std::is_array<A>::value &&
+  !std::is_array<B>::value && std::is_base_of<A,B>::value,
+  std::unique_ptr<A>>::type
+make_unique_inherit(Args&&... args) {
+  return std::unique_ptr<A>(new B(std::forward<Args>(args)...));
+}
+
 /**
  * static_function_deleter
  *

--- a/folly/test/MemoryTest.cpp
+++ b/folly/test/MemoryTest.cpp
@@ -33,6 +33,31 @@ TEST(make_unique, compatible_with_std_make_unique) {
   make_unique<string>("hello, world");
 }
 
+/**
+ * Auxiliary classes for use in the test of make_unique_inherit
+ */
+class shape {
+public:
+  virtual int area() const = 0;
+};
+
+class rectangle : public shape {
+  int x_, y_;
+
+public:
+  rectangle(int x, int y):x_(x), y_(y) {}
+
+  int area() const override {
+    return x_*y_;
+  }
+};
+
+TEST(make_unique_inherit, basic_test) {
+  int x = 2, y = 2;
+  std::unique_ptr<shape> fig = make_unique_inherit<shape, rectangle>(x, y);
+  EXPECT_EQ(x*y, fig->area());
+}
+
 template <std::size_t> struct T {};
 template <std::size_t> struct S {};
 template <std::size_t> struct P {};


### PR DESCRIPTION
In some cases is useful to use unique_ptr with polymorphism. Using make_unique_inherit is possible uses unique_ptr to do in a modern way operations like A *b = new B(); where B is derived from A.