### PR TITLE
Allow clients of FBVector to customize the growth strategy

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -341,6 +341,34 @@ bool greater_than_impl(LHS const lhs) {
     lhs > rhs;
 }
 
+struct has_custom_growth_strategy_tag { };
+struct no_custom_growth_strategy_tag  { };
+
+template<bool Flag>
+struct select_custom_growth_tag_if 
+  : no_custom_growth_strategy_tag { };
+
+template<>
+struct select_custom_growth_tag_if<true> 
+  : has_custom_growth_strategy_tag { };
+
+template<typename _Alloc, typename size_type>
+struct allocator_implements_growth_strategy
+{
+  typedef char yes_t[2];
+  typedef char no_t;
+
+  template<typename U, size_type (U::*)(size_type) const = 
+    &U::calculate_capacity>
+  static yes_t const& test(U const*);
+
+  static no_t const&  test(...);
+
+  typedef detail::select_custom_growth_tag_if<
+    sizeof(test(static_cast<_Alloc const*>(nullptr))) ==
+    sizeof(yes_t)> result_type;
+};
+
 } // namespace detail {
 
 // same as `x < 0`

--- a/folly/test/FBVectorTest.cpp
+++ b/folly/test/FBVectorTest.cpp
@@ -285,6 +285,41 @@ TEST(FBVector, shrink_to_fit_after_clear) {
   EXPECT_EQ(fb1.capacity(), 0);
 }
 
+namespace {
+
+  template<typename T>
+  struct growth_policy_allocator
+  {
+    typedef T value_type;
+
+    T* allocate(size_t n)
+    {
+      return static_cast<T*>(malloc(sizeof(T) * n));
+    }
+
+    void deallocate(void *p, size_t n)
+    {
+      free(p);
+    }
+
+    size_t calculate_capacity(size_t current) const
+    {
+      return current + 1;
+    }
+  };
+}
+
+TEST(FBVector, vector_growth_honours_growth_policy) {
+  
+  growth_policy_allocator<int> alloc;
+
+  fbvector<int, decltype(alloc)> v;
+  v.push_back(1);
+  EXPECT_EQ(v.capacity(), 1);
+  v.push_back(1);
+  EXPECT_EQ(v.capacity(), 2);
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);


### PR DESCRIPTION
As per the suggestion in the comments of `FBVector.h`, I've added the ability to customize the growth strategy using the `fbvector`'s allocator. If the allocator used implements a non-static member function of type `size_type calculate_capacity(size_type) const` then this will be called in every case where the `fbvector` instance needs to grow. E.g. to use an `N+1` strategy the allocator would look something like...

``` c++
template<typename T>
struct growth_policy_allocator
{
  typedef T value_type;

  T* allocate(size_t n)
  {
    ...
  }

  void deallocate(void *p, size_t n)
  {
    ...
  }

  size_t calculate_capacity(size_t current) const // const is required
  {
    return current + 1;
  }
};
```

If the allocate doesn't implement `calculate_capacity` then `fbvector` falls back to its default growth strategy.

I've also added a simple test case for this feature. Compiles and passes on Ubuntu 14.04
