### PR TITLE
Remove extra ';' from  used macros in Traits.h

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -93,7 +93,7 @@ namespace folly {
 namespace traits_detail {
 
 #define FOLLY_HAS_TRUE_XXX(name)                          \
-  BOOST_MPL_HAS_XXX_TRAIT_DEF(name);                      \
+  BOOST_MPL_HAS_XXX_TRAIT_DEF(name)                      \
   template <class T> struct name ## _is_true              \
     : std::is_same<typename T::name, std::true_type> {};  \
   template <class T> struct has_true_ ## name             \
@@ -387,17 +387,17 @@ constexpr construct_in_place_t construct_in_place{};
 
 // gcc-5.0 changed string's implementation in libgcc to be non-relocatable
 #if __GNUC__ < 5
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_3(std::basic_string);
+FOLLY_ASSUME_FBVECTOR_COMPATIBLE_3(std::basic_string)
 #endif
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::vector);
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::list);
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::deque);
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::unique_ptr);
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_1(std::shared_ptr);
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_1(std::function);
+FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::vector)
+FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::list)
+FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::deque)
+FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::unique_ptr)
+FOLLY_ASSUME_FBVECTOR_COMPATIBLE_1(std::shared_ptr)
+FOLLY_ASSUME_FBVECTOR_COMPATIBLE_1(std::function)
 
 // Boost
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_1(boost::shared_ptr);
+FOLLY_ASSUME_FBVECTOR_COMPATIBLE_1(boost::shared_ptr)
 
 #define FOLLY_CREATE_HAS_MEMBER_TYPE_TRAITS(classname, type_name) \
   template <typename T> \


### PR DESCRIPTION
Using folly on OSX using gcc-5.3 causes errors due to extra ';' in macro expansion in Traits.h.