### PR TITLE
Use DCHECK to warn fallback implementation in qfind_first_byte_of_sse

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -1003,11 +1003,10 @@ namespace detail {
 
 inline size_t qfind_first_byte_of(const StringPiece haystack,
                                   const StringPiece needles) {
-#if FOLLY_SSE_PREREQ(4, 2)
-  return qfind_first_byte_of_sse42(haystack, needles);
-#else
-  return qfind_first_byte_of_nosse(haystack, needles);
-#endif
+  static auto const qfind_first_byte_of_fn =
+    folly::CpuId().sse42() ? qfind_first_byte_of_sse42
+                           : qfind_first_byte_of_nosse;
+  return qfind_first_byte_of_fn(haystack, needles);
 }
 
 } // namespace detail

--- a/folly/Range.h
+++ b/folly/Range.h
@@ -1003,10 +1003,11 @@ namespace detail {
 
 inline size_t qfind_first_byte_of(const StringPiece haystack,
                                   const StringPiece needles) {
-  static auto const qfind_first_byte_of_fn =
-    folly::CpuId().sse42() ? qfind_first_byte_of_sse42
-                           : qfind_first_byte_of_nosse;
-  return qfind_first_byte_of_fn(haystack, needles);
+#if FOLLY_SSE_PREREQ(4, 2)
+  return qfind_first_byte_of_sse42(haystack, needles);
+#else
+  return qfind_first_byte_of_nosse(haystack, needles);
+#endif
 }
 
 } // namespace detail

--- a/folly/detail/RangeSse42.cpp
+++ b/folly/detail/RangeSse42.cpp
@@ -38,7 +38,7 @@ namespace detail {
 
 size_t qfind_first_byte_of_sse42(const StringPieceLite haystack,
                                  const StringPieceLite needles) {
-  CHECK(false) << "Function " << __func__ << " only works with SSE42!";
+  DCHECK(false) << "Function " << __func__ << " only works with SSE42!";
   return qfind_first_byte_of_nosse(haystack, needles);
 }
 


### PR DESCRIPTION
qfind_first_byte_of  calls qfind_first_byte_of_sse42 if CpuId().sse42() return true, but qfind_first_byte_of_sse42 checks error if FOLLY_SSE_PREREQ(4, 2) is false.

So if gcc turn off msse4.2 by default, but CPU supports SSE 4.2 actually, qfind_first_byte_of will throw exception. 