### PR TITLE
Fix for HHWheelTimer assert-fails when destroy() happens after cancel…

### DIFF
--- a/folly/io/async/HHWheelTimer.cpp
+++ b/folly/io/async/HHWheelTimer.cpp
@@ -258,6 +258,7 @@ size_t HHWheelTimer::cancelAll() {
     }
   }
 
+  count_ = 0;
   return count;
 }
 


### PR DESCRIPTION
…All() #397
