### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Folly: Facebook Open-source Library
+Folly: Facebook Open-source LibrarY
 -----------------------------------
 
 Folly is an open-source C++ library developed and used at Facebook.


### PR DESCRIPTION
We should be [showcasing the almost-backronym that the word "folly" is supposed to be](https://github.com/facebook/folly/pull/110#issuecomment-67681553). @tudor

Breaking change: https://github.com/facebook/folly/commit/b85957465746e9275528ceeb4d6646094a586874