### PR TITLE
Fix issue #348: OSX doesn't know about __NR_gettid.

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -63,6 +63,12 @@
   #endif
 #endif
 
+#if defined(__APPLE__)
+  #if !defined(__NR_gettid)
+    #define __NR_gettid SYS_gettid
+  #endif
+#endif
+
 // compiler specific attribute translation
 // msvc should come first, so if clang is in msvc mode it gets the right defines
 


### PR DESCRIPTION
This is one way to resolve issue #348.  It may not be the best way, but I can confirm that it works on OSX Yosemite. 