### PR TITLE
Remove dependency from boost class noncopyable

### DIFF
--- a/folly/AtomicBitSet.h
+++ b/folly/AtomicBitSet.h
@@ -22,8 +22,6 @@
 #include <cstddef>
 #include <limits>
 
-#include <boost/noncopyable.hpp>
-
 #include <folly/Portability.h>
 
 namespace folly {
@@ -32,8 +30,13 @@ namespace folly {
  * An atomic bitset of fixed size (specified at compile time).
  */
 template <size_t N>
-class AtomicBitSet : private boost::noncopyable {
+class AtomicBitSet {
  public:
+
+  // noncopyable
+  AtomicBitSet(const AtomicBitSet&) = delete;
+  AtomicBitSet& operator = (const AtomicBitSet&) = delete;
+
   /**
    * Construct an AtomicBitSet; all bits are initially false.
    */

--- a/folly/AtomicHashArray.h
+++ b/folly/AtomicHashArray.h
@@ -35,7 +35,6 @@
 #include <atomic>
 
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/noncopyable.hpp>
 
 #include <folly/Hash.h>
 #include <folly/ThreadCachedInt.h>
@@ -105,7 +104,7 @@ template <class KeyT, class ValueT,
           class Allocator = std::allocator<char>,
           class ProbeFcn = AtomicHashArrayLinearProbeFcn,
           class KeyConvertFcn = detail::AHAIdentity>
-class AtomicHashArray : boost::noncopyable {
+class AtomicHashArray {
   static_assert((std::is_convertible<KeyT,int32_t>::value ||
                  std::is_convertible<KeyT,int64_t>::value ||
                  std::is_convertible<KeyT,const void*>::value),
@@ -398,6 +397,10 @@ friend class AtomicHashMap<KeyT,
   std::atomic<int64_t> numErases_;   // Successful key erases
 
   value_type cells_[0];  // This must be the last field of this class
+
+  // noncopyable
+  AtomicHashArray(const AtomicHashArray&) = delete;
+  AtomicHashArray& operator = (const AtomicHashArray&) = delete;
 
   // Force constructor/destructor private since create/destroy should be
   // used externally instead

--- a/folly/AtomicHashMap.h
+++ b/folly/AtomicHashMap.h
@@ -83,7 +83,6 @@
 #define FOLLY_ATOMICHASHMAP_H_
 
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/noncopyable.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
 #include <stdexcept>
@@ -157,7 +156,7 @@ struct AtomicHashMapFullError : std::runtime_error {
 
 template<class KeyT, class ValueT, class HashFcn, class EqualFcn,
          class Allocator, class ProbeFcn, class KeyConvertFcn>
-class AtomicHashMap : boost::noncopyable {
+class AtomicHashMap {
 typedef AtomicHashArray<KeyT, ValueT, HashFcn, EqualFcn,
                         Allocator, ProbeFcn, KeyConvertFcn>
     SubMap;
@@ -190,6 +189,10 @@ typedef AtomicHashArray<KeyT, ValueT, HashFcn, EqualFcn,
 
  public:
   const float kGrowthFrac_;  // How much to grow when we run out of capacity.
+
+  // noncopyable
+  AtomicHashMap(const AtomicHashMap&) = delete;
+  AtomicHashMap& operator = (const AtomicHashMap&) = delete;
 
   // The constructor takes a finalSizeEst which is the optimal
   // number of elements to maximize space utilization and performance,

--- a/folly/ConcurrentSkipList-inl.h
+++ b/folly/ConcurrentSkipList-inl.h
@@ -26,7 +26,6 @@
 #include <mutex>
 #include <type_traits>
 #include <vector>
-#include <boost/noncopyable.hpp>
 #include <boost/random.hpp>
 #include <boost/type_traits.hpp>
 #include <glog/logging.h>
@@ -40,7 +39,7 @@ namespace folly { namespace detail {
 template<typename ValT, typename NodeT> class csl_iterator;
 
 template<typename T>
-class SkipListNode : private boost::noncopyable {
+class SkipListNode {
   enum {
     IS_HEAD_NODE = 1,
     MARKED_FOR_REMOVAL = (1 << 1),
@@ -140,6 +139,10 @@ class SkipListNode : private boost::noncopyable {
       new (&skip_[i]) std::atomic<SkipListNode*>(nullptr);
     }
   }
+
+  // noncopyable
+  SkipListNode(const SkipListNode&) = delete;
+  SkipListNode& operator = (const SkipListNode&) = delete;
 
   ~SkipListNode() {
     for (uint8_t i = 0; i < height_; ++i) {

--- a/folly/EvictingCacheMap.h
+++ b/folly/EvictingCacheMap.h
@@ -90,7 +90,7 @@ namespace folly {
  * (using their own eviction criteria).
  */
 template <class TKey, class TValue, class THash = std::hash<TKey> >
-class EvictingCacheMap : private boost::noncopyable {
+class EvictingCacheMap {
 
  private:
   // typedefs for brevity
@@ -131,6 +131,10 @@ class EvictingCacheMap : private boost::noncopyable {
   typedef iterator_base<
     const TPair,
     typename NodeList::const_reverse_iterator> const_reverse_iterator;
+
+  // noncopyable
+  EvictingCacheMap(const EvictingCacheMap&) = delete;
+  EvictingCacheMap& operator = (const EvictingCacheMap&) = delete;
 
   /**
    * Construct a EvictingCacheMap

--- a/folly/IndexedMemPool.h
+++ b/folly/IndexedMemPool.h
@@ -19,7 +19,6 @@
 #include <type_traits>
 #include <stdint.h>
 #include <assert.h>
-#include <boost/noncopyable.hpp>
 #include <folly/AtomicStruct.h>
 #include <folly/detail/CacheLocality.h>
 #include <folly/portability/SysMman.h>
@@ -89,7 +88,7 @@ template <typename T,
           template<typename> class Atom = std::atomic,
           bool EagerRecycleWhenTrivial = false,
           bool EagerRecycleWhenNotTrivial = true>
-struct IndexedMemPool : boost::noncopyable {
+struct IndexedMemPool {
   typedef T value_type;
 
   typedef std::unique_ptr<T, detail::IndexedMemPoolRecycler<IndexedMemPool>>
@@ -120,6 +119,9 @@ struct IndexedMemPool : boost::noncopyable {
     return maxIndex - (NumLocalLists - 1) * LocalListLimit;
   }
 
+  // noncopyable
+  IndexedMemPool(const IndexedMemPool&) = delete;
+  IndexedMemPool& operator = (const IndexedMemPool&) = delete;
 
   /// Constructs a pool that can allocate at least _capacity_ elements,
   /// even if all the local lists are full

--- a/folly/MPMCQueue.h
+++ b/folly/MPMCQueue.h
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <atomic>
 #include <assert.h>
-#include <boost/noncopyable.hpp>
 #include <limits>
 #include <string.h>
 #include <type_traits>
@@ -95,7 +94,7 @@ template <typename T> class MPMCPipelineStageImpl;
 /// complete in O(log P) time instead of O(P)).
 template<typename T,
          template<typename> class Atom = std::atomic>
-class MPMCQueue : boost::noncopyable {
+class MPMCQueue {
 
   static_assert(std::is_nothrow_constructible<T,T&&>::value ||
                 folly::IsRelocatable<T>::value,
@@ -104,6 +103,10 @@ class MPMCQueue : boost::noncopyable {
   friend class detail::MPMCPipelineStageImpl<T>;
  public:
   typedef T value_type;
+
+  // noncopyable
+  MPMCQueue(const MPMCQueue&) = delete;
+  MPMCQueue& operator = (const MPMCQueue&) = delete;
 
   explicit MPMCQueue(size_t queueCapacity)
     : capacity_(queueCapacity)

--- a/folly/MemoryMapping.h
+++ b/folly/MemoryMapping.h
@@ -20,7 +20,6 @@
 #include <folly/File.h>
 #include <folly/Range.h>
 #include <glog/logging.h>
-#include <boost/noncopyable.hpp>
 
 namespace folly {
 
@@ -29,7 +28,7 @@ namespace folly {
  *
  * @author Tudor Bosman (tudorb@fb.com)
  */
-class MemoryMapping : boost::noncopyable {
+class MemoryMapping {
  public:
   /**
    * Lock the pages in memory?
@@ -129,6 +128,10 @@ class MemoryMapping : boost::noncopyable {
   MemoryMapping(MemoryMapping&&) noexcept;
 
   ~MemoryMapping();
+
+  // noncopyable
+  MemoryMapping(const MemoryMapping&) = delete;
+  MemoryMapping& operator=(const MemoryMapping&) = delete;
 
   MemoryMapping& operator=(MemoryMapping);
 

--- a/folly/MicroSpinLock.h
+++ b/folly/MicroSpinLock.h
@@ -40,7 +40,6 @@
 #include <array>
 #include <cinttypes>
 #include <type_traits>
-#include <boost/noncopyable.hpp>
 #include <cstdlib>
 #include <pthread.h>
 #include <mutex>

--- a/folly/SpinLock.h
+++ b/folly/SpinLock.h
@@ -49,7 +49,7 @@ typedef SpinLockPthreadMutexImpl SpinLock;
 #endif
 
 template <typename LOCK>
-class SpinLockGuardImpl : private boost::noncopyable {
+class SpinLockGuardImpl {
  public:
   FOLLY_ALWAYS_INLINE explicit SpinLockGuardImpl(LOCK& lock) :
     lock_(lock) {
@@ -58,6 +58,11 @@ class SpinLockGuardImpl : private boost::noncopyable {
   FOLLY_ALWAYS_INLINE ~SpinLockGuardImpl() {
     lock_.unlock();
   }
+
+  // noncopyable
+  SpinLockGuardImpl(const SpinLockGuardImpl&) = delete;
+  SpinLockGuardImpl& operator = (const SpinLockGuardImpl&) = delete;
+
  private:
   LOCK& lock_;
 };

--- a/folly/ThreadCachedInt.h
+++ b/folly/ThreadCachedInt.h
@@ -24,8 +24,6 @@
 
 #include <atomic>
 
-#include <boost/noncopyable.hpp>
-
 #include <folly/Likely.h>
 #include <folly/ThreadLocal.h>
 
@@ -37,13 +35,17 @@ namespace folly {
 // ThreadCachedInt's you should considering breaking up the Tag space even
 // further.
 template <class IntT, class Tag=IntT>
-class ThreadCachedInt : boost::noncopyable {
+class ThreadCachedInt {
   struct IntCache;
 
  public:
   explicit ThreadCachedInt(IntT initialVal = 0, uint32_t cacheSize = 1000)
     : target_(initialVal), cacheSize_(cacheSize) {
   }
+
+  // noncopyable
+  ThreadCachedInt(const ThreadCachedInt&) = delete;
+  ThreadCachedInt& operator = (const ThreadCachedInt&) = delete;
 
   void increment(IntT inc) {
     auto cache = cache_.get();

--- a/folly/detail/Futex.h
+++ b/folly/detail/Futex.h
@@ -20,7 +20,6 @@
 #include <chrono>
 #include <limits>
 #include <assert.h>
-#include <boost/noncopyable.hpp>
 
 #include <folly/portability/Unistd.h>
 
@@ -43,7 +42,11 @@ enum class FutexResult {
  * (and benchmarks to back you up).
  */
 template <template <typename> class Atom = std::atomic>
-struct Futex : Atom<uint32_t>, boost::noncopyable {
+struct Futex : Atom<uint32_t> {
+
+  // noncopyable
+  Futex(const Futex&) = delete;
+  Futex& operator = (const Futex&) = delete;
 
   explicit Futex(uint32_t init = 0) : Atom<uint32_t>(init) {}
 

--- a/folly/detail/SpinLockImpl.h
+++ b/folly/detail/SpinLockImpl.h
@@ -26,7 +26,6 @@
  * platform.
  */
 
-#include <boost/noncopyable.hpp>
 #include <folly/Portability.h>
 
 #if __x86_64__

--- a/folly/experimental/LockFreeRingBuffer.h
+++ b/folly/experimental/LockFreeRingBuffer.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <atomic>
-#include <boost/noncopyable.hpp>
 #include <iostream>
 #include <cmath>
 #include <memory>
@@ -56,7 +55,7 @@ class RingBufferSlot;
 ///
 
 template<typename T, template<typename> class Atom = std::atomic>
-class LockFreeRingBuffer: boost::noncopyable {
+class LockFreeRingBuffer {
 
    static_assert(std::is_nothrow_default_constructible<T>::value,
        "Element type must be nothrow default constructible");
@@ -94,6 +93,10 @@ public:
     uint64_t ticket;
     friend class LockFreeRingBuffer;
   };
+  
+  // noncopyable
+  LockFreeRingBuffer(const LockFreeRingBuffer&) = delete;
+  LockFreeRingBuffer& operator = (const LockFreeRingBuffer&) = delete;
 
   explicit LockFreeRingBuffer(uint32_t capacity) noexcept
     : capacity_(capacity)

--- a/folly/experimental/io/AsyncIO.h
+++ b/folly/experimental/io/AsyncIO.h
@@ -28,8 +28,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/noncopyable.hpp>
-
 #include <folly/Portability.h>
 #include <folly/Range.h>
 #include <folly/portability/SysUio.h>
@@ -42,11 +40,15 @@ namespace folly {
  *
  * The op must remain allocated until completion.
  */
-class AsyncIOOp : private boost::noncopyable {
+class AsyncIOOp {
   friend class AsyncIO;
   friend std::ostream& operator<<(std::ostream& stream, const AsyncIOOp& o);
  public:
   typedef std::function<void(AsyncIOOp*)> NotificationCallback;
+
+  // noncopyable
+  AsyncIOOp(const AsyncIOOp&) = delete;
+  AsyncIOOp& operator = (const AsyncIOOp&) = delete;
 
   explicit AsyncIOOp(NotificationCallback cb = NotificationCallback());
   ~AsyncIOOp();
@@ -117,7 +119,7 @@ std::ostream& operator<<(std::ostream& stream, AsyncIOOp::State state);
 /**
  * C++ interface around Linux Async IO.
  */
-class AsyncIO : private boost::noncopyable {
+class AsyncIO {
  public:
   typedef AsyncIOOp Op;
 
@@ -148,6 +150,10 @@ class AsyncIO : private boost::noncopyable {
    */
   explicit AsyncIO(size_t capacity, PollMode pollMode=NOT_POLLABLE);
   ~AsyncIO();
+
+  // noncopyable
+  AsyncIO(const AsyncIO&) = delete;
+  AsyncIO& operator = (const AsyncIO&) = delete;
 
   /**
    * Wait for at least minRequests to complete.  Returns the requests that

--- a/folly/experimental/io/HugePages.cpp
+++ b/folly/experimental/io/HugePages.cpp
@@ -27,7 +27,6 @@
 #include <stdexcept>
 #include <system_error>
 
-#include <boost/noncopyable.hpp>
 #include <boost/regex.hpp>
 
 #include <glog/logging.h>

--- a/folly/experimental/symbolizer/LineReader.h
+++ b/folly/experimental/symbolizer/LineReader.h
@@ -18,8 +18,6 @@
 
 #include <cstddef>
 
-#include <boost/noncopyable.hpp>
-
 #include <folly/Range.h>
 
 namespace folly { namespace symbolizer {
@@ -27,13 +25,17 @@ namespace folly { namespace symbolizer {
 /**
  * Async-signal-safe line reader.
  */
-class LineReader : private boost::noncopyable {
+class LineReader {
  public:
   /**
    * Create a line reader that reads into a user-provided buffer (of size
    * bufSize).
    */
   LineReader(int fd, char* buf, size_t bufSize);
+
+  // noncopyable
+  LineReader(const LineReader&) = delete;
+  LineReader& operator = (const LineReader&) = delete;
 
   enum State {
     kReading,

--- a/folly/io/ShutdownSocketSet.h
+++ b/folly/io/ShutdownSocketSet.h
@@ -20,8 +20,6 @@
 #include <cstdlib>
 #include <memory>
 
-#include <boost/noncopyable.hpp>
-
 #include <folly/File.h>
 
 namespace folly {
@@ -29,7 +27,7 @@ namespace folly {
 /**
  * Set of sockets that allows immediate, take-no-prisoners abort.
  */
-class ShutdownSocketSet : private boost::noncopyable {
+class ShutdownSocketSet {
  public:
   /**
    * Create a socket set that can handle file descriptors < maxFd.
@@ -38,6 +36,10 @@ class ShutdownSocketSet : private boost::noncopyable {
    * on your system.
    */
   explicit ShutdownSocketSet(size_t maxFd = 1 << 18);
+
+  // noncopyable
+  ShutdownSocketSet(const ShutdownSocketSet&) = delete;
+  ShutdownSocketSet& operator = (const ShutdownSocketSet&) = delete;
 
   /**
    * Add an already open socket to the list of sockets managed by

--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -19,7 +19,6 @@
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/Sockets.h>
 
-#include <boost/noncopyable.hpp>
 #include <errno.h>
 #include <fcntl.h>
 #include <openssl/err.h>
@@ -157,7 +156,7 @@ class AsyncSSLSocketConnector: public AsyncSocket::ConnectCallback,
  * Utility class that corks a TCP socket upon construction or uncorks
  * the socket upon destruction
  */
-class CorkGuard : private boost::noncopyable {
+class CorkGuard {
  public:
   CorkGuard(int fd, bool multipleWrites, bool haveMore, bool* corked):
     fd_(fd), haveMore_(haveMore), corked_(corked) {
@@ -174,6 +173,10 @@ class CorkGuard : private boost::noncopyable {
       *corked_ = true;
     }
   }
+
+  // noncopyable
+  CorkGuard(const CorkGuard&) = delete;
+  CorkGuard& operator = (const CorkGuard&) = delete;
 
   ~CorkGuard() {
     if (haveMore_) {
@@ -196,9 +199,13 @@ class CorkGuard : private boost::noncopyable {
   bool* corked_;
 };
 #else
-class CorkGuard : private boost::noncopyable {
+class CorkGuard {
  public:
   CorkGuard(int, bool, bool, bool*) {}
+
+  // noncopyable
+  CorkGuard(const CorkGuard&) = delete;
+  CorkGuard& operator = (const CorkGuard&) = delete;
 };
 #endif
 

--- a/folly/io/async/AsyncTimeout.h
+++ b/folly/io/async/AsyncTimeout.h
@@ -24,7 +24,6 @@
 
 #include <folly/portability/Event.h>
 
-#include <boost/noncopyable.hpp>
 #include <event.h>
 #include <memory>
 #include <utility>
@@ -38,9 +37,13 @@ class TimeoutManager;
 /**
  * AsyncTimeout is used to asynchronously wait for a timeout to occur.
  */
-class AsyncTimeout : private boost::noncopyable {
+class AsyncTimeout {
  public:
   typedef TimeoutManager::InternalEnum InternalEnum;
+
+  // noncopyable
+  AsyncTimeout(const AsyncTimeout&) = delete;
+  AsyncTimeout& operator = (const AsyncTimeout&) = delete;
 
   /**
    * Create a new AsyncTimeout object, driven by the specified TimeoutManager.

--- a/folly/io/async/DelayedDestructionBase.h
+++ b/folly/io/async/DelayedDestructionBase.h
@@ -21,7 +21,6 @@
 #include <memory>
 #include <type_traits>
 #include <utility>
-#include <boost/noncopyable.hpp>
 #include <functional>
 #include <glog/logging.h>
 #include <inttypes.h>
@@ -45,9 +44,13 @@ namespace folly {
  * DelayedDestructionBase does not perform any locking.  It is intended to be
  * used only from a single thread.
  */
-class DelayedDestructionBase : private boost::noncopyable {
+class DelayedDestructionBase {
  public:
   virtual ~DelayedDestructionBase() = default;
+
+  // noncopyable
+  DelayedDestructionBase(const DelayedDestructionBase&) = delete;
+  DelayedDestructionBase& operator = (const DelayedDestructionBase&) = delete;
 
   /**
    * Classes should create a DestructorGuard object on the stack in any

--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -119,8 +119,7 @@ class RequestEventBase : public RequestData {
  * EventBase from other threads.  When it is safe to call a method from
  * another thread it is explicitly listed in the method comments.
  */
-class EventBase : private boost::noncopyable,
-                  public TimeoutManager,
+class EventBase : public TimeoutManager,
                   public DrivableExecutor {
  public:
   using Func = folly::Function<void()>;
@@ -165,6 +164,10 @@ class EventBase : private boost::noncopyable,
     friend class EventBase;
     std::shared_ptr<RequestContext> context_;
   };
+
+  // noncopyable
+  EventBase(const EventBase&) = delete;
+  EventBase& operator = (const EventBase&) = delete;
 
   /**
    * Create a new EventBase object.

--- a/folly/io/async/EventBaseLocal.h
+++ b/folly/io/async/EventBaseLocal.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <boost/noncopyable.hpp>
 #include <folly/Synchronized.h>
 #include <folly/io/async/EventBase.h>
 #include <memory>
@@ -28,8 +27,12 @@ namespace folly {
 
 namespace detail {
 
-class EventBaseLocalBase : public EventBaseLocalBaseBase, boost::noncopyable {
+class EventBaseLocalBase : public EventBaseLocalBaseBase {
  public:
+  // noncopyable
+  EventBaseLocalBase(const EventBaseLocalBase&) = delete;
+  EventBaseLocalBase& operator = (const EventBaseLocalBase&) = delete;
+
   EventBaseLocalBase() {}
   virtual ~EventBaseLocalBase();
   void erase(EventBase& evb);

--- a/folly/io/async/EventHandler.h
+++ b/folly/io/async/EventHandler.h
@@ -23,7 +23,6 @@
 #include <glog/logging.h>
 #include <folly/io/async/EventUtil.h>
 #include <folly/portability/Event.h>
-#include <boost/noncopyable.hpp>
 #include <stddef.h>
 
 namespace folly {
@@ -37,7 +36,7 @@ class EventBase;
  * Users that wish to wait on I/O events should derive from EventHandler and
  * implement the handlerReady() method.
  */
-class EventHandler : private boost::noncopyable {
+class EventHandler {
  public:
   enum EventFlags {
     NONE = 0,
@@ -46,6 +45,10 @@ class EventHandler : private boost::noncopyable {
     READ_WRITE = (READ | WRITE),
     PERSIST = EV_PERSIST
   };
+
+  // noncopyable
+  EventHandler(const EventHandler&) = delete;
+  EventHandler& operator = (const EventHandler&) = delete;
 
   /**
    * Create a new EventHandler object.

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -20,7 +20,6 @@
 #include <thread>
 #include <unordered_map>
 
-#include <boost/noncopyable.hpp>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
@@ -32,8 +31,12 @@
 
 namespace folly { namespace io { namespace test {
 
-class DataHolder : private boost::noncopyable {
+class DataHolder {
  public:
+  // noncopyable
+  DataHolder(const DataHolder&) = delete;
+  DataHolder& operator = (const DataHolder&) = delete;
+
   uint64_t hash(size_t size) const;
   ByteRange data(size_t size) const;
 

--- a/folly/test/DeterministicSchedule.h
+++ b/folly/test/DeterministicSchedule.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <assert.h>
-#include <boost/noncopyable.hpp>
 #include <errno.h>
 #include <glog/logging.h>
 #include <semaphore.h>
@@ -66,7 +65,7 @@ namespace test {
  * Invocations of the scheduler function will be serialized, but will
  * occur from multiple threads.  A good starting schedule is uniform(0).
  */
-class DeterministicSchedule : boost::noncopyable {
+class DeterministicSchedule {
  public:
   /**
    * Arranges for the current thread (and all threads created by
@@ -77,6 +76,10 @@ class DeterministicSchedule : boost::noncopyable {
 
   /** Completes the schedule. */
   ~DeterministicSchedule();
+
+  // noncopyable
+  DeterministicSchedule(const DeterministicSchedule&) = delete;
+  DeterministicSchedule& operator = (const DeterministicSchedule&) = delete;
 
   /**
    * Returns a scheduling function that randomly chooses one of the


### PR DESCRIPTION
With explicitly deleted member functions in C++11 the boost class noncopyable is not needed anymore
