### PR TITLE
Upgrade ScopeGuard for Visual Studio 2015

### DIFF
--- a/folly/ScopeGuard.h
+++ b/folly/ScopeGuard.h
@@ -128,7 +128,8 @@ typedef ScopeGuardImplBase&& ScopeGuard;
 namespace detail {
 
 #if defined(FOLLY_EXCEPTION_COUNT_USE_CXA_GET_GLOBALS) || \
-    defined(FOLLY_EXCEPTION_COUNT_USE_GETPTD)
+    defined(FOLLY_EXCEPTION_COUNT_USE_GETPTD) || \
+	defined(FOLLY_EXCEPTION_COUNT_USE_STD)
 
 /**
  * ScopeGuard used for executing a function when leaving the current scope
@@ -220,7 +221,8 @@ operator+(detail::ScopeGuardOnExit, FunctionType&& fn) {
   = ::folly::detail::ScopeGuardOnExit() + [&]() noexcept
 
 #if defined(FOLLY_EXCEPTION_COUNT_USE_CXA_GET_GLOBALS) || \
-    defined(FOLLY_EXCEPTION_COUNT_USE_GETPTD)
+    defined(FOLLY_EXCEPTION_COUNT_USE_GETPTD) || \
+	defined(FOLLY_EXCEPTION_COUNT_USE_STD)
 #define SCOPE_FAIL \
   auto FB_ANONYMOUS_VARIABLE(SCOPE_FAIL_STATE) \
   = ::folly::detail::ScopeGuardOnFail() + [&]() noexcept

--- a/folly/detail/UncaughtExceptionCounter.h
+++ b/folly/detail/UncaughtExceptionCounter.h
@@ -27,11 +27,13 @@ struct __cxa_eh_globals;
 // declared in cxxabi.h from libstdc++-v3
 extern "C" __cxa_eh_globals* __cxa_get_globals() noexcept;
 }
-#elif defined(_MSC_VER) && (_MSC_VER >= 1400) // MSVC++ 8.0 or greater
+#elif defined(_MSC_VER) && (_MSC_VER >= 1400) && (_MSC_VER < 1900)// MSVC++ 8.0 or greater
 #define FOLLY_EXCEPTION_COUNT_USE_GETPTD
 // forward declaration (originally defined in mtdll.h from MSVCRT)
 struct _tiddata;
 extern "C" _tiddata* _getptd(); // declared in mtdll.h from MSVCRT
+#elif defined(_MSC_VER) && (_MSC_VER >= 1900) //MSVC++ 2015 Update 1
+#define FOLLY_EXCEPTION_COUNT_USE_STD
 #else
 // Raise an error when trying to use this on unsupported platforms.
 #error "Unsupported platform, don't include this header."
@@ -84,6 +86,8 @@ inline int UncaughtExceptionCounter::getUncaughtExceptionCount() noexcept {
   // The offset below returns _tiddata::_ProcessingThrow.
   return *(reinterpret_cast<int*>(static_cast<char*>(
       static_cast<void*>(_getptd())) + sizeof(void*) * 28 + 0x4 * 8));
+#elif defined(FOLLY_EXCEPTION_COUNT_USE_STD)
+	return std::uncaught_exceptions();
 #endif
 }
 

--- a/folly/detail/UncaughtExceptionCounter.h
+++ b/folly/detail/UncaughtExceptionCounter.h
@@ -32,7 +32,7 @@ extern "C" __cxa_eh_globals* __cxa_get_globals() noexcept;
 // forward declaration (originally defined in mtdll.h from MSVCRT)
 struct _tiddata;
 extern "C" _tiddata* _getptd(); // declared in mtdll.h from MSVCRT
-#elif defined(_MSC_VER) && (_MSC_VER >= 1900) //MSVC++ 2015 Update 1
+#elif defined(_MSC_VER) && (_MSC_VER >= 1900) //MSVC++ 2015
 #define FOLLY_EXCEPTION_COUNT_USE_STD
 #else
 // Raise an error when trying to use this on unsupported platforms.


### PR DESCRIPTION
Upgrade UncaughtExceptionCounter to use std::uncaught_exceptions on Visual Studio 2015 Update 1