### PR TITLE
Promote memory_order_consume to memory_order_acquire

### DIFF
--- a/folly/ProducerConsumerQueue.h
+++ b/folly/ProducerConsumerQueue.h
@@ -135,16 +135,16 @@ struct ProducerConsumerQueue {
   }
 
   bool isEmpty() const {
-   return readIndex_.load(std::memory_order_consume) ==
-         writeIndex_.load(std::memory_order_consume);
+   return readIndex_.load(std::memory_order_acquire) ==
+         writeIndex_.load(std::memory_order_acquire);
   }
 
   bool isFull() const {
-    auto nextRecord = writeIndex_.load(std::memory_order_consume) + 1;
+    auto nextRecord = writeIndex_.load(std::memory_order_acquire) + 1;
     if (nextRecord == size_) {
       nextRecord = 0;
     }
-    if (nextRecord != readIndex_.load(std::memory_order_consume)) {
+    if (nextRecord != readIndex_.load(std::memory_order_acquire)) {
       return false;
     }
     // queue is full
@@ -157,8 +157,8 @@ struct ProducerConsumerQueue {
   //   be removing items concurrently).
   // * It is undefined to call this from any other thread.
   size_t sizeGuess() const {
-    int ret = writeIndex_.load(std::memory_order_consume) -
-              readIndex_.load(std::memory_order_consume);
+    int ret = writeIndex_.load(std::memory_order_acquire) -
+              readIndex_.load(std::memory_order_acquire);
     if (ret < 0) {
       ret += size_;
     }


### PR DESCRIPTION
The current use case of `std::memory_order_consume` in this project was intended to provide the appropriate synchronization in cases where a consumer spins on `while( spsc_queue.empty() ) {} `, and then attempts to use an element of the queue since the loop was broken out of, according to comments [here](https://reviews.facebook.net/D48141). Consume semantics do not provide this guarantee according to the standard since there is no data dependency from the producer that can be carried to the consumer by doing a load-consume from the corresponding functions. What is needed is a load-acquire. Current compilers promote `memory_order_consume` to `memory_order_acquire`. Thus, this example appears to work simply due to the promotion from consume to acquire, but would fail to generate the right synchronization instructions on weaker architectures once `memory_order_consume` is implemented as intended.  Therefore, the `memory_order` should be tightened to `memory_order_acquire` to guarantee visibility to the consumer. 

