### PR TITLE
Fix architecture specific code for AArch64 machines.

### DIFF
--- a/folly/DiscriminatedPtr.h
+++ b/folly/DiscriminatedPtr.h
@@ -33,8 +33,8 @@
 #include <folly/Portability.h>
 #include <folly/detail/DiscriminatedPtrDetail.h>
 
-#if !FOLLY_X64 && !FOLLY_PPC64
-# error "DiscriminatedPtr is x64 and ppc64 specific code."
+#if !FOLLY_X64 && !FOLLY_A64 && !FOLLY_PPC64
+# error "DiscriminatedPtr is x64, aarch64 and ppc64 specific code."
 #endif
 
 namespace folly {


### PR DESCRIPTION
It's fully compatible with aarch64, but preprocessing didn't allow for
aarch64
