### PR TITLE
Modified ref-qualifiers return type for Optional::value() and Optional::operator*

### DIFF
--- a/folly/Optional.h
+++ b/folly/Optional.h
@@ -223,10 +223,16 @@ class Optional {
     return value_;
   }
 
-  Value value() && {
+  Value&& value() && {
     require_value();
     return std::move(value_);
   }
+
+  const Value&& value() const&& {
+    require_value();
+    return std::move(value_);
+  }
+
 
   const Value* get_pointer() const&  { return hasValue_ ? &value_ : nullptr; }
         Value* get_pointer()      &  { return hasValue_ ? &value_ : nullptr; }
@@ -238,9 +244,10 @@ class Optional {
     return hasValue();
   }
 
-  const Value& operator*() const&  { return value(); }
-        Value& operator*()      &  { return value(); }
-        Value  operator*()      && { return std::move(value()); }
+  const Value& operator*()     const& { return value(); }
+        Value& operator*()          & { return value(); }
+        Value&& operator*()        && { return std::move(value()); }
+  const Value&& operator*()  const && { return std::move(value()); }
 
   const Value* operator->() const { return &value(); }
         Value* operator->()       { return &value(); }

--- a/folly/test/OptionalTest.cpp
+++ b/folly/test/OptionalTest.cpp
@@ -173,23 +173,9 @@ struct ExpectingDeleter {
   }
 };
 
-TEST(Optional, value_life_extention) {
-  // Extends the life of the value.
-  const auto& ptr = Optional<std::unique_ptr<int, ExpectingDeleter>>(
-      {new int(42), ExpectingDeleter{1337}}).value();
-  *ptr = 1337;
-}
-
 TEST(Optional, value_move) {
   auto ptr = Optional<std::unique_ptr<int, ExpectingDeleter>>(
       {new int(42), ExpectingDeleter{1337}}).value();
-  *ptr = 1337;
-}
-
-TEST(Optional, dereference_life_extention) {
-  // Extends the life of the value.
-  const auto& ptr = *Optional<std::unique_ptr<int, ExpectingDeleter>>(
-      {new int(42), ExpectingDeleter{1337}});
   *ptr = 1337;
 }
 


### PR DESCRIPTION
Optional::value() returns a temporary object when the object is an rvalue. This is different in semantics then what boost::optional/std::optional do.

The decision to make the copy or not should be up to the user and not the library. Consider an example:

```
void F(Optional<T> &&opt) {
  T&& t = std::move(opt).get();
  // I know `opt` is alive in this scope, I should be able to keep a rvalue ref to the internals
}
// if we were to return a `T`, that would actually return a new temporary.
```

```
void G(T&& t);
G(std::move(opt).get()); // This could have surprising behavior too !
```

This change modified the return type to be `T&&` and also introduces an extra overload for `const T&&`. Also, deleted two test-cases that assume the lifetime to be extended. This is a breaking change but this brings folly::Optional on parity with other siblings.