### PR TITLE
Proposed changes to (or replacement for) folly::Synchronized

### DIFF
--- a/folly/LockTraits.h
+++ b/folly/LockTraits.h
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This module provides traits classes for describing properties about mutex
+ * classes.
+ *
+ * This allows custom mutex/lock classes to be used with folly::Locked.
+ */
+#pragma once
+
+#include <chrono>
+#include <type_traits>
+
+// Android, OSX, and Cygwin don't have timed mutexes
+#if defined(ANDROID) || defined(__ANDROID__) || defined(__APPLE__) || \
+    defined(__CYGWIN__)
+#define FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES 0
+#else
+#define FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES 1
+#endif
+
+namespace folly {
+namespace detail {
+
+/**
+ * An internal helper class for identifying if a lock type supports
+ * lock_shared() and try_lock_for() methods.
+ */
+template <class Mutex>
+class LockTraitsImpl {
+ private:
+  // Helper functions for implementing the traits using SFINAE
+  template <class T>
+  static auto timed_lock_test(T*) -> typename std::is_same<
+      decltype(std::declval<T>().try_lock_for(std::chrono::milliseconds(0))),
+      bool>::type;
+  template <class T>
+  static std::false_type timed_lock_test(...);
+
+  template <class T>
+  static auto lock_shared_test(T*) -> typename std::
+      is_same<decltype(std::declval<T>().lock_shared()), void>::type;
+  template <class T>
+  static std::false_type lock_shared_test(...);
+
+ public:
+  static constexpr bool has_timed_lock =
+      decltype(timed_lock_test<Mutex>(0))::value;
+  static constexpr bool has_lock_shared =
+      decltype(lock_shared_test<Mutex>(0))::value;
+};
+
+template <class Mutex>
+struct LockTraitsUniqueBase {
+  /**
+   * Acquire the lock exclusively.
+   */
+  static void lock(Mutex& mutex) {
+    mutex.lock();
+  }
+
+  /**
+   * Release an exclusively-held lock.
+   */
+  static void unlock(Mutex& mutex) {
+    mutex.unlock();
+  }
+};
+
+template <class Mutex>
+struct LockTraitsSharedBase : public LockTraitsUniqueBase<Mutex> {
+  /**
+   * Acquire the lock in shared (read) mode.
+   */
+  static void lock_shared(Mutex& mutex) {
+    mutex.lock_shared();
+  }
+
+  /**
+   * Release a lock held in shared mode.
+   */
+  static void unlock_shared(Mutex& mutex) {
+    mutex.unlock_shared();
+  }
+};
+
+template <class Mutex, bool is_shared, bool is_timed>
+struct LockTraitsBase {};
+
+template <class Mutex>
+struct LockTraitsBase<Mutex, false, false>
+    : public LockTraitsUniqueBase<Mutex> {
+  static constexpr bool is_shared = false;
+  static constexpr bool has_timed_lock = false;
+};
+
+template <class Mutex>
+struct LockTraitsBase<Mutex, true, false> : public LockTraitsSharedBase<Mutex> {
+  static constexpr bool is_shared = true;
+  static constexpr bool has_timed_lock = false;
+};
+
+template <class Mutex>
+struct LockTraitsBase<Mutex, false, true> : public LockTraitsUniqueBase<Mutex> {
+  static constexpr bool is_shared = false;
+  static constexpr bool has_timed_lock = true;
+
+  /**
+   * Acquire the lock exclusively, with a timeout.
+   *
+   * Returns true or false indicating if the lock was acquired or not.
+   */
+  template <class Rep, class Period>
+  static bool try_lock_for(
+      Mutex& mutex,
+      const std::chrono::duration<Rep, Period>& timeout) {
+    return mutex.try_lock_for(timeout);
+  }
+};
+
+template <class Mutex>
+struct LockTraitsBase<Mutex, true, true> : public LockTraitsSharedBase<Mutex> {
+  static constexpr bool is_shared = true;
+  static constexpr bool has_timed_lock = true;
+
+  /**
+   * Acquire the lock exclusively, with a timeout.
+   *
+   * Returns true or false indicating if the lock was acquired or not.
+   */
+  template <class Rep, class Period>
+  static bool try_lock_for(
+      Mutex& mutex,
+      const std::chrono::duration<Rep, Period>& timeout) {
+    return mutex.try_lock_for(timeout);
+  }
+
+  /**
+   * Acquire the lock in shared (read) mode, with a timeout.
+   *
+   * Returns true or false indicating if the lock was acquired or not.
+   */
+  template <class Rep, class Period>
+  static bool try_lock_shared_for(
+      Mutex& mutex,
+      const std::chrono::duration<Rep, Period>& timeout) {
+    return mutex.try_lock_shared_for(timeout);
+  }
+};
+} // detail
+
+/**
+ * LockTraits describes details about a particular mutex type.
+ *
+ * The default implementation automatically attempts to detect traits
+ * based on the presence of various member functions.
+ *
+ * You can specialize LockTraits to provide custom behavior for lock
+ * classes that do not use the standard method names
+ * (lock()/unlock()/lock_shared()/unlock_shared()/try_lock_for())
+ *
+ *
+ * LockTraits contains the following members variables:
+ * - static constexpr bool is_shared
+ *   True if the lock supports separate shared vs exclusive locking states.
+ * - static constexpr bool has_timed_lock
+ *   True if the lock supports acquiring the lock with a timeout.
+ *
+ * The following static methods always exist:
+ * - lock(Mutex& mutex)
+ * - unlock(Mutex& mutex)
+ *
+ * The following static methods may exist, depending on is_shared and
+ * has_timed_lock:
+ * - try_lock_for(Mutex& mutex, <std_chrono_duration> timeout)
+ * - lock_shared(Mutex& mutex)
+ * - unlock_shared(Mutex& mutex)
+ * - try_lock_shared_for(Mutex& mutex, <std_chrono_duration> timeout)
+ */
+template <class Mutex>
+struct LockTraits : public detail::LockTraitsBase<
+                        Mutex,
+                        detail::LockTraitsImpl<Mutex>::has_lock_shared,
+                        detail::LockTraitsImpl<Mutex>::has_timed_lock> {};
+
+/**
+ * If the lock is a shared lock, acquire it in shared mode.
+ * Otherwise, for plain (exclusive-only) locks, perform a normal acquire.
+ */
+template <class Mutex>
+typename std::enable_if<LockTraits<Mutex>::is_shared>::type
+lock_shared_or_unique(Mutex& mutex) {
+  LockTraits<Mutex>::lock_shared(mutex);
+}
+template <class Mutex>
+typename std::enable_if<!LockTraits<Mutex>::is_shared>::type
+lock_shared_or_unique(Mutex& mutex) {
+  LockTraits<Mutex>::lock(mutex);
+}
+
+/**
+ * If the lock is a shared lock, try to acquire it in shared mode, for up to
+ * the given timeout.  Otherwise, for plain (exclusive-only) locks, try to
+ * perform a normal acquire.
+ *
+ * Returns true if the lock was acquired, or false on time out.
+ */
+template <class Mutex, class Rep, class Period>
+typename std::enable_if<LockTraits<Mutex>::is_shared, bool>::type
+try_lock_shared_or_unique_for(
+    Mutex& mutex,
+    const std::chrono::duration<Rep, Period>& timeout) {
+  return LockTraits<Mutex>::try_lock_shared_for(mutex, timeout);
+}
+template <class Mutex, class Rep, class Period>
+typename std::enable_if<!LockTraits<Mutex>::is_shared, bool>::type
+try_lock_shared_or_unique_for(
+    Mutex& mutex,
+    const std::chrono::duration<Rep, Period>& timeout) {
+  return LockTraits<Mutex>::try_lock_for(mutex, timeout);
+}
+
+/**
+ * Release a lock acquired with lock_shared_or_unique()
+ */
+template <class Mutex>
+typename std::enable_if<LockTraits<Mutex>::is_shared>::type
+unlock_shared_or_unique(Mutex& mutex) {
+  LockTraits<Mutex>::unlock_shared(mutex);
+}
+template <class Mutex>
+typename std::enable_if<!LockTraits<Mutex>::is_shared>::type
+unlock_shared_or_unique(Mutex& mutex) {
+  LockTraits<Mutex>::unlock(mutex);
+}
+} // folly

--- a/folly/LockTraitsBoost.h
+++ b/folly/LockTraitsBoost.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This file contains LockTraits specializations for boost mutex types.
+ *
+ * These need to be specialized simply due to the fact that the timed
+ * methods take boost::chrono arguments instead of std::chrono.
+ */
+#pragma once
+
+#include <folly/LockTraits.h>
+
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+
+#include <boost/thread.hpp>
+
+namespace folly {
+
+/**
+ * LockTraits specialization for boost::shared_mutex
+ */
+template <>
+struct LockTraits<boost::shared_mutex>
+    : public folly::detail::LockTraitsSharedBase<boost::shared_mutex> {
+  static constexpr bool is_shared = true;
+  static constexpr bool has_timed_lock = true;
+
+  static bool try_lock_for(
+      boost::shared_mutex& mutex,
+      std::chrono::milliseconds timeout) {
+    // Convert the std::chrono argument to boost::chrono
+    return mutex.try_lock_for(boost::chrono::milliseconds(timeout.count()));
+  }
+
+  static bool try_lock_shared_for(
+      boost::shared_mutex& mutex,
+      std::chrono::milliseconds timeout) {
+    // Convert the std::chrono argument to boost::chrono
+    return mutex.try_lock_shared_for(
+        boost::chrono::milliseconds(timeout.count()));
+  }
+};
+
+/**
+ * LockTraits specialization for boost::timed_mutex
+ */
+template <>
+struct LockTraits<boost::timed_mutex>
+    : public folly::detail::LockTraitsUniqueBase<boost::timed_mutex> {
+  static constexpr bool is_shared = false;
+  static constexpr bool has_timed_lock = true;
+
+  static bool try_lock_for(
+      boost::timed_mutex& mutex,
+      std::chrono::milliseconds timeout) {
+    // Convert the std::chrono argument to boost::chrono
+    return mutex.try_lock_for(boost::chrono::milliseconds(timeout.count()));
+  }
+};
+
+/**
+ * LockTraits specialization for boost::recursive_timed_mutex
+ */
+template <>
+struct LockTraits<boost::recursive_timed_mutex>
+    : public folly::detail::LockTraitsUniqueBase<boost::recursive_timed_mutex> {
+  static constexpr bool is_shared = false;
+  static constexpr bool has_timed_lock = true;
+
+  static bool try_lock_for(
+      boost::recursive_timed_mutex& mutex,
+      std::chrono::milliseconds timeout) {
+    // Convert the std::chrono argument to boost::chrono
+    return mutex.try_lock_for(boost::chrono::milliseconds(timeout.count()));
+  }
+};
+} // folly
+
+#endif // FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES

--- a/folly/Locked.h
+++ b/folly/Locked.h
@@ -1,0 +1,968 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This module implements a Locked abstraction useful in mutex-based
+ * concurrency.
+ *
+ * The Locked<T, Mutex> is the primary public API exposed by this module.
+ * See its class documentation for more information about how to use this
+ * functionality.
+ */
+#pragma once
+
+#include <mutex>
+#include <type_traits>
+
+#include <folly/LockTraits.h>
+#include <folly/SharedMutex.h>
+#include <glog/logging.h>
+
+namespace folly {
+
+namespace detail {
+class LockExclusive;
+class LockShared;
+class LockSharedOrExclusive;
+}
+
+template <class LockedType, class Mutex, class LockPolicy>
+class LockedPtrBase;
+template <class LockedType, class LockPolicy>
+class LockedPtr;
+template <class LockedType, class LockPolicy = detail::LockExclusive>
+class LockedGuardPtr;
+
+template <class T, class Mutex>
+class Locked;
+
+/**
+ * RWLocked is a Locked object using folly::SharedMutex as the
+ * default lock type.
+ */
+template <class T, class Mutex = folly::SharedMutex>
+using RWLocked = Locked<T, Mutex>;
+
+/**
+ * LockedBase is a helper parent class for Locked<T>.
+ *
+ * It provides wlock() and rlock() methods for shared mutex types,
+ * or lock() methods for purely exclusive mutex types.
+ */
+template <class Subclass, bool is_shared>
+class LockedBase;
+
+/**
+ * LockedBase specialization for shared mutex types.
+ *
+ * This class provides wlock() and rlock() methods for acquiring the lock and
+ * accessing the data.
+ */
+template <class Subclass>
+class LockedBase<Subclass, true> {
+ public:
+  using LockedPtr = ::folly::LockedPtr<Subclass, detail::LockExclusive>;
+  using ConstWLockedPtr =
+      ::folly::LockedPtr<const Subclass, detail::LockExclusive>;
+  using ConstLockedPtr = ::folly::LockedPtr<const Subclass, detail::LockShared>;
+
+  /**
+   * Acquire an exclusive lock, and return a LockedPtr that can be used to
+   * safely access the datum.
+   *
+   * LockedPtr offers operator -> and * to provide access to the datum.
+   * The lock will be released when the LockedPtr is destroyed.
+   */
+  LockedPtr wlock() {
+    return LockedPtr(static_cast<Subclass*>(this));
+  }
+  ConstWLockedPtr wlock() const {
+    return ConstWLockedPtr(static_cast<Subclass*>(this));
+  }
+
+  /**
+   * Acquire a read lock, and return a ConstLockedPtr that can be used to
+   * safely access the datum.
+   */
+  ConstLockedPtr rlock() const {
+    return ConstLockedPtr(static_cast<const Subclass*>(this));
+  }
+
+  /**
+   * Attempts to acquire the lock for up to the given number of milliseconds.
+   * If acquisition is unsuccessful, the returned LockedPtr will be invalid.
+   *
+   * (Use LockedPtr::isValid() to check for validity.)
+   */
+  LockedPtr wlock(std::chrono::milliseconds timeout) {
+    return LockedPtr(static_cast<Subclass*>(this), timeout);
+  }
+  ConstWLockedPtr wlock(std::chrono::milliseconds timeout) const {
+    return ConstWLockedPtr(static_cast<const Subclass*>(this), timeout);
+  }
+
+  /**
+   * Attempts to acquire the lock for up to the given number of milliseconds.
+   * If acquisition is unsuccessful, the returned LockedPtr will be invalid.
+   *
+   * (Use LockedPtr::isValid() to check for validity.)
+   */
+  ConstLockedPtr rlock(std::chrono::milliseconds timeout) const {
+    return ConstLockedPtr(static_cast<const Subclass*>(this), timeout);
+  }
+
+  /**
+   * Invoke a function while holding th lock exclusively.
+   *
+   * A reference to the datum will be passed into the function as its only
+   * argument.
+   *
+   * This can be used with a lambda argument for easily defining small critical
+   * sections in the code.  For example:
+   *
+   *   auto value = obj.withWLock([](auto& data) {
+   *     data.doStuff();
+   *     return data.getValue();
+   *   });
+   */
+  template <class Function>
+  auto withWLock(Function&& function) {
+    LockedGuardPtr<Subclass, detail::LockExclusive> guardPtr(
+        static_cast<Subclass*>(this));
+    return function(*guardPtr);
+  }
+  template <class Function>
+  auto withWLock(Function&& function) const {
+    LockedGuardPtr<const Subclass, detail::LockExclusive> guardPtr(
+        static_cast<const Subclass*>(this));
+    return function(*guardPtr);
+  }
+
+  /**
+   * Invoke a function while holding th lock exclusively.
+   *
+   * This is similar to withWLock(), but the function will be passed a
+   * LockedPtr rather than a reference to the data itself.
+   *
+   * This allows scopedUnlock() to be called on the LockedPtr argument if
+   * desired.
+   */
+  template <class Function>
+  auto withWLockPtr(Function&& function) {
+    return function(wlock());
+  }
+  template <class Function>
+  auto withWLockPtr(Function&& function) const {
+    return function(wlock());
+  }
+
+  /**
+   * Invoke a function while holding an the lock in shared mode.
+   *
+   * A const reference to the datum will be passed into the function as its
+   * only argument.
+   */
+  template <class Function>
+  auto withRLock(Function&& function) const {
+    LockedGuardPtr<const Subclass, detail::LockShared> guardPtr(
+        static_cast<const Subclass*>(this));
+    return function(*guardPtr);
+  }
+
+  template <class Function>
+  auto withRLockPtr(Function&& function) const {
+    return function(rlock());
+  }
+};
+
+/**
+ * LockedBase specialization for non-shared mutex types.
+ *
+ * This class provides lock() methods for acquiring the lock and accessing the
+ * data.
+ */
+template <class Subclass>
+class LockedBase<Subclass, false> {
+ public:
+  using LockedPtr = ::folly::LockedPtr<Subclass, detail::LockExclusive>;
+  using ConstLockedPtr =
+      ::folly::LockedPtr<const Subclass, detail::LockExclusive>;
+
+  /**
+   * Acquire a lock, and return a LockedPtr that can be used to safely access
+   * the datum.
+   */
+  LockedPtr lock() {
+    return LockedPtr(static_cast<Subclass*>(this));
+  }
+
+  /**
+   * Acquire a lock, and return a ConstLockedPtr that can be used to safely
+   * access the datum.
+   */
+  ConstLockedPtr lock() const {
+    return ConstLockedPtr(static_cast<const Subclass*>(this));
+  }
+
+  /**
+   * Attempts to acquire the lock for up to the given number of milliseconds.
+   * If acquisition is unsuccessful, the returned LockedPtr will be invalid.
+   */
+  LockedPtr lock(std::chrono::milliseconds timeout) {
+    return LockedPtr(static_cast<Subclass*>(this), timeout);
+  }
+
+  /**
+   * Attempts to acquire the lock for up to the given number of milliseconds.
+   * If acquisition is unsuccessful, the returned LockedPtr will be invalid.
+   */
+  ConstLockedPtr lock(std::chrono::milliseconds timeout) const {
+    return ConstLockedPtr(static_cast<const Subclass*>(this), timeout);
+  }
+
+  /**
+   * Invoke a function while holding the lock.
+   *
+   * A reference to the datum will be passed into the function as its only
+   * argument.
+   *
+   * This can be used with a lambda argument for easily defining small critical
+   * sections in the code.  For example:
+   *
+   *   auto value = obj.withLock([](auto& data) {
+   *     data.doStuff();
+   *     return data.getValue();
+   *   });
+   */
+  template <class Function>
+  auto withLock(Function&& function) {
+    LockedGuardPtr<Subclass, detail::LockExclusive> guardPtr(
+        static_cast<Subclass*>(this));
+    return function(*guardPtr);
+  }
+  template <class Function>
+  auto withLock(Function&& function) const {
+    LockedGuardPtr<const Subclass, detail::LockExclusive> guardPtr(
+        static_cast<const Subclass*>(this));
+    return function(*guardPtr);
+  }
+
+  /**
+   * Invoke a function while holding th lock exclusively.
+   *
+   * This is similar to withWLock(), but the function will be passed a
+   * LockedPtr rather than a reference to the data itself.
+   *
+   * This allows scopedUnlock() and getUniqueLock() to be called on the
+   * LockedPtr argument.
+   */
+  template <class Function>
+  auto withLockPtr(Function&& function) {
+    return function(lock());
+  }
+  template <class Function>
+  auto withLockPtr(Function&& function) const {
+    return function(lock());
+  }
+};
+
+/**
+ * Locked<T> encapsulates an object of type T (a "datum") paired
+ * with a mutex. The only way to access the datum is while the mutex
+ * is locked, and Locked makes it virtually impossible to do
+ * otherwise. The code that would access the datum in unsafe ways
+ * would look odd and convoluted, thus readily alerting the human
+ * reviewer. In contrast, the code that uses Locked<T> correctly
+ * looks simple and intuitive.
+ *
+ * The second parameter must be a mutex type.  Any mutex type supported by
+ * LockTraits<Mutex> can be used.  By default any class with lock() and
+ * unlock() methods will work automatically.  LockTraits can be specialized to
+ * teach Locked how to use other custom mutex types.  See the documentation in
+ * LockTraits.h for additional details.
+ *
+ * Supported mutexes that work by default include std::mutex,
+ * std::recursive_mutex, std::timed_mutex, std::recursive_timed_mutex,
+ * folly::SharedMutex, folly::RWSpinLock, folly::SpinLock,
+ * boost::mutex, boost::recursive_mutex, boost::shared_mutex,
+ * boost::timed_mutex, and boost::recursive_timed_mutex.
+ */
+template <class T, class Mutex = std::mutex>
+class Locked
+    : public LockedBase<Locked<T, Mutex>, LockTraits<Mutex>::is_shared> {
+ private:
+  /*
+   * Helpers to indicate if the copy and move constructors are noexcept.
+   */
+  static constexpr bool nxCopyCtor{
+      std::is_nothrow_copy_constructible<T>::value};
+  static constexpr bool nxMoveCtor{
+      std::is_nothrow_move_constructible<T>::value};
+
+ public:
+  using DataType = T;
+  using MutexType = Mutex;
+
+  /**
+   * Default constructor leaves both members call their own default
+   * constructor.
+   */
+  Locked() = default;
+
+  /**
+   * Constructor taking a datum as argument copies it. There is no
+   * need to lock the constructing object.
+   */
+  explicit Locked(const T& rhs) noexcept(nxCopyCtor) : datum_(rhs) {}
+
+  /**
+   * Constructor taking a datum rvalue as argument moves it. Again,
+   * there is no need to lock the constructing object.
+   */
+  explicit Locked(T&& rhs) noexcept(nxMoveCtor) : datum_(std::move(rhs)) {}
+
+  /**
+   * Lets you construct non-movable types in-place.
+   */
+  template <typename... Args>
+  explicit Locked(Args&&... args) : datum_(std::forward<Args>(args)...) {}
+
+  /**
+   * Lock object, assign datum.
+   */
+  Locked& operator=(const T& rhs) {
+    auto guard = contextualLock();
+    datum_ = rhs;
+    return *this;
+  }
+
+  /**
+   * Lock object, move-assign datum.
+   */
+  Locked& operator=(T&& rhs) {
+    auto guard = contextualLock();
+    datum_ = std::move(rhs);
+    return *this;
+  }
+
+  /*
+   * Note that our parent LockedBase class provides wlock() and rlock() methods
+   * if MutexType is a read-write mutex, or a lock() method if MutexType is a
+   * purely exclusive lock.
+   */
+
+  /**
+   * Acquire an appropriate lock based on the context.
+   *
+   * If the mutex is a read-write lock, and the locked object is const,
+   * this acquires a shared lock.  Otherwise this acquires an exclusive lock.
+   *
+   * In general, prefer using the explicit rlock() and wlock() methods
+   * for read-write locks, and lock() for purely exclusive locks.
+   *
+   * contextualLock() is primarily intended for use in other template functions
+   * that do not necessarily know the lock type.
+   */
+  LockedPtr<Locked<T, Mutex>, detail::LockExclusive> contextualLock() {
+    return LockedPtr<Locked<T, Mutex>, detail::LockExclusive>(this);
+  }
+  LockedPtr<const Locked<T, Mutex>, detail::LockSharedOrExclusive>
+  contextualLock() const {
+    return LockedPtr<const Locked<T, Mutex>, detail::LockSharedOrExclusive>(
+        this);
+  }
+  LockedPtr<Locked<T, Mutex>, detail::LockExclusive> contextualLock(
+      std::chrono::milliseconds timeout) {
+    return LockedPtr<Locked<T, Mutex>, detail::LockExclusive>(this, timeout);
+  }
+  LockedPtr<const Locked<T, Mutex>, detail::LockSharedOrExclusive>
+  contextualLock(std::chrono::milliseconds timeout) const {
+    return LockedPtr<const Locked<T, Mutex>, detail::LockSharedOrExclusive>(
+        this, timeout);
+  }
+  /**
+   * contextualRLock() acquires a read lock if the mutex type is shared,
+   * or a regular exclusive lock for non-shared mutex types.
+   *
+   * contextualRLock() when you know that you prefer a read lock (if
+   * available), even if the Locked<T> object itself is non-const.
+   */
+  LockedPtr<const Locked<T, Mutex>, detail::LockSharedOrExclusive>
+  contextualRLock() const {
+    return LockedPtr<const Locked<T, Mutex>, detail::LockSharedOrExclusive>(
+        this);
+  }
+  LockedPtr<const Locked<T, Mutex>, detail::LockSharedOrExclusive>
+  contextualRLock(std::chrono::milliseconds timeout) const {
+    return LockedPtr<const Locked<T, Mutex>, detail::LockSharedOrExclusive>(
+        this, timeout);
+  }
+
+  /**
+   * Swap data with another Locked<T> object.
+   *
+   * Locks are acquired in increasing address order.
+   */
+  void swapData(Locked& rhs) {
+    if (this == &rhs) {
+      return;
+    }
+    if (this > &rhs) {
+      return rhs.swapData(*this);
+    }
+    auto guard = contextualLock();
+    auto rhsGuard = rhs.contextualLock();
+
+    using std::swap;
+    swap(datum_, rhs.datum_);
+  }
+
+  /**
+   * Swap with another datum.
+   */
+  void swapData(T& rhs) {
+    auto guard = contextualLock();
+
+    using std::swap;
+    swap(datum_, rhs);
+  }
+
+  /**
+   * Copies datum to a given target.
+   */
+  void copy(T* target) const {
+    auto guard = contextualLock();
+    *target = datum_;
+  }
+
+  /**
+   * Returns a fresh copy of the datum.
+   */
+  T copy() const {
+    auto guard = contextualLock();
+    return datum_;
+  }
+
+ private:
+  template <class LockedType, class MutexType, class LockPolicy>
+  friend class folly::LockedPtrBase;
+  template <class LockedType, class LockPolicy>
+  friend class folly::LockedPtr;
+  template <class LockedType, class LockPolicy>
+  friend class folly::LockedGuardPtr;
+
+  /**
+   * Forbidden copy and move constructors and assignment operators.
+   *
+   * These are deleted since mutex objects cannot be copied or moved.
+   *
+   * It conceivably might be reasonable to support a copy constructor that
+   * copies the data and not the mutex.  (The older Synchronized class in fact
+   * did this for both copy and move construction and assignment.)  However, it
+   * seems like this has a large potential for surprising behaviors.  (For
+   * instance, it would allow std::vector<Locked<T>>, but this vector can't
+   * actually be used sanely without holding a global lock for the duration of
+   * pretty much any access, to ensure that the Locked objects aren't copied or
+   * moved out from users in other threads if the vector is resized.)
+   *
+   * We could consider adding support for these operators in the future if we
+   * find a compelling use case, but for now they seem too dangerous.
+   */
+  Locked(const Locked&) = delete;
+  Locked(Locked&&) = delete;
+  Locked& operator=(const Locked&) = delete;
+  Locked& operator=(Locked&&) = delete;
+
+  T datum_;
+  mutable Mutex mutex_;
+};
+
+template <class LockedType, class LockPolicy>
+class ScopedUnlocker;
+
+/**
+ * A helper base class for implementing LockedPtr.
+ *
+ * The main reason for having this as a separate class is so we can specialize
+ * it for std::mutex, so we can expose a std::unique_lock to the caller
+ * when std::mutex is being used.  This allows callers to use a
+ * std::condition_variable with the mutex from a Locked<T, std::mutex>.
+ *
+ * Note that the LockedType template parameter may or may not be const
+ * qualified.
+ */
+template <class LockedType, class Mutex, class LockPolicy>
+class LockedPtrBase {
+ public:
+  using MutexType = Mutex;
+  friend class folly::ScopedUnlocker<LockedType, LockPolicy>;
+
+  /**
+   * Destructor releases.
+   */
+  ~LockedPtrBase() {
+    if (parent_) {
+      LockPolicy::unlock(parent_->mutex_);
+    }
+  }
+
+ protected:
+  LockedPtrBase() {}
+  explicit LockedPtrBase(LockedType* parent) : parent_(parent) {
+    LockPolicy::lock(parent_->mutex_);
+  }
+  LockedPtrBase(LockedType* parent, std::chrono::milliseconds timeout) {
+    if (LockPolicy::try_lock_for(parent->mutex_, timeout)) {
+      this->parent_ = parent;
+    }
+  }
+  LockedPtrBase(LockedPtrBase&& rhs) noexcept : parent_(rhs.parent_) {
+    rhs.parent_ = nullptr;
+  }
+  LockedPtrBase& operator=(LockedPtrBase&& rhs) noexcept {
+    if (parent_) {
+      LockPolicy::unlock(parent_->mutex_);
+    }
+
+    parent_ = rhs.parent_;
+    rhs.parent_ = nullptr;
+  }
+
+  using Data = LockedType*;
+
+  Data releaseLock() {
+    auto current = parent_;
+    parent_ = nullptr;
+    LockPolicy::unlock(current->mutex_);
+    return current;
+  }
+  void reacquireLock(Data&& data) {
+    DCHECK(parent_ == nullptr);
+    parent_ = data;
+    LockPolicy::lock(parent_->mutex_);
+  }
+
+  LockedType* parent_ = nullptr;
+};
+
+/**
+ * LockedPtrBase specialization for use with std::mutex.
+ *
+ * When std::mutex is used we use a std::unique_lock to hold the mutex.
+ * This makes it possible to use std::condition_variable with a
+ * Locked<T, std::mutex>.
+ */
+template <class LockedType, class LockPolicy>
+class LockedPtrBase<LockedType, std::mutex, LockPolicy> {
+ public:
+  using MutexType = std::mutex;
+  friend class folly::ScopedUnlocker<LockedType, LockPolicy>;
+
+  /**
+   * Destructor releases.
+   */
+  ~LockedPtrBase() {
+    // The std::unique_lock will automatically release the lock when it is
+    // destroyed, so we don't need to do anything extra here.
+  }
+
+  LockedPtrBase(LockedPtrBase&& rhs) noexcept
+      : lock_(std::move(rhs.lock_)), parent_(rhs.parent_) {
+    rhs.parent_ = nullptr;
+  }
+  LockedPtrBase& operator=(LockedPtrBase&& rhs) noexcept {
+    lock_ = std::move(rhs.lock_);
+    parent_ = rhs.parent_;
+    rhs.parent_ = nullptr;
+  }
+
+  /*
+   * Get a reference to the std::unique_lock.
+   *
+   * This is providede so that callers can use Locked<T, std::mutex>
+   * with a std::condition_variable.
+   *
+   * While this API could be used to bypass the normal Locked APIs and manually
+   * interact with the underlying unique_lock, this is strongly discouraged.
+   */
+  std::unique_lock<std::mutex>& getUniqueLock() {
+    return lock_;
+  }
+
+ protected:
+  LockedPtrBase() {}
+  explicit LockedPtrBase(LockedType* parent)
+      : lock_(parent->mutex_), parent_(parent) {}
+
+  using Data = std::pair<std::unique_lock<std::mutex>, LockedType*>;
+
+  Data releaseLock() {
+    Data data(std::move(lock_), parent_);
+    parent_ = nullptr;
+    data.first.unlock();
+    return data;
+  }
+  void reacquireLock(Data&& data) {
+    lock_ = std::move(data.first);
+    lock_.lock();
+    parent_ = data.second;
+  }
+
+  // The specialization for std::mutex does have to store slightly more
+  // state than the default implementation.
+  std::unique_lock<std::mutex> lock_;
+  LockedType* parent_ = nullptr;
+};
+
+/**
+ * This class temporarily unlocks a LockedPtr in a scoped manner.
+ */
+template <class LockedType, class LockPolicy>
+class ScopedUnlocker {
+ public:
+  explicit ScopedUnlocker(LockedPtr<LockedType, LockPolicy>* p)
+      : ptr_(p), data_(ptr_->releaseLock()) {}
+  ScopedUnlocker(const ScopedUnlocker&) = delete;
+  ScopedUnlocker& operator=(const ScopedUnlocker&) = delete;
+  ScopedUnlocker(ScopedUnlocker&& other) noexcept
+      : ptr_(other.ptr_), data_(std::move(other.data_)) {
+    other.ptr_ = nullptr;
+  }
+  ScopedUnlocker& operator=(ScopedUnlocker&& other) = delete;
+
+  ~ScopedUnlocker() {
+    if (ptr_) {
+      ptr_->reacquireLock(std::move(data_));
+    }
+  }
+
+ private:
+  using Data = typename LockedPtr<LockedType, LockPolicy>::LockData;
+  LockedPtr<LockedType, LockPolicy>* ptr_{nullptr};
+  Data data_;
+};
+
+/*
+ * Helper class to get a "DataType" from "Locked<DataType>", and
+ * "const DataType" from "const Locked<DataType>",
+ */
+namespace detail {
+template <class Locked>
+struct LockedDataType {
+  using DataType = typename Locked::DataType;
+};
+template <class T, class Mutex>
+struct LockedDataType<const Locked<T, Mutex>> {
+  using DataType = typename Locked<T, Mutex>::DataType const;
+};
+}
+
+/**
+ * A LockedPtr keeps a Locked<T> object locked for the duration of
+ * LockedPtr's existence.
+ *
+ * It provides access the datum's members directly by using operator->() and
+ * operator*().
+ *
+ * If the LockedType parameter is a non-const Locked<T> an exclusive lock is
+ * acquired.  If the LockedType parameter is a const Locked<T>, then a shared
+ * lock is acquired if the mutex supports read/write semantics; if the lock is
+ * not a read/write lock then an exclusive lock is acquired.
+ */
+template <class LockedType, class LockPolicy>
+class LockedPtr : public LockedPtrBase<
+                      LockedType,
+                      typename LockedType::MutexType,
+                      LockPolicy> {
+ private:
+  using Base =
+      LockedPtrBase<LockedType, typename LockedType::MutexType, LockPolicy>;
+  using LockData = typename Base::Data;
+  // CDataType is the DataType with the appropriate const-qualification
+  using CDataType = typename detail::LockedDataType<LockedType>::DataType;
+
+ public:
+  using DataType = typename LockedType::DataType;
+  using MutexType = typename LockedType::MutexType;
+  using Locked = typename std::remove_const<LockedType>::type;
+  friend class ScopedUnlocker<LockedType, LockPolicy>;
+
+  /**
+   * Creates an uninitialized LockedPtr.
+   *
+   * Dereferencing an uninitialized LockedPtr is not allowed.
+   */
+  LockedPtr() {}
+
+  /**
+   * Takes a Locked<T> and locks it.
+   */
+  explicit LockedPtr(LockedType* parent) : Base(parent) {}
+
+  /**
+   * Takes a Locked<T> and attempts to lock it, within the specified timeout.
+   *
+   * Blocks until the lock is acquired or until the specified timeout expires.
+   * If the timeout expired without acquiring the lock, the LockedPtr will be
+   * invalid, and LockedPtr::isValid() will return false.
+   */
+  LockedPtr(LockedType* parent, std::chrono::milliseconds timeout)
+      : Base(parent, timeout) {}
+
+  /**
+   * Move constructor.
+   */
+  LockedPtr(LockedPtr&& rhs) noexcept = default;
+
+  /**
+   * Move assignment operator.
+   */
+  LockedPtr& operator=(LockedPtr&& rhs) noexcept = default;
+
+  /*
+   * Copy constructor and assignment operator are deleted.
+   */
+  LockedPtr(const LockedPtr& rhs) = delete;
+  LockedPtr& operator=(const LockedPtr& rhs) = delete;
+
+  /**
+   * Destructor releases.
+   */
+  ~LockedPtr() {}
+
+  /**
+   * Check if this LockedPtr is valid or not.
+   *
+   * In particular, this method must be used to check if a timed-acquire
+   * operation succeeded.  If an acquire operation times out it will result in
+   * a null LockedPtr.
+   */
+  bool isValid() const {
+    return this->parent_ != nullptr;
+  }
+
+  /**
+   * Support using the ! operator to check if the LockedPtr is valid.
+   *
+   * This allows slightly more succinct checks to detect if we failed to
+   * acquire a lock within the given timeout, while avoiding the pitfalls of
+   * an implicit bool conversion operator.
+   */
+  bool operator!() const {
+    return this->parent_ == nullptr;
+  }
+
+  /**
+   * Access the locked data.
+   *
+   * This method should only be used if the LockedPtr is valid.
+   */
+  CDataType* operator->() const {
+    return &this->parent_->datum_;
+  }
+
+  /**
+   * Access the locked data.
+   *
+   * This method should only be used if the LockedPtr is valid.
+   */
+  CDataType& operator*() const {
+    return this->parent_->datum_;
+  }
+
+  /**
+   * Temporarily unlock the LockedPtr.
+   *
+   * Returns an helper object that will re-lock the LockedPtr when the helper
+   * is destroyed.
+   */
+  ScopedUnlocker<LockedType, LockPolicy> scopedUnlock() {
+    return ScopedUnlocker<LockedType, LockPolicy>(this);
+  }
+};
+
+/**
+ * LockedGuardPtr is a simplified version of LockedPtr.
+ *
+ * It is non-movable, and supports fewer features than LockedPtr.  However, it
+ * is ever-so-slightly more performant than LockedPtr.  (The destructor can
+ * unconditionally release the lock, without requiring a conditional branch.)
+ *
+ * The relationship between LockedGuardPtr and LockedPtr is similar to that
+ * between std::lock_guard and std::unique_lock.
+ */
+template <class LockedType, class LockPolicy>
+class LockedGuardPtr {
+ private:
+  // CDataType is the DataType with the appropriate const-qualification
+  using CDataType = typename detail::LockedDataType<LockedType>::DataType;
+
+ public:
+  using DataType = typename LockedType::DataType;
+  using MutexType = typename LockedType::MutexType;
+  using Locked = typename std::remove_const<LockedType>::type;
+
+  LockedGuardPtr() = delete;
+
+  /**
+   * Takes a Locked<T> and locks it.
+   */
+  explicit LockedGuardPtr(LockedType* parent) : parent_(parent) {
+    LockPolicy::lock(parent_->mutex_);
+  }
+
+  /**
+   * Destructor releases.
+   */
+  ~LockedGuardPtr() {
+    LockPolicy::unlock(parent_->mutex_);
+  }
+
+  /**
+   * Access the locked data.
+   *
+   * This method should only be used if the LockedPtr is valid.
+   */
+  CDataType* operator->() const {
+    return &parent_->datum_;
+  }
+
+  /**
+   * Access the locked data.
+   *
+   * This method should only be used if the LockedPtr is valid.
+   */
+  CDataType& operator*() const {
+    return parent_->datum_;
+  }
+
+ private:
+  // This is the entire state of LockedGuardPtr.
+  LockedType* const parent_{nullptr};
+};
+
+namespace detail {
+template <class Locked>
+struct LockedPtrType {
+  using type = LockedPtr<Locked, LockExclusive>;
+};
+template <class T, class Mutex>
+struct LockedPtrType<const Locked<T, Mutex>> {
+  using type = LockedPtr<const Locked<T, Mutex>, LockSharedOrExclusive>;
+};
+}
+
+/**
+ * Acquire locks for multiple Locked<T> objects, in a deadlock-safe manner.
+ *
+ * The locks are acquired in order from lowest address to highest address.
+ * (Note that this is not necessarily the same algorithm used by std::lock().)
+ *
+ * For parameters that are const and support shared locks, a read lock is
+ * acquired.  Otherwise an exclusive lock is acquired.
+ *
+ * TODO: Extend acquireLocked() with variadic template versions that
+ * allow for more than 2 Locked arguments.  (I haven't given too much thought
+ * about how to implement this.  It seems like it would be rather complicated,
+ * but I think it should be possible.)
+ */
+template <class Locked1, class Locked2>
+std::tuple<
+    typename detail::LockedPtrType<Locked1>::type,
+    typename detail::LockedPtrType<Locked2>::type>
+acquireLocked(Locked1& l1, Locked2& l2) {
+  if (static_cast<const void*>(&l1) < static_cast<const void*>(&l2)) {
+    auto p1 = l1.contextualLock();
+    auto p2 = l2.contextualLock();
+    return std::make_tuple(std::move(p1), std::move(p2));
+  } else {
+    auto p2 = l2.contextualLock();
+    auto p1 = l1.contextualLock();
+    return std::make_tuple(std::move(p1), std::move(p2));
+  }
+}
+
+namespace detail {
+
+/**
+ * A lock policy for LockedPtr which performs exclusive lock operations.
+ */
+class LockExclusive {
+ public:
+  template <class Mutex>
+  static void lock(Mutex& mutex) {
+    LockTraits<Mutex>::lock(mutex);
+  }
+  template <class Mutex, class Rep, class Period>
+  static bool try_lock_for(
+      Mutex& mutex,
+      const std::chrono::duration<Rep, Period>& timeout) {
+    return LockTraits<Mutex>::try_lock_for(mutex, timeout);
+  }
+  template <class Mutex>
+  static void unlock(Mutex& mutex) {
+    LockTraits<Mutex>::unlock(mutex);
+  }
+};
+
+/**
+ * A lock policy for LockedPtr which performs shared lock operations.
+ * This policy only works with shared mutex types.
+ */
+class LockShared {
+ public:
+  template <class Mutex>
+  static void lock(Mutex& mutex) {
+    LockTraits<Mutex>::lock_shared(mutex);
+  }
+  template <class Mutex, class Rep, class Period>
+  static bool try_lock_for(
+      Mutex& mutex,
+      const std::chrono::duration<Rep, Period>& timeout) {
+    return LockTraits<Mutex>::try_lock_shared_for(mutex, timeout);
+  }
+  template <class Mutex>
+  static void unlock(Mutex& mutex) {
+    LockTraits<Mutex>::unlock_shared(mutex);
+  }
+};
+
+/**
+ * A lock policy for LockedPtr which performs a shared lock operation if a
+ * shared mutex type is given, or a normal exclusive lock operation on
+ * non-shared mutex types.
+ */
+class LockSharedOrExclusive {
+ public:
+  template <class Mutex>
+  static void lock(Mutex& mutex) {
+    lock_shared_or_unique(mutex);
+  }
+  template <class Mutex, class Rep, class Period>
+  static bool try_lock_for(
+      Mutex& mutex,
+      const std::chrono::duration<Rep, Period>& timeout) {
+    return try_lock_shared_or_unique_for(mutex, timeout);
+  }
+  template <class Mutex>
+  static void unlock(Mutex& mutex) {
+    unlock_shared_or_unique(mutex);
+  }
+};
+
+} // detail
+
+} // folly

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -229,6 +229,8 @@ nobase_follyinclude_HEADERS = \
 	Lazy.h \
 	LifoSem.h \
 	Likely.h \
+	LockTraits.h \
+	LockTraitsBoost.h \
 	Logging.h \
 	MacAddress.h \
 	Malloc.h \

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -229,6 +229,7 @@ nobase_follyinclude_HEADERS = \
 	Lazy.h \
 	LifoSem.h \
 	Likely.h \
+	Locked.h \
 	LockTraits.h \
 	LockTraitsBoost.h \
 	Logging.h \
@@ -314,6 +315,8 @@ nobase_follyinclude_HEADERS = \
 	test/FBVectorTestBenchmarks.cpp.h \
 	test/function_benchmark/benchmark_impl.h \
 	test/function_benchmark/test_functions.h \
+	test/LockedTestLib.h \
+	test/LockedTestLib-inl.h \
 	test/SynchronizedTestLib.h \
 	test/SynchronizedTestLib-inl.h \
 	test/TestUtils.h \

--- a/folly/Synchronized.h
+++ b/folly/Synchronized.h
@@ -197,6 +197,11 @@ releaseReadWrite(T& mutex) {
 } // namespace detail
 
 /**
+ * NOTE: Synchronized<T> is deprecated in favor of Locked<T>.
+ * See the documentation in folly/docs/Synchronized.md and folly/docs/Locked.md
+ * for details, and steps for how to convert your code from Synchronized to
+ * Locked.
+ *
  * Synchronized<T> encapsulates an object of type T (a "datum") paired
  * with a mutex. The only way to access the datum is while the mutex
  * is locked, and Synchronized makes it virtually impossible to do

--- a/folly/docs/Locked.md
+++ b/folly/docs/Locked.md
@@ -1,0 +1,539 @@
+`folly/Locked.h`
+----------------
+
+`folly/Locked.h` introduces a simple abstraction for mutex-
+based concurrency. It replaces convoluted, unwieldy, and just
+plain wrong code with simple constructs that are easy to get
+right and difficult to get wrong.
+
+### Motivation
+
+Many of our multithreaded C++ programs use shared data structures
+associated with locks. This follows the time-honored adage of
+mutex-based concurrency control "associate mutexes with data, not code".
+Examples are abundant and easy to find. For example:
+
+``` Cpp
+
+    class AdPublisherHandler {
+      ...
+      OnDemandUpdateIdMap adsToBeUpdated_;
+      ReadWriteMutex adsToBeUpdatedLock_;
+
+      OnDemandUpdateIdMap limitsToBeUpdated_;
+      ReadWriteMutex limitsToBeUpdatedLock_;
+
+      OnDemandUpdateIdMap campaignsToBeUpdated_;
+      ReadWriteMutex campaignsToBeUpdatedLock_;
+      ...
+    };
+```
+
+Whenever the code needs to read or write some of the protected
+data, it acquires the mutex for reading or for reading and
+writing. For example:
+
+``` Cpp
+    void AdPublisherHandler::requestUpdateAdId(const int64_t adId,
+                                               const int32_t dbId) {
+      checkDbHandlingStatus(dbId);
+      RWGuard g(adsToBeUpdatedLock_, RW_WRITE);
+      adsToBeUpdated_->insert(dbId, adId);
+      adPublisherMonitor_->addStatValue("request_adId_update", 1, dbId);
+      LOG(INFO) << "received request to update ad id " << adId;
+    }
+```
+
+However, the correctness of this technique is entirely predicated on
+convention.  Developers manipulating these data members must be take
+care to manually acquire the correct lock for the data they wish to
+access.  There is no ostensible error for code that:
+
+* manipulates a piece of data without acquiring its lock first
+* acquires a different lock instead of the intended one
+* acquires a lock in read mode but modifies the guarded data structure
+
+### Introduction to `folly/Locked.h`
+
+The same code sample could be rewritten with `Locked`
+as follows:
+
+``` Cpp
+    class AdPublisherHandler : public AdPopulatorIf,
+                               public fb303::FacebookBase,
+                               public ZkBaseApplication {
+      ...
+      RWLocked<OnDemandUpdateIdMap> adsToBeUpdated_;
+      RWLocked<OnDemandUpdateIdMap> limitsToBeUpdated_;
+      RWLocked<OnDemandUpdateIdMap> campaignsToBeUpdated_;
+      ...
+    };
+
+    void AdPublisherHandler::requestUpdateAdId(const int64_t adId,
+                                               const int32_t dbId) {
+      checkDbHandlingStatus(dbId);
+      adsToBeUpdated_.wlock()->insert(dbId, adId);
+      adPublisherMonitor_->addStatValue("request_adId_update", 1, dbId);
+      LOG(INFO) << "received request to update ad id " << adId;
+    }
+```
+
+The rewrite does at maximum efficiency what needs to be done:
+acquires the lock associated with the `OnDemandUpdateIdMap`
+object, writes to the map, and releases the lock immediately
+thereafter.
+
+On the face of it, that's not much to write home about, and not
+an obvious improvement over the previous state of affairs. But
+the features at work invisible in the code above are as important
+as those that are visible:
+
+* Unlike before, the data and the mutex protecting it are
+  inextricably encapsulated together.
+* If you tried to use `adsToBeUpdated_` without acquiring the lock you
+  wouldn't be able to; it is virtually impossible to access the map
+  object without acquiring the correct lock.
+* The lock is released immediately after the insert operation is
+  performed, and is not held for operations that do not need it.
+
+If you need to perform several operations while holding the lock,
+`Locked` provides a couple ways of doing this.
+
+The `wlock()` method (or `lock()` if you have a non-shared mutex type)
+returns a `LockedPtr` object that can be stored in a variable.  The lock
+will be held for as long as this object exists, similar to a
+`std::unique_lock`.  This object can be used as if it were a pointer to
+get access to the locked data:
+
+``` Cpp
+    {
+       auto lockedAds = adsToBeUpdated_.wlock();
+       lockedAds->insert(dbId1, adId1);
+       lockedAds->insert(dbId2, adId2);
+    }
+```
+
+Alternatively, `Locked` also provides mechanisms to run a function while
+holding the lock.  This makes it possible to use lambdas to define brief
+critical sections:
+
+``` Cpp
+    void AdPublisherHandler::requestUpdateAdId(const int64_t adId,
+                                               const int32_t dbId) {
+      checkDbHandlingStatus(dbId);
+      adsToBeUpdated_.withWLock([](auto& lockedAds) {
+        lockedAds.insert(dbId, adId);
+      });
+      adPublisherMonitor_->addStatValue("request_adId_update", 1, dbId);
+      LOG(INFO) << "received request to update ad id " << adId;
+    }
+```
+
+One advantage of the `withWLock()` approach is that it forces a new
+scope to be used for the critical section, making the critical section
+more obvious in the code, and helping to encourage code that releases
+the lock as soon as possible.
+
+### Template class `Locked<T>`
+
+##### Template Parameters
+
+`Locked` is a template with two parameters, the data type and a mutex
+type: `Locked<T, Mutex>`.
+
+If not specified, the mutex type defaults to `std::mutex`.  However, any
+mutex type supported by `folly::LockTraits` can be used instead.
+`folly::LockTraits` can be specialized to support other custom lock
+types that it does not know about out of the box.
+
+`RWLocked<T>` is a template alias for `Locked<T, folly::SharedMutex>`.
+This provides shared lock functionality for callers that benefit from
+separate read/write locking behavior.
+
+`Locked` provides slightly different APIs when instantiated with a
+shared lock type than with a plain exclusive lock type.  When used with
+a shared lock type, it has separate `wlock()` and `rlock()` methods.
+When used with a plain exclusive lock it only has a single `lock()`
+method.
+
+##### Constructors
+
+The default constructor default-initializes the data and its
+associated mutex.
+
+If the `Locked<T>` constructor is called with any arguments, it forwards
+those arguments to the `T` constructor to initialize the data.
+
+The copy constructor and move constructor are disabled, since the mutex
+itself cannot be copy or move constructed.  However, you can pass in a
+`const T&` to copy construct the internal data, as long as that is
+supported by the data type.
+
+#### Assignment
+
+Since the mutex inside the `Locked<T>` object is not movable or
+assignable, the assignment operators for `Locked<T>` are disabled,
+just like the copy constructor.
+
+However, you can assign a `Locked<T>` from another `T` object as long as
+the data type supports the corresponding copy or move assignment
+operator.
+
+If you are assigning one `Locked<T>` to the value of data from another
+`Locked<T>` object, make sure to always acquire the locks in a
+consistent order to avoid deadlocks.  The `acquireLocked()` helper
+function can be used for this purpose.  It always acquires the lock on
+the object with the lowest address first.
+
+To get a copy of the guarded data, there are two methods
+available: `void copy(T*)` and `T copy()`. The first copies data
+to a provided target and the second returns a copy by value. Both
+operations are done under a read lock. Example:
+
+``` Cpp
+    Locked< vector<string> > syncVec;
+    vector<string> vec;
+
+    // Copy to given target
+    syncVec.copy(&vec);
+    // Get a copy by value
+    auto copy = syncVec.copy();
+```
+
+#### `lock()`
+
+If the mutex type used with `Locked` is a simple exclusive lock (as
+opposed to a read/write lock), `Locked<T>` provides a `lock()` method
+that returns a `LockedPtr` to access the data while holding the lock.
+
+The `LockedPtr` object returned by `lock()` holds the lock for as long
+as it exists.  Whenever possible, prefer declaring a separate inner
+scope to make sure the `LockedPtr` is destroyed as soon as the lock is
+no longer needed:
+
+``` Cpp
+    void fun(Locked<std::vector<std::string>>& vec) {
+      {
+        auto locked = vec.lock();
+        locked->push_back("hello");
+        locked->push_back("world");
+      }
+      LOG(INFO) << "successfully added greeting";
+    }
+```
+
+#### `wlock()` and `rlock()`
+
+If the mutex type used with `Locked` is a shared lock, `Locked<T>`
+provides a `wlock()` method that acquires an exclusive lock, and an
+`rlock()` method that acquires a shared lock.
+
+The `LockedPtr` returned by `rlock()` only provides const access to the
+internal data, to ensure that it cannot be modified while only holding a
+shared lock.
+
+``` Cpp
+    int computeSum(const RWLocked<std::vector<int>>& vec) {
+      int sum = 0;
+      auto locked = *vec.rlock();
+      for (int n : *locked) {
+        sum += locked;
+      }
+      return sum;
+    }
+
+    void doubleValues(RWLocked<std::vector<int>>& vec) {
+      auto locked = vec.wlock();
+      for (int& n : *locked) {
+        n *= 2;
+      }
+    }
+```
+
+This example brings us to a cautionary discussion.  The `LockedPtr`
+object returned by `lock()`, `rlock()`, or `wlock()` only holds the lock
+as long as it exists.  This object makes it difficult to access the data
+without holding the lock, but not impossible.  In particular you should
+never store a raw pointer or reference to the internal data for longer
+than the lifetime of the `LockedPtr` object.
+
+In particular, if we had written the following code in the examples
+above, this would have continued accessing the vector after the lock had
+been released:
+
+``` Cpp
+    // No. NO. NO!
+    for (int& n : *vec.wlock()) {
+      n *= 2;
+    }
+```
+
+The `vec.wlock()` return value is destroyed in this case as soon as the
+internal range iterators are created.  Therefore the lock is not held
+for the duration of the loop bocy.
+
+Needless to say, this is a crime punishable by long debugging nights.
+
+Range-based for loops are slightly subtle about the lifetime of objects
+used in the initializer statement.  Most other problematic use cases are
+a bit easier to spot than this, since the lifetime of the `LockedPtr` is
+more explicitly visible.
+
+#### `withLock()`
+
+As an alternative to the `lock()` API, `Locked` also provides a
+`withLock()` method that executes a function or lambda expression while
+holding the lock.  The function receives a reference to the data as its
+only argument.
+
+This has a few benefits compared to `lock()`:
+
+* The lambda expression requires its own nested scope, making critical
+  sections more visible in the code.  Callers can always define a new
+  scope when using `lock()` if they choose to.  `withLock()` ensures
+  that a new scope must always be defined.
+* Because a new scope is required, `withLock()` also helps encourage
+  users to release the lock as soon as possible.  Because the critical
+  section scope is easily visible in the code, it is harder to
+  accidentally put extraneous code inside the critical section without
+  realizing it.
+* The separate lambda scope makes it more difficult to store raw
+  pointers or references to the protected data and continue using those
+  pointers outside the critical section.
+
+For example, `withLock()` makes the range-based for loop mistake from
+above much harder to accidentally run into:
+
+``` Cpp
+    vec.withLock([](auto& locked) {
+      for (int& n : locked) {
+        n *= 2;
+      }
+    });
+```
+
+This code does not have the same problem as the counter-example with
+`wlock()` above, since the lock is held for the duration of the loop.
+
+When using `Locked` with a shared mutex type, it provides separate
+`withWLock()` and `withRLock()` methods instead of `withLock()`.
+
+### Timed Locking
+
+When `Locked` is used with a mutex type that supports timed lock acquisition,
+`lock()`, `wlock()`, and `rlock()` can all take an optional
+`std::chrono` duration argument.  This argument specifies a timeout to
+use for acquiring the lock.  If the lock it not acquired before the
+timeout expires, a null pointer will be returned.  Callers must
+explicitly check the return value before using it:
+
+``` Cpp
+    void fun(Locked<std::vector<std::string>>& vec) {
+      {
+        auto locked = vec.lock(10_ms);
+        if (!locked()) {
+          LOG(ERROR) << "failed to acquire lock";
+          throw std::runtime_error("failed to acquire lock");
+        }
+        locked->push_back("hello");
+        locked->push_back("world");
+      }
+      LOG(INFO) << "successfully added greeting";
+    }
+```
+
+### `Locked` and `std::condition_variable`
+
+When used with a `std::mutex`, `Locked<T>` supports using a
+`std::condition_variable` with its internal mutex.  This allows a
+`condition_variable` to be used to wait for a particular change to occur
+in the internal data.
+
+The `LockedPtr` returned by `lock()` has a `getUniqueLock()` method that
+returns a reference to a `std::unique_lock<std::mutex>` which can be
+given to the `std::condition_variable`:
+
+``` Cpp
+    Locked<std::vector<std::string>>& vec;
+    std::condition_variable emptySignal;
+
+    // Asuming some other thread will put data on vec and signal
+    // emptySignal, we can then wait on it as follows:
+    auto locked = vec.lock();
+    while (locked->empty()) {
+      emptySignal.wait(locked.getUniqueLock());
+    }
+```
+
+### `scopedUnlock()`
+
+`withLock()` is a good mechanism for enforcing scoped
+synchronization, but it has the inherent limitation that it
+requires the critical section to be, well, scoped. Sometimes the
+code structure requires a fleeting "escape" from the iron fist of
+synchronization. Clearly, simple cases are handled with sequenced
+`withLock()` calls:
+
+``` Cpp
+    Locked<map<int, string>> dic;
+    ...
+    dic.withLock([](auto& locked) {
+      if (locked.find(0) != locked.end()) {
+        return;
+      }
+    });
+    LOG(INFO) << "Key 0 not found, inserting it."
+    dic.withLock([](auto& locked) {
+      locked[0] = "zero";
+    });
+```
+
+For more complex, nested flow control, you may want to use the
+`scopedUnlock()` method.  This method is available on the `LockedPtr`
+object returned by `lock()`.  It returns an object that will release the
+lock for as long as it exists, and re-acquire the lock when it is
+destroyed.
+
+Since the `withLock()` method does not provide you with access to
+`LockedPtr` object, you can instead use `withLockPtr()`.
+`withLockPtr()` is similar to `withLock()`, but passes a `LockedPtr`
+argument to your function instead of passing the reference to the data
+directly.
+
+``` Cpp
+
+    Locked<map<int, string>> dic;
+    ...
+    dic.withLockPtr([](auto& lockedPtr) {
+      auto i = lockedPtr->find(0);
+      if (i != lockedPtr->end()) {
+        {
+          auto unlocker = lockedPtr->scopedUnlock();
+          LOG(INFO) << "Key 0 not found, inserting it."
+        }
+        (*lockedPtr)[0] = "zero";
+      } else {
+        *i = "zero";
+      }
+    });
+    LOG(INFO) << "Key 0 not found, inserting it."
+    dic.withLock([](auto& locked) {
+      dic[0] = "zero";
+    });
+```
+
+Clearly `scopedUnlock()` comes with specific caveats and
+liabilities. You must assume that during the `scopedUnlock()`
+section, other threads might have changed the protected structure
+in arbitrary ways. In the example above, you cannot use the
+iterator `i` and you cannot assume that the key `0` is not in the
+map; another thread might have inserted it while you were
+bragging on `LOG(INFO)`.
+
+### `acquireLocked()`
+
+Sometimes locking just one object won't be able to cut the mustard.
+Consider a function that needs to lock two `Locked` objects at the
+same time - for example, to copy some data from one to the other.
+At first sight, it looks like sequential `lock()` statements
+will work just fine:
+
+``` Cpp
+    void fun(Locked<vector<int>>& a, Locked<vector<int>>& b) {
+      auto lockedA = a.lock();
+      auto lockedB = b.lock();
+      ... use lockedA and lockedB ...
+    }
+```
+
+This code compiles and may even run most of the time, but embeds
+a deadly peril: if one threads call `fun(x, y)` and another
+thread calls `fun(y, x)`, then the two threads are liable to
+deadlocking as each thread will be waiting for a lock the other
+is holding. This issue is a classic that applies regardless of
+the fact the objects involved have the same type.
+
+This classic problem has a classic solution: all threads must
+acquire locks in the same order. The actual order is not
+important, just the fact that the order is the same in all
+threads. Many libraries simply acquire mutexes in increasing
+order of their address, which is what we'll do, too. The
+`acquireLocked()` function locking of two objects and offering their
+innards.  It returns a `std::tuple` of `LockedPtr`s
+
+``` Cpp
+    void fun(Locked<vector<int>>& a, Locked<vector<int>>& b) {
+      auto ret = folly::acquireLocked(a, b);
+      auto& lockedA = std::get<0>(ret);
+      auto& lockedB = std::get<1>(ret);
+      ... use lockedA and lockedB ...
+    }
+```
+
+### Synchronizing several data items with one mutex
+
+The library is geared at protecting one object of a given type
+with a mutex. However, sometimes we'd like to protect two or more
+members with the same mutex. Consider for example a bidirectional
+map, i.e. a map that holds an `int` to `string` mapping and also
+the converse `string` to `int` mapping. The two maps would need
+to be manipulated simultaneously. There are at least two designs
+that come to mind.
+
+#### Using a nested `struct`
+
+You can easily pack the needed data items in a little struct.
+For example:
+
+``` Cpp
+    class Server {
+      struct BiMap {
+        map<int, string> direct;
+        map<string, int> inverse;
+      };
+      Locked<BiMap> bimap_;
+      ...
+    };
+    ...
+    bymap_.withLock([](auto& locked) {
+      locked.direct[0] = "zero";
+      locked.inverse["zero"] = 0;
+    });
+```
+
+With this code in tow you get to use `bimap_` just like any other
+`Locked` object, without much effort.
+
+#### Using `std::tuple`
+
+If you won't stop short of using a spaceship-era approach,
+`std::tuple` is there for you. The example above could be
+rewritten for the same functionality like this:
+
+``` Cpp
+    class Server {
+      Locked<tuple<map<int, string>, map<string, int>>> bimap_;
+      ...
+    };
+    ...
+    bimap_.withLock([](auto& locked) {
+      get<0>(locked)[0] = "zero";
+      get<1>(locked)["zero"] = 0;
+    });
+```
+
+The code uses `std::get` with compile-time integers to access the
+fields in the tuple. The relative advantages and disadvantages of
+using a local struct vs. `std::tuple` are quite obvious - in the
+first case you need to invest in the definition, in the second
+case you need to put up with slightly more verbose and less clear
+access syntax.
+
+### Summary
+
+`Locked` and its supporting tools offer you a simple,
+robust paradigm for mutual exclusion-based concurrency. Instead
+of manually pairing data with the mutexes that protect it and
+relying on convention to use them appropriately, you can benefit
+of encapsulation and type checking to offload a large part of that
+task and to provide good guarantees.

--- a/folly/docs/Synchronized.md
+++ b/folly/docs/Synchronized.md
@@ -1,609 +1,169 @@
 `folly/Synchronized.h`
 ----------------------
 
-`folly/Synchronized.h` introduces a simple abstraction for mutex-
-based concurrency. It replaces convoluted, unwieldy, and just
-plain wrong code with simple constructs that are easy to get
-right and difficult to get wrong.
-
-### Motivation
-
-Many of our multithreaded Thrift services (not to mention general
-concurrent C++ code) use shared data structures associated with
-locks. This follows the time-honored adage of mutex-based
-concurrency control "associate mutexes with data, not code".
-Examples are abundant and easy to find. For example:
-
-``` Cpp
-
-    class AdPublisherHandler : public AdPopulatorIf,
-                               public fb303::FacebookBase,
-                               public ZkBaseApplication {
-      ...
-      OnDemandUpdateIdMap adsToBeUpdated_;
-      ReadWriteMutex adsToBeUpdatedLock_;
-
-      OnDemandUpdateIdMap limitsToBeUpdated_;
-      ReadWriteMutex limitsToBeUpdatedLock_;
-
-      OnDemandUpdateIdMap campaignsToBeUpdated_;
-      ReadWriteMutex campaignsToBeUpdatedLock_;
-      ...
-    };
-```
-
-Whenever the code needs to read or write some of the protected
-data, it acquires the mutex for reading or for reading and
-writing. For example:
-
-``` Cpp
-    void AdPublisherHandler::requestUpdateAdId(const int64_t adId,
-                                               const int32_t dbId) {
-      checkDbHandlingStatus(dbId);
-      RWGuard g(adsToBeUpdatedLock_, RW_WRITE);
-      adsToBeUpdated_[dbId][adId] = 1;
-      adPublisherMonitor_->addStatValue("request_adId_update", 1, dbId);
-      LOG(INFO) << "received request to update ad id " << adId;
-    }
-```
-
-The pattern is an absolute classic and present everywhere.
-However, it is inefficient, makes incorrect code easy to
-write, is prone to deadlocking, and is bulkier than it could
-otherwise be. To expand:
-
-* In the code above, for example, the critical section is only
-  the line right after `RWGuard`'s definition; it is frivolous
-  that everything else (including a splurging `LOG(INFO)`) keeps
-  the lock acquired for no good reason. This is because the
-  locked regions are not visible; the guard's construction
-  introduces a critical section as long as the remainder of the
-  current scope.
-* The correctness of the technique is entirely predicated on
-  convention. There is no ostensible error for code that:
-
-    * manipulates a piece of data without acquiring its lock first
-    * acquires a different lock instead of the intended one
-    * acquires a lock in read mode but modifies the guarded data structure
-    * acquires a lock in read-write mode although it only has `const`
-      access to the guarded data
-    * acquires one lock when another lock is already held, which may
-      lead to deadlocks if another thread acquires locks in the
-      inverse order
-
-### Introduction to `folly/Synchronized.h`
-
-The same code sample could be rewritten with `Synchronized`
-as follows:
-
-``` Cpp
-    class AdPublisherHandler : public AdPopulatorIf,
-                               public fb303::FacebookBase,
-                               public ZkBaseApplication {
-      ...
-      Synchronized<OnDemandUpdateIdMap>
-        adsToBeUpdated_,
-        limitsToBeUpdated_,
-        campaignsToBeUpdated_;
-      ...
-    };
-
-    void AdPublisherHandler::requestUpdateAdId(const int64_t adId,
-                                               const int32_t dbId) {
-      checkDbHandlingStatus(dbId);
-      SYNCHRONIZED (adsToBeUpdated_) {
-        adsToBeUpdated_[dbId][adId] = 1;
-      }
-      adPublisherMonitor_->addStatValue("request_adId_update", 1, dbId);
-      LOG(INFO) << "received request to update ad id " << adId;
-    }
-```
-
-The rewrite does at maximum efficiency what needs to be done:
-acquires the lock associated with the `OnDemandUpdateIdMap`
-object, writes to the map, and releases the lock immediately
-thereafter.
-
-On the face of it, that's not much to write home about, and not
-an obvious improvement over the previous state of affairs. But
-the features at work invisible in the code above are as important
-as those that are visible:
-
-* Unlike before, the data and the mutex protecting it are
-  inextricably encapsulated together.
-* Critical sections are readily visible and emphasize code that
-  needs to do minimal work and be subject to extra scrutiny.
-* Dangerous nested `SYNCHRONIZED` statements are more visible
-  than sequenced declarations of guards at the same level. (This
-  is not foolproof because a method call issued inside a
-  `SYNCHRONIZED` scope may open its own `SYNCHRONIZED` block.) A
-  construct `SYNCHRONIZED_DUAL`, discussed later in this
-  document, allows locking two objects quasi-simultaneously in
-  the same order in all threads, thus avoiding deadlocks.
-* If you tried to use `adsToBeUpdated_` outside the
-  `SYNCHRONIZED` scope, you wouldn't be able to; it is virtually
-  impossible to tease the map object without acquiring the
-  correct lock. However, inside the `SYNCHRONIZED` scope, the
-  *same* name serves as the actual underlying object of type
-  `OnDemandUpdateIdMap` (which is a map of maps).
-* Outside `SYNCHRONIZED`, if you just want to call one
-  method, you can do so by using `adsToBeUpdated_` as a
-  pointer like this:
-
-    `adsToBeUpdated_->clear();`
-
-This acquires the mutex, calls `clear()` against the underlying
-map object, and releases the mutex immediately thereafter.
-
-`Synchronized` offers several other methods, which are described
-in detail below.
-
-### Template class `Synchronized<T>`
-
-##### Constructors
-
-The default constructor default-initializes the data and its
-associated mutex.
+|:exclamation: `Synchronized` is deprecated            |
+|------------------------------------------------------|
+|Use `Locked` in new code instead of `Synchronized<T>` |
 
 
-The copy constructor locks the source for reading and copies its
-data into the target. (The target is not locked as an object
-under construction is only accessed by one thread.)
+### `Locked`
 
-Finally, `Synchronized<T>` defines an explicit constructor that
-takes an object of type `T` and copies it. For example:
+`Locked` is a newer replacement for `Synchronized`.  Like `Synchronized`, it
+provides a way for defining a variable and associated lock, and ensuring that
+the data can only be accessed with the lock held.
 
-``` Cpp
-    // Default constructed
-    Synchronized< map<string, int> > syncMap1;
+`Locked` has several advantages over `Synchronized`, but the primary ones are:
 
-    // Copy constructed
-    Synchronized< map<string, int> > syncMap2(syncMap1);
+* It eliminates the `SYNCHRONIZED` macro.  Besides the fact that preprocessor
+  macros are generally to be avoided, `SYNCHRONIZED` also had a few subtle
+  issues that turned out to be unfixable.
+* It uses exclusive locks by default, and when using shared locks it makes the
+  decision to obtain an exclusive lock versus a shared lock much more explicit.
+  With `Synchronized` this decision was usually implicit based on the
+  const-ness of the object, making it easy for code to unintentionally acquire
+  an exclusive lock when only a shared one was needed.
 
-    // Initializing from an existing map
-    map<string, int> init;
-    init["world"] = 42;
-    Synchronized< map<string, int> > syncMap3(init);
-    EXPECT_EQ(syncMap3->size(), 1);
-```
+### Differences between `Locked` and `Synchronized`
 
-#### Assignment, swap, and copying
+##### `SYNCHRONIZED`
 
-The canonical assignment operator locks both objects involved and
-then copies the underlying data objects. The mutexes are not
-copied. The locks are acquired in increasing address order, so
-deadlock is avoided. For example, there is no problem if one
-thread assigns `a = b` and the other assigns `b = a` (other than
-that design probably deserving a Razzie award). Similarly, the
-`swap` method takes a reference to another `Synchronized<T>`
-object and swaps the data. Again, locks are acquired in a well-
-defined order. The mutexes are not swapped.
+The main difference between `Synchronized` and `Locked` is that the
+`SYNCHRONIZED` macro is now gone.
 
-An additional assignment operator accepts a `const T&` on the
-right-hand side. The operator copies the datum inside a
-critical section.
+While this macro had some advantages (forcing a new scope when you acquired the
+lock), it had a number of disadvantages as well.  Besides being a preprocessor
+macro, and having all the disadvantages associated with that, there were
+several minor issues with it that could not be fixed.
 
-In addition to assignment operators, `Synchronized<T>` has move
-assignment operators.
+* It was implemented using `for` loops internally.  This resulted in confusing
+  behavior for `break` and `continue` statements inside `SYNCHRONIZED` blocks.
+  For instance
 
-An additional `swap` method accepts a `T&` and swaps the data
-inside a critical section. This is by far the preferred method of
-changing the guarded datum wholesale because it keeps the lock
-only for a short time, thus lowering the pressure on the mutex.
-
-To get a copy of the guarded data, there are two methods
-available: `void copy(T*)` and `T copy()`. The first copies data
-to a provided target and the second returns a copy by value. Both
-operations are done under a read lock. Example:
-
-``` Cpp
-    Synchronized< fbvector<fbstring> > syncVec1, syncVec2;
-    fbvector<fbstring> vec;
-
-    // Assign
-    syncVec1 = syncVec2;
-    // Assign straight from vector
-    syncVec1 = vec;
-
-    // Swap
-    syncVec1.swap(syncVec2);
-    // Swap with vector
-    syncVec1.swap(vec);
-
-    // Copy to given target
-    syncVec1.copy(&vec);
-    // Get a copy by value
-    auto copy = syncVec1.copy();
-```
-
-#### `LockedPtr operator->()` and `ConstLockedPtr operator->() const`
-
-We've already seen `operator->` at work. Essentially calling a
-method `obj->foo(x, y, z)` calls the method `foo(x, y, z)` inside
-a critical section as long-lived as the call itself. For example:
-
-``` Cpp
-    void fun(Synchronized< fbvector<fbstring> > & vec) {
-      vec->push_back("hello");
-      vec->push_back("world");
-    }
-```
-
-The code above appends two elements to `vec`, but the elements
-won't appear necessarily one after another. This is because in
-between the two calls the mutex is released, and another thread
-may modify the vector. At the cost of anticipating a little, if
-you want to make sure you insert "world" right after "hello", you
-should do this:
-
-``` Cpp
-    void fun(Synchronized< fbvector<fbstring> > & vec) {
-      SYNCHRONIZED (vec) {
-        vec.push_back("hello");
-        vec.push_back("world");
+  ```cpp
+  for (const auto* elem : lruQueue) {
+    SYNCHRONIZED(lockedElem, *elem) {
+      if (lockedElem.lastAccessedTime() > expirationTime) {
+        break;
       }
     }
-```
+  }
+  ```
 
-This brings us to a cautionary discussion. The way `operator->`
-works is rather ingenious with creating an unnamed temporary that
-enforces locking and all, but it's not a panacea. Between two
-uses of `operator->`, other threads may change the synchronized
-object in arbitrary ways, so you shouldn't assume any sort of
-sequential consistency. For example, the innocent-looking code
-below may be patently wrong.
+  This break statement would apply to the internal `for` loops that
+  `SYNCHRONIZED` expanded to, and would not break out of the loop that was
+  actually visible to anyone reading this code.
 
-If another thread clears the vector in between the call to
-`empty` and the call to `pop_back`, this code ends up attempting
-to extract an element from an empty vector. Needless to say,
-iteration a la:
+* Due to the way for loops were used internally, this often confused compilers
+  about possible function return paths, resulting in false positive warnings
+  about unreachable code.  (Particularly warnings about unreachable code paths
+  not returning a value from functions that return non-void.)
 
-``` Cpp
-    // No. NO. NO!
-    FOR_EACH_RANGE (i, vec->begin(), vec->end()) {
-      ...
-    }
-```
+##### `operator->()`
 
-is a crime punishable by long debugging nights.
+`Synchronized<T>` provided an `->` operator that returned a `LockedPtr` or
+`ConstLockedPtr` as appropriate.
 
-If the `Synchronized<T>` object involved is `const`-qualified,
-then you'll only be able to call `const` methods through `operator->`. 
-So, for example, `vec->push_back("xyz")` won't work if `vec`
-were `const`-qualified. The locking mechanism capitalizes on the
-assumption that `const` methods don't modify their underlying
-data and only acquires a read lock (as opposed to a read and
-write lock), which is cheaper but works only if the immutability
-assumption holds. Note that this is strictly not the case because
-`const`-ness can always be undone via `mutable` members, casts,
-and surreptitious access to shared data. Our code is seldom
-guilty of such, and we also assume the STL uses no shenanigans.
-But be warned.
+While this provided a convenient API for acquiring the lock without having to
+declare a `SYNCHRONIZED` block, it also had several pitfalls:
 
-#### `asConst()`
+* It was easy for callers to unintentionally write code that acquired and
+  released the lock multiple times, when it really should have been held for
+  the entire duration of the operation.
 
-Consider:
+  For example, the following code acquires and releases the lock separately for
+  the `begin()` and `end()` calls, and is not holding the lock at all for the
+  actual loop code.
 
-``` Cpp
-    void fun(Synchronized<fbvector<fbstring>> & vec) {
-      if (vec->size() > 1000000) {
-        LOG(WARNING) << "The blinkenlights are overloaded.";
-      }
-      vec->push_back("another blinkenlight");
-    }
-```
-
-This code is correct (at least according to a trivial intent),
-but less efficient than it could otherwise be. This is because
-the call `vec->size()` acquires a full read-write lock, but only
-needs a read lock. We need to help the type system here by
-telling it "even though `vec` is a mutable object, consider it a
-constant for this call". This should be easy enough because
-conversion to const is trivial - just issue `const_cast<const
-Synchronized<fbvector<fbstring>>&>(vec)`. Ouch. To make that
-operation simpler - a lot simpler - `Synchronized<T>` defines the
-method `asConst()`, which is a glorious one-liner. With `asConst`
-in tow, it's very easy to achieve what we wanted:
-
-``` Cpp
-    void fun(Synchronized<fbvector<fbstring>> & vec) {
-      if (vec.asConst()->size() > 1000000) {
-        LOG(WARNING) << "The blinkenlights are overloaded.";
-      }
-      vec->push_back("another blinkenlight");
-    }
-```
-
-QED (Quite Easy Done). This concludes the documentation for
-`Synchronized<T>`.
-
-### `SYNCHRONIZED`
-
-The `SYNCHRONIZED` macro introduces a pseudo-statement that adds
-a whole new level of usability to `Synchronized<T>`. As
-discussed, `operator->` can only lock over the duration of a
-call, so it is insufficient for complex operations. With
-`SYNCHRONIZED` you get to lock the object in a scoped manner (not
-unlike Java's `synchronized` statement) and to directly access
-the object inside that scope.
-
-`SYNCHRONIZED` has two forms. We've seen the first one a couple
-of times already:
-
-``` Cpp
-    void fun(Synchronized<fbvector<int>> & vec) {
-      SYNCHRONIZED (vec) {
-        vec.push_back(42);
-        CHECK(vec.back() == 42);
-        ...
-      }
-    }
-```
-
-The scope introduced by `SYNCHRONIZED` is a critical section
-guarded by `vec`'s mutex. In addition to doing that,
-`SYNCHRONIZED` also does an interesting sleight of hand: it binds
-the name `vec` inside the scope to the underlying `fbvector<int>`
-object - as opposed to `vec`'s normal type, which is
-`Synchronized<fbvector<int>>`. This fits very nice the "form
-follow function" - inside the critical section you have earned
-access to the actual data, and the name bindings reflect that as
-well. `SYNCHRONIZED(xyz)` essentially cracks `xyz` temporarily
-and gives you access to its innards.
-
-Now, what if `fun` wants to take a pointer to
-`Synchronized<fbvector<int>>` - let's call it `pvec`? Generally,
-what if we want to synchronize on an expression as opposed to a
-symbolic variable? In that case `SYNCHRONIZED(*pvec)` would not
-work because "`*pvec`" is not a name. That's where the second
-form of `SYNCHRONIZED` kicks in:
-
-``` Cpp
-    void fun(Synchronized<fbvector<int>> * pvec) {
-      SYNCHRONIZED (vec, *pvec) {
-        vec.push_back(42);
-        CHECK(vec.back() == 42);
-        ...
-      }
-    }
-```
-
-Ha, so now we pass two arguments to `SYNCHRONIZED`. The first
-argument is the name bound to the data, and the second argument
-is the expression referring to the `Synchronized<T>` object. So
-all cases are covered.
-
-### `SYNCHRONIZED_CONST`
-
-Recall from the discussion about `asConst()` that we
-sometimes want to voluntarily restrict access to an otherwise
-mutable object. The `SYNCHRONIZED_CONST` pseudo-statement
-makes that intent easily realizable and visible to
-maintainers. For example:
-
-``` Cpp
-    void fun(Synchronized<fbvector<int>> & vec) {
-      fbvector<int> local;
-      SYNCHRONIZED_CONST (vec) {
-        CHECK(vec.size() > 42);
-        local = vec;
-      }
-      local.resize(42000);
-      SYNCHRONIZED (vec) {
-        local.swap(vec);
-      }
-    }
-```
-
-Inside a `SYNCHRONIZED_CONST(xyz)` scope, `xyz` is bound to a `const`-
-qualified datum. The corresponding lock is a read lock.
-
-`SYNCHRONIZED_CONST` also has a two-arguments version, just like
-`SYNCHRONIZED`. In fact, `SYNCHRONIZED_CONST(a)` simply expands
-to `SYNCHRONIZED(a, a.asConst())` and `SYNCHRONIZED_CONST(a, b)`
-expands to `SYNCHRONIZED(a, (b).asConst())`. The type system and
-`SYNCHRONIZED` take care of the rest.
-
-### `TIMED_SYNCHRONIZED` and `TIMED_SYNCHRONIZED_CONST`
-
-These pseudo-statements allow you to acquire the mutex with a
-timeout. Example:
-
-``` Cpp
-    void fun(Synchronized<fbvector<int>> & vec) {
-      TIMED_SYNCHRONIZED (10, vec) {
-        if (vec) {
-          vec->push_back(42);
-          CHECK(vec->back() == 42);
-        } else {
-            LOG(INFO) << "Dognabbit, I've been waiting over here for 10 milliseconds and couldn't get through!";
-        }
-      }
-    }
-```
-
-If the mutex acquisition was successful within a number of
-milliseconds dictated by its first argument, `TIMED_SYNCHRONIZED`
-binds its second argument to a pointer to the protected object.
-Otherwise, the pointer will be `NULL`. (Contrast that with
-`SYNCHRONIZED`), which always succeeds so it binds the protected
-object to a reference.) Inside the `TIMED_SYNCHRONIZED` statement
-you must, of course, make sure the pointer is not null to make
-sure the operation didn't time out.
-
-`TIMED_SYNCHRONIZED` takes two or three parameters. The first is
-always the timeout, and the remaining one or two are just like
-the parameters of `SYNCHRONIZED`.
-
-Issuing `TIMED_SYNCHRONIZED` with a zero timeout is an
-opportunistic attempt to acquire the mutex.
-
-### `UNSYNCHRONIZED`
-
-`SYNCHRONIZED` is a good mechanism for enforcing scoped
-synchronization, but it has the inherent limitation that it
-requires the critical section to be, well, scoped. Sometimes the
-code structure requires a fleeting "escape" from the iron fist of
-synchronization. Clearly, simple cases are handled with sequenced
-`SYNCHRONIZED` scopes:
-
-``` Cpp
-    Synchronized<map<int, string>> dic;
+  ```cpp
+  Synchronized<vector<int>> vec;
+  FOR_EACH_RANGE (i, vec->begin(), vec->end()) {
     ...
-    SYNCHRONIZED (dic) {
-      if (dic.find(0) != dic.end()) {
-        return;
-      }
-    }
-    LOG(INFO) << "Key 0 not found, inserting it."
-    SYNCHRONIZED (dic) {
-      dic[0] = "zero";
-    }
+  }
+  ```
+
+* It led to callers acquiring a write lock when they really only needed a
+  read-lock.  As long as you had a non-const pointer or reference to the
+  object, `operator->` would acquire a write lock.
+
+  You could use the `asConst()` method to cast the object to const if you knew
+  you wanted a read-only lock, but it was very easy for callers to forget to do
+  this, and not realize they would be acquiring an exclusive lock.
+
+  With `Locked`, callers have to explicitly use `wlock()` or `rlock()` to hold
+  the lock, making this choice explicit.
+
+##### Move and swap operators
+
+`Synchronized<T>` provided a move constructor and move assignment operator that
+moved the underlying data, but not the lock.
+
+TODO: Should we retain this for `Locked`?  The fact that it does not move the
+lock seems potentially confusing, but I am not sure in what scenarios this will
+matter.
+
+With `Locked` you can construct a `Locked<T>` from an rvalue reference to `T`,
+but not an rvalue-reference to `Locked<T>`.
+
+##### std::condition_variable support
+
+`Locked<T, std::mutex>` supports using a `std::condition_variable` with the
+underlying mutex, while `Synchronized<T, std::mutex>` does not.
+
+##### std::chrono durations
+
+For acquiring the lock with a timeout, the `Locked<T>` APIs use `std::chrono`
+duration arguments, while `Synchronized<T>` uses plain integers, and treats
+them as milliseconds.
+
+
+### Converting code from `Locked` to `Synchronized`
+
+##### `SYNCHRONIZED`
+
+`SYNCHRONIZED` blocks can be converted from this:
+
+```cpp
+  Synchronized<MyObject> obj;
+  SYNCHRONIZED (obj) {
+    obj.doStuff();
+    obj.otherStuff();
+  }
 ```
 
-For more complex, nested flow control, you may want to use the
-`UNSYNCHRONIZED` macro. It (only) works inside a `SYNCHRONIZED`
-pseudo-statement and temporarily unlocks the mutex:
+to this:
 
-``` Cpp
-
-    Synchronized<map<int, string>> dic;
-    ...
-    SYNCHRONIZED (dic) {
-      auto i = dic.find(0);
-      if (i != dic.end()) {
-        UNSYNCHRONIZED (dic) {
-          LOG(INFO) << "Key 0 not found, inserting it."
-        }
-        dic[0] = "zero";
-      } else {
-        *i = "zero";
-      }
-    }
-    LOG(INFO) << "Key 0 not found, inserting it."
-    SYNCHRONIZED (dic) {
-      dic[0] = "zero";
-    }
+```cpp
+  Locked<MyObject> obj;
+  obj.withLock([](auto& locked) {
+    locked.doStuff();
+    locked.otherStuff();
+  });
 ```
 
-Clearly `UNSYNCHRONIZED` comes with specific caveats and
-liabilities. You must assume that during the `UNSYNCHRONIZED`
-section, other threads might have changed the protected structure
-in arbitrary ways. In the example above, you cannot use the
-iterator `i` and you cannot assume that the key `0` is not in the
-map; another thread might have inserted it while you were
-bragging on `LOG(INFO)`.
+or this:
 
-### `SYNCHRONIZED_DUAL`
-
-Sometimes locking just one object won't be able to cut the mustard. Consider a
-function that needs to lock two `Synchronized` objects at the
-same time - for example, to copy some data from one to the other.
-At first sight, it looks like nested `SYNCHRONIZED` statements
-will work just fine:
-
-``` Cpp
-    void fun(Synchronized<fbvector<int>> & a, Synchronized<fbvector<int>> & b) {
-      SYNCHRONIZED (a) {
-        SYNCHRONIZED (b) {
-          ... use a and b ...
-        }
-      }
-    }
+```cpp
+  Locked<MyObject> obj;
+  {
+    auto locked = obj.lock();
+    locked->doStuff();
+    locked->otherStuff();
+  }
 ```
 
-This code compiles and may even run most of the time, but embeds
-a deadly peril: if one threads call `fun(x, y)` and another
-thread calls `fun(y, x)`, then the two threads are liable to
-deadlocking as each thread will be waiting for a lock the other
-is holding. This issue is a classic that applies regardless of
-the fact the objects involved have the same type.
+##### Single statements
 
-This classic problem has a classic solution: all threads must
-acquire locks in the same order. The actual order is not
-important, just the fact that the order is the same in all
-threads. Many libraries simply acquire mutexes in increasing
-order of their address, which is what we'll do, too. The pseudo-
-statement `SYNCHRONIZED_DUAL` takes care of all details of proper
-locking of two objects and offering their innards:
+Statements that used `operator->` to acquire the lock implicitly can be
+converted from this:
 
-``` Cpp
-    void fun(Synchronized<fbvector<int>> & a, Synchronized<fbvector<int>> & b) {
-      SYNCHRONIZED_DUAL (myA, a, myB, b) {
-        ... use myA and myB ...
-      }
-    }
+```cpp
+  Synchronized<MyObject> obj;
+  obj->doStuff();
 ```
 
-To avoid potential confusions, `SYNCHRONIZED_DUAL` only defines a
-four-arguments version. The code above locks `a` and `b` in
-increasing order of their address and offers their data under the
-names `myA` and `myB`, respectively.
+to this:
 
-### Synchronizing several data items with one mutex
-
-The library is geared at protecting one object of a given type
-with a mutex. However, sometimes we'd like to protect two or more
-members with the same mutex. Consider for example a bidirectional
-map, i.e. a map that holds an `int` to `string` mapping and also
-the converse `string` to `int` mapping. The two maps would need
-to be manipulated simultaneously. There are at least two designs
-that come to mind.
-
-#### Using a nested `struct`
-
-You can easily pack the needed data items in a little struct.
-For example:
-
-``` Cpp
-    class Server {
-      struct BiMap {
-        map<int, string> direct;
-        map<string, int> inverse;
-      };
-      Synchronized<BiMap> bimap_;
-      ...
-    };
-    ...
-    SYNCHRONIZED (bymap_) {
-      bymap_.direct[0] = "zero";
-      bymap_.inverse["zero"] = 0;
-    }
+```cpp
+  Locked<MyObject> obj;
+  obj.lock()->doStuff();
 ```
-
-With this code in tow you get to use `bimap_` just like any other
-`Synchronized` object, without much effort.
-
-#### Using `std::tuple`
-
-If you won't stop short of using a spaceship-era approach,
-`std::tuple` is there for you. The example above could be
-rewritten for the same functionality like this:
-
-``` Cpp
-    class Server {
-      Synchronized<tuple<map<int, string>, map<string, int>>> bimap_;
-      ...
-    };
-    ...
-    SYNCHRONIZED (bymap_) {
-      get<0>(bymap_)[0] = "zero";
-      get<1>(bymap_)["zero"] = 0;
-    }
-```
-
-The code uses `std::get` with compile-time integers to access the
-fields in the tuple. The relative advantages and disadvantages of
-using a local struct vs. `std::tuple` are quite obvious - in the
-first case you need to invest in the definition, in the second
-case you need to put up with slightly more verbose and less clear
-access syntax.
-
-### Summary
-
-`Synchronized` and its supporting tools offer you a simple,
-robust paradigm for mutual exclusion-based concurrency. Instead
-of manually pairing data with the mutexes that protect it and
-relying on convention to use them appropriately, you can benefit
-of encapsulation and typechecking to offload a large part of that
-task and to provide good guarantees.

--- a/folly/test/LockTraitsTest.cpp
+++ b/folly/test/LockTraitsTest.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/LockTraits.h>
+#include <folly/LockTraitsBoost.h>
+
+#include <gtest/gtest.h>
+#include <mutex>
+
+#include <folly/RWSpinLock.h>
+#include <folly/SharedMutex.h>
+#include <folly/SpinLock.h>
+
+using namespace folly;
+
+TEST(LockTraits, std_mutex) {
+  static_assert(
+      !LockTraits<std::mutex>::has_timed_lock,
+      "std:mutex does not have timed acquire");
+  static_assert(
+      !LockTraits<std::mutex>::is_shared, "std:mutex is not a read-write lock");
+
+  std::mutex mutex;
+  LockTraits<std::mutex>::lock(mutex);
+  LockTraits<std::mutex>::unlock(mutex);
+}
+
+TEST(LockTraits, SharedMutex) {
+  static_assert(
+      LockTraits<SharedMutex>::has_timed_lock, "SharedMutex has timed acquire");
+  static_assert(
+      LockTraits<SharedMutex>::is_shared, "SharedMutex is a read-write lock");
+
+  SharedMutex mutex;
+  LockTraits<SharedMutex>::lock(mutex);
+  LockTraits<SharedMutex>::unlock(mutex);
+
+  LockTraits<SharedMutex>::lock_shared(mutex);
+  LockTraits<SharedMutex>::lock_shared(mutex);
+  LockTraits<SharedMutex>::unlock_shared(mutex);
+  LockTraits<SharedMutex>::unlock_shared(mutex);
+}
+
+TEST(LockTraits, SpinLock) {
+  static_assert(
+      !LockTraits<SpinLock>::has_timed_lock,
+      "folly::SpinLock does not have timed acquire");
+  static_assert(
+      !LockTraits<SpinLock>::is_shared,
+      "folly::SpinLock is not a read-write lock");
+
+  SpinLock mutex;
+  LockTraits<SpinLock>::lock(mutex);
+  LockTraits<SpinLock>::unlock(mutex);
+}
+
+TEST(LockTraits, RWSpinLock) {
+  static_assert(
+      !LockTraits<RWSpinLock>::has_timed_lock,
+      "folly::RWSpinLock does not have timed acquire");
+  static_assert(
+      LockTraits<RWSpinLock>::is_shared,
+      "folly::RWSpinLock is a read-write lock");
+
+  RWSpinLock mutex;
+  LockTraits<RWSpinLock>::lock(mutex);
+  LockTraits<RWSpinLock>::unlock(mutex);
+
+  LockTraits<RWSpinLock>::lock_shared(mutex);
+  LockTraits<RWSpinLock>::lock_shared(mutex);
+  LockTraits<RWSpinLock>::unlock_shared(mutex);
+  LockTraits<RWSpinLock>::unlock_shared(mutex);
+}
+
+TEST(LockTraits, boost_mutex) {
+  static_assert(
+      !LockTraits<boost::mutex>::has_timed_lock,
+      "boost::mutex does not have timed acquire");
+  static_assert(
+      !LockTraits<boost::mutex>::is_shared,
+      "boost::mutex is not a read-write lock");
+
+  boost::mutex mutex;
+  LockTraits<boost::mutex>::lock(mutex);
+  LockTraits<boost::mutex>::unlock(mutex);
+}
+
+TEST(LockTraits, boost_recursive_mutex) {
+  static_assert(
+      !LockTraits<boost::mutex>::has_timed_lock,
+      "boost::recursive_mutex does not have timed acquire");
+  static_assert(
+      !LockTraits<boost::recursive_mutex>::is_shared,
+      "boost::recursive_mutex is not a read-write lock");
+
+  boost::recursive_mutex mutex;
+  LockTraits<boost::recursive_mutex>::lock(mutex);
+  LockTraits<boost::recursive_mutex>::unlock(mutex);
+}
+
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+TEST(LockTraits, timed_mutex) {
+  static_assert(
+      LockTraits<std::timed_mutex>::has_timed_lock,
+      "std::timed_mutex supports timed acquire");
+  static_assert(
+      !LockTraits<std::timed_mutex>::is_shared,
+      "std::timed_mutex is not a read-write lock");
+
+  std::timed_mutex mutex;
+  LockTraits<std::timed_mutex>::lock(mutex);
+  bool gotLock = LockTraits<std::timed_mutex>::try_lock_for(
+      mutex, std::chrono::milliseconds(1));
+  EXPECT_FALSE(gotLock) << "should not have been able to acquire the "
+                        << "timed_mutex a second time";
+  LockTraits<std::timed_mutex>::unlock(mutex);
+}
+
+TEST(LockTraits, recursive_timed_mutex) {
+  static_assert(
+      LockTraits<std::recursive_timed_mutex>::has_timed_lock,
+      "std::recursive_timed_mutex supports timed acquire");
+  static_assert(
+      !LockTraits<std::recursive_timed_mutex>::is_shared,
+      "std::recursive_timed_mutex is not a read-write lock");
+
+  std::recursive_timed_mutex mutex;
+  LockTraits<std::recursive_timed_mutex>::lock(mutex);
+  auto gotLock = LockTraits<std::recursive_timed_mutex>::try_lock_for(
+      mutex, std::chrono::milliseconds(10));
+  EXPECT_TRUE(gotLock) << "should have been able to acquire the "
+                       << "recursive_timed_mutex a second time";
+  LockTraits<std::recursive_timed_mutex>::unlock(mutex);
+  LockTraits<std::recursive_timed_mutex>::unlock(mutex);
+}
+
+TEST(LockTraits, boost_shared_mutex) {
+  static_assert(
+      LockTraits<boost::shared_mutex>::has_timed_lock,
+      "boost::shared_mutex supports timed acquire");
+  static_assert(
+      LockTraits<boost::shared_mutex>::is_shared,
+      "boost::shared_mutex is a read-write lock");
+
+  boost::shared_mutex mutex;
+  LockTraits<boost::shared_mutex>::lock(mutex);
+  auto gotLock = LockTraits<boost::shared_mutex>::try_lock_for(
+      mutex, std::chrono::milliseconds(1));
+  EXPECT_FALSE(gotLock) << "should not have been able to acquire the "
+                        << "shared_mutex a second time";
+  gotLock = LockTraits<boost::shared_mutex>::try_lock_shared_for(
+      mutex, std::chrono::milliseconds(1));
+  EXPECT_FALSE(gotLock) << "should not have been able to acquire the "
+                        << "shared_mutex a second time";
+  LockTraits<boost::shared_mutex>::unlock(mutex);
+
+  LockTraits<boost::shared_mutex>::lock_shared(mutex);
+  gotLock = LockTraits<boost::shared_mutex>::try_lock_for(
+      mutex, std::chrono::milliseconds(1));
+  EXPECT_FALSE(gotLock) << "should not have been able to acquire the "
+                        << "shared_mutex a second time";
+  gotLock = LockTraits<boost::shared_mutex>::try_lock_shared_for(
+      mutex, std::chrono::milliseconds(10));
+  EXPECT_TRUE(gotLock) << "should have been able to acquire the "
+                       << "shared_mutex a second time in shared mode";
+  LockTraits<boost::shared_mutex>::unlock_shared(mutex);
+  LockTraits<boost::shared_mutex>::unlock_shared(mutex);
+}
+#endif // FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES

--- a/folly/test/LockedTest.cpp
+++ b/folly/test/LockedTest.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Test bed for folly/Locked.h
+
+#include <folly/Locked.h>
+
+#include <boost/thread.hpp>
+#include <folly/Portability.h>
+#include <folly/RWSpinLock.h>
+#include <folly/SharedMutex.h>
+#include <folly/SpinLock.h>
+#include <folly/test/LockedTestLib.h>
+#include <gtest/gtest.h>
+#include <mutex>
+#include <shared_mutex>
+
+using namespace folly::locked_tests;
+
+namespace {
+
+template <class Mutex>
+class LockedTest : public testing::Test {};
+
+using LockedTestTypes = testing::Types<
+    folly::SharedMutexReadPriority,
+    folly::SharedMutexWritePriority,
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+    std::timed_mutex,
+    std::shared_timed_mutex,
+    std::recursive_timed_mutex,
+#endif
+    boost::mutex,
+    boost::recursive_mutex,
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+    boost::timed_mutex,
+    boost::recursive_timed_mutex,
+#endif
+    boost::shared_mutex,
+    folly::SpinLock,
+#ifdef RW_SPINLOCK_USE_X86_INTRINSIC_
+    folly::RWTicketSpinLock32,
+    folly::RWTicketSpinLock64,
+#endif
+    std::mutex,
+    std::recursive_mutex>;
+TYPED_TEST_CASE(LockedTest, LockedTestTypes);
+
+TYPED_TEST(LockedTest, Basic) {
+  testBasic<TypeParam>();
+}
+
+TYPED_TEST(LockedTest, Concurrency) {
+  testConcurrency<TypeParam>();
+}
+
+TYPED_TEST(LockedTest, DualLocking) {
+  testDualLocking<TypeParam>();
+}
+
+TYPED_TEST(LockedTest, DualLockingShared) {
+  testDualLockingShared<TypeParam>();
+}
+
+TYPED_TEST(LockedTest, ConstCopy) {
+  testConstCopy<TypeParam>();
+}
+
+template <class Mutex>
+class LockedTimedTest : public testing::Test {};
+
+using LockedTimedTestTypes = testing::Types<
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+    std::timed_mutex,
+    std::shared_timed_mutex,
+    std::recursive_timed_mutex,
+    boost::timed_mutex,
+    boost::recursive_timed_mutex,
+    boost::shared_mutex,
+#endif
+#ifdef RW_SPINLOCK_USE_X86_INTRINSIC_
+    folly::RWTicketSpinLock32,
+    folly::RWTicketSpinLock64,
+#endif
+    folly::SharedMutexReadPriority,
+    folly::SharedMutexWritePriority>;
+TYPED_TEST_CASE(LockedTimedTest, LockedTimedTestTypes);
+
+TYPED_TEST(LockedTimedTest, Timed) {
+  testTimed<TypeParam>();
+}
+
+template <class Mutex>
+class LockedTimedRWTest : public testing::Test {};
+
+using LockedTimedRWTestTypes = testing::Types<
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+    boost::shared_mutex,
+    std::shared_timed_mutex,
+#endif
+#ifdef RW_SPINLOCK_USE_X86_INTRINSIC_
+    folly::RWTicketSpinLock32,
+    folly::RWTicketSpinLock64,
+#endif
+    folly::SharedMutexReadPriority,
+    folly::SharedMutexWritePriority>;
+TYPED_TEST_CASE(LockedTimedRWTest, LockedTimedRWTestTypes);
+
+TYPED_TEST(LockedTimedRWTest, TimedSynchronizeRW) {
+  testTimedSynchronizedRW<TypeParam>();
+}
+
+TYPED_TEST(LockedTest, InPlaceConstruction) {
+  testInPlaceConstruction<TypeParam>();
+}
+
+using CountPair = std::pair<int, int>;
+// This class is specialized only to be uesed in LockedLockTest
+class FakeMutex {
+ public:
+  bool lock() {
+    ++lockCount_;
+    return true;
+  }
+
+  bool unlock() {
+    ++unlockCount_;
+    return true;
+  }
+
+  static CountPair getLockUnlockCount() {
+    return CountPair{lockCount_, unlockCount_};
+  }
+
+  static void resetLockUnlockCount() {
+    lockCount_ = 0;
+    unlockCount_ = 0;
+  }
+ private:
+  // Keep these two static for test access
+  // Keep them thread_local in case of tests are run in parallel within one
+  // process
+  static FOLLY_TLS int lockCount_;
+  static FOLLY_TLS int unlockCount_;
+};
+FOLLY_TLS int FakeMutex::lockCount_{0};
+FOLLY_TLS int FakeMutex::unlockCount_{0};
+
+// LockedLockTest is used to verify the correct lock unlock behavior
+// happens per design
+class LockedLockTest : public testing::Test {
+ public:
+  void SetUp() override {
+    FakeMutex::resetLockUnlockCount();
+  }
+};
+
+// Single level of lock() and scopedUnlock(), although nested test are
+// super set of it, it is possible single level test passes while nested tests
+// fail
+TEST_F(LockedLockTest, LockUnlock) {
+  folly::Locked<std::vector<int>, FakeMutex> obj;
+  EXPECT_EQ((CountPair{0, 0}), FakeMutex::getLockUnlockCount());
+  {
+    auto lptr = obj.lock();
+    EXPECT_EQ((CountPair{1, 0}), FakeMutex::getLockUnlockCount());
+    {
+      auto unlocker = lptr.scopedUnlock();
+      EXPECT_EQ((CountPair{1, 1}), FakeMutex::getLockUnlockCount());
+    }
+    EXPECT_EQ((CountPair{2, 1}), FakeMutex::getLockUnlockCount());
+  }
+  EXPECT_EQ((CountPair{2, 2}), FakeMutex::getLockUnlockCount());
+}
+
+// Nested lock() and scopedUnlock() test, 2 levels for each are used here
+TEST_F(LockedLockTest, NestedSyncUnSync) {
+  folly::Locked<std::vector<int>, FakeMutex> obj;
+  EXPECT_EQ((CountPair{0, 0}), FakeMutex::getLockUnlockCount());
+  {
+    auto lptr1 = obj.lock();
+    EXPECT_EQ((CountPair{1, 0}), FakeMutex::getLockUnlockCount());
+    {
+      auto lptr2 = obj.lock();
+      EXPECT_EQ((CountPair{2, 0}), FakeMutex::getLockUnlockCount());
+      {
+        auto unlocker2 = lptr2.scopedUnlock();
+        EXPECT_EQ((CountPair{2, 1}), FakeMutex::getLockUnlockCount());
+        {
+          auto unlocker1 = lptr1.scopedUnlock();
+          EXPECT_EQ((CountPair{2, 2}),
+                    FakeMutex::getLockUnlockCount());
+        }
+        EXPECT_EQ((CountPair{3, 2}), FakeMutex::getLockUnlockCount());
+      }
+      EXPECT_EQ((CountPair{4, 2}), FakeMutex::getLockUnlockCount());
+    }
+    EXPECT_EQ((CountPair{4, 3}), FakeMutex::getLockUnlockCount());
+  }
+  EXPECT_EQ((CountPair{4, 4}), FakeMutex::getLockUnlockCount());
+}
+
+// Different nesting behavior, scopedUnlock() called on different depth from
+// the corresponding lock()
+TEST_F(LockedLockTest, NestedSyncUnSync2) {
+  folly::Locked<std::vector<int>, FakeMutex> obj;
+  EXPECT_EQ((CountPair{0, 0}), FakeMutex::getLockUnlockCount());
+  {
+    auto lptr1 = obj.lock();
+    EXPECT_EQ((CountPair{1, 0}), FakeMutex::getLockUnlockCount());
+    {
+      auto lptr2 = obj.lock();
+      EXPECT_EQ((CountPair{2, 0}), FakeMutex::getLockUnlockCount());
+      {
+        auto unlocker = lptr2.scopedUnlock();
+        EXPECT_EQ((CountPair{2, 1}), FakeMutex::getLockUnlockCount());
+      }
+      EXPECT_EQ((CountPair{3, 1}), FakeMutex::getLockUnlockCount());
+    }
+    EXPECT_EQ((CountPair{3, 2}), FakeMutex::getLockUnlockCount());
+    {
+      auto unlocker = lptr1.scopedUnlock();
+      EXPECT_EQ((CountPair{3, 3}), FakeMutex::getLockUnlockCount());
+    }
+    EXPECT_EQ((CountPair{4, 3}), FakeMutex::getLockUnlockCount());
+  }
+  EXPECT_EQ((CountPair{4, 4}), FakeMutex::getLockUnlockCount());
+}
+}

--- a/folly/test/LockedTestLib-inl.h
+++ b/folly/test/LockedTestLib-inl.h
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include <folly/Foreach.h>
+#include <folly/LockTraitsBoost.h>
+#include <folly/Locked.h>
+#include <folly/Random.h>
+#include <glog/logging.h>
+#include <algorithm>
+#include <condition_variable>
+#include <functional>
+#include <map>
+#include <random>
+#include <thread>
+#include <type_traits>
+#include <vector>
+
+namespace {
+inline std::mt19937& getRNG() {
+  static const auto seed = folly::randomNumberSeed();
+  static std::mt19937 rng(seed);
+  return rng;
+}
+
+void randomSleep(std::chrono::milliseconds min, std::chrono::milliseconds max) {
+  std::uniform_int_distribution<> range(min.count(), max.count());
+  std::chrono::milliseconds duration(range(getRNG()));
+  std::this_thread::sleep_for(duration);
+}
+} // unnamed namespace
+
+namespace folly {
+namespace locked_tests {
+
+template <class Mutex>
+typename std::enable_if<folly::LockTraits<Mutex>::is_shared>::type
+testBasicImpl() {
+  folly::Locked<std::vector<int>, Mutex> obj;
+
+  obj.wlock()->resize(1000);
+
+  folly::Locked<std::vector<int>, Mutex> obj2{*obj.wlock()};
+  EXPECT_EQ(obj2.rlock()->size(), 1000);
+
+  {
+    auto lockedObj = obj.wlock();
+    lockedObj->push_back(10);
+    EXPECT_EQ(lockedObj->size(), 1001);
+    EXPECT_EQ(lockedObj->back(), 10);
+    EXPECT_EQ(obj2.wlock()->size(), 1000);
+
+    {
+      auto unlocker = lockedObj.scopedUnlock();
+      EXPECT_EQ(obj.rlock()->size(), 1001);
+    }
+  }
+
+  {
+    auto lockedObj = obj.rlock();
+    EXPECT_EQ(lockedObj->size(), 1001);
+    {
+      auto unlocker = lockedObj.scopedUnlock();
+      EXPECT_EQ(obj.rlock()->size(), 1001);
+    }
+  }
+
+  {
+    auto lockedObj = obj.wlock();
+    lockedObj->front() = 2;
+  }
+
+  EXPECT_EQ(obj.rlock()->size(), 1001);
+  EXPECT_EQ(obj.rlock()->back(), 10);
+  EXPECT_EQ(obj2.rlock()->size(), 1000);
+
+  auto size = obj.withWLock([](std::vector<int>& vec) {
+    vec.push_back(9);
+    return vec.size();
+  });
+
+  EXPECT_EQ(size, 1002);
+  EXPECT_EQ(obj.rlock()->size(), 1002);
+  EXPECT_EQ(obj.rlock()->back(), 9);
+
+  auto size2 = obj.withRLock([](const std::vector<int>& vec) {
+    EXPECT_EQ(vec.size(), 1002);
+    return vec.size();
+  });
+  EXPECT_EQ(size2, 1002);
+
+  const auto& constObj = obj;
+  auto size3 = constObj.withWLock([](const std::vector<int>& vec) {
+    EXPECT_EQ(vec.back(), 9);
+    return vec.size();
+  });
+  EXPECT_EQ(size3, 1002);
+
+  // Note: gcc 4.8 doesn't support generic lambdas, so we can't use auto&&
+  // here as the argument type yet.
+  //
+  // However, even with generic lambdas, this still isn't quite convenient to
+  // use, since withWLockPtr() has both const and non-const overloads, and we
+  // can't really use an auto argument since it the compiler can't tell
+  // which overload its should prefer.
+  auto size4 = obj.withWLockPtr(
+      [](typename folly::Locked<std::vector<int>, Mutex>::LockedPtr&& vec) {
+        vec->push_back(13);
+        return vec->size();
+      });
+  EXPECT_EQ(size4, 1003);
+  EXPECT_EQ(obj.rlock()->back(), 13);
+}
+
+template <class Mutex>
+typename std::enable_if<!folly::LockTraits<Mutex>::is_shared>::type
+testBasicImpl() {
+  folly::Locked<std::vector<int>, Mutex> obj;
+
+  obj.lock()->resize(1000);
+
+  folly::Locked<std::vector<int>, Mutex> obj2{*obj.lock()};
+  EXPECT_EQ(obj2.lock()->size(), 1000);
+
+  {
+    auto lockedObj = obj.lock();
+    lockedObj->push_back(10);
+    EXPECT_EQ(lockedObj->size(), 1001);
+    EXPECT_EQ(lockedObj->back(), 10);
+    EXPECT_EQ(obj2.lock()->size(), 1000);
+
+    {
+      auto unlocker = lockedObj.scopedUnlock();
+      EXPECT_EQ(obj.lock()->size(), 1001);
+    }
+  }
+
+  {
+    auto lockedObj = obj.lock();
+    EXPECT_EQ(lockedObj->size(), 1001);
+    {
+      auto unlocker = lockedObj.scopedUnlock();
+      EXPECT_EQ(obj.lock()->size(), 1001);
+    }
+  }
+
+  {
+    auto lockedObj = obj.lock();
+    lockedObj->front() = 2;
+  }
+
+  EXPECT_EQ(obj.lock()->size(), 1001);
+  EXPECT_EQ(obj.lock()->back(), 10);
+  EXPECT_EQ(obj2.lock()->size(), 1000);
+
+  auto size = obj.withLock([](std::vector<int>& vec) {
+    vec.push_back(9);
+    return vec.size();
+  });
+
+  EXPECT_EQ(size, 1002);
+  EXPECT_EQ(obj.lock()->size(), 1002);
+  EXPECT_EQ(obj.lock()->back(), 9);
+
+  auto size2 = obj.withLock([](const std::vector<int>& vec) {
+    EXPECT_EQ(vec.size(), 1002);
+    return vec.size();
+  });
+  EXPECT_EQ(size2, 1002);
+
+  const auto& constObj = obj;
+  auto size3 = constObj.withLock([](const std::vector<int>& vec) {
+    EXPECT_EQ(vec.back(), 9);
+    return vec.size();
+  });
+  EXPECT_EQ(size3, 1002);
+
+  auto size4 = obj.withLockPtr(
+      [](typename folly::Locked<std::vector<int>, Mutex>::LockedPtr&& vec) {
+        vec->push_back(13);
+        return vec->size();
+      });
+  EXPECT_EQ(size4, 1003);
+  EXPECT_EQ(obj.lock()->back(), 13);
+}
+
+template <class Mutex>
+void testBasic() {
+  testBasicImpl<Mutex>();
+}
+
+/*
+ * Run a functon simultaneously in a number of different threads.
+ *
+ * The function will be passed the index number of the thread it is running in.
+ * This function makes an attempt to synchronize the start of the threads as
+ * best as possible.  (It waits for all threads to be allocated and started
+ * before invoking the function.)
+ */
+template <class Function>
+void runParallel(size_t numThreads, const Function& function) {
+  std::vector<std::thread> threads;
+
+  // Variables used to synchronize all threads to try and start them
+  // as close to the same time as possible
+  folly::Locked<size_t> threadsReady(0);
+  std::condition_variable readyCV;
+  folly::Locked<bool> go(false);
+  std::condition_variable goCV;
+
+  auto worker = [&](size_t threadIndex) {
+    // Signal that we are ready
+    ++(*threadsReady.lock());
+    readyCV.notify_one();
+
+    // Wait until we are given the signal to start
+    // The purpose of this is to try and make sure all threads start
+    // as close to the same time as possible.
+    {
+      auto lockedGo = go.lock();
+      while (!*lockedGo) {
+        goCV.wait(lockedGo.getUniqueLock());
+      }
+    }
+
+    function(threadIndex);
+  };
+
+  // Start all of the threads
+  for (size_t threadIndex = 0; threadIndex < numThreads; ++threadIndex) {
+    threads.push_back(
+        std::thread([threadIndex, &worker]() { worker(threadIndex); }));
+  }
+
+  // Wait for all threads to become ready
+  {
+    auto readyLocked = threadsReady.lock();
+    while (*readyLocked < numThreads) {
+      readyCV.wait(readyLocked.getUniqueLock());
+    }
+    go = true;
+  }
+  // Now signal the threads that they can go
+  goCV.notify_all();
+
+  // Wait for all threads to finish
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}
+
+template <class Mutex>
+void testConcurrency() {
+  folly::Locked<std::vector<int>, Mutex> v;
+  static const size_t numThreads = 100;
+  // Note: I initially tried using itersPerThread = 1000,
+  // which works fine for most lock types, but std::shared_timed_mutex
+  // appears to be extraordinarily slow.  It could take around 30 seconds
+  // to run this test with 1000 iterations per thread using shared_timed_mutex.
+  static const size_t itersPerThread = 100;
+
+  auto pushNumbers = [&](size_t threadIdx) {
+    // Test lock()
+    for (size_t n = 0; n < itersPerThread; ++n) {
+      v.contextualLock()->push_back((itersPerThread * threadIdx) + n);
+      sched_yield();
+    }
+  };
+  runParallel(numThreads, pushNumbers);
+
+  std::vector<int> result;
+  v.swapData(result);
+
+  EXPECT_EQ(result.size(), itersPerThread * numThreads);
+  sort(result.begin(), result.end());
+
+  for (size_t i = 0; i < itersPerThread * numThreads; ++i) {
+    EXPECT_EQ(result[i], i);
+  }
+}
+
+template <class Mutex>
+void testDualLocking() {
+  folly::Locked<std::vector<int>, Mutex> v;
+  folly::Locked<std::map<int, int>, Mutex> m;
+
+  auto dualLockWorker = [&](size_t threadIdx) {
+    if (threadIdx & 1) {
+      auto ret = folly::acquireLocked(v, m);
+      std::get<0>(ret)->push_back(threadIdx);
+      (*std::get<1>(ret))[threadIdx] = threadIdx + 1;
+    } else {
+      auto ret = folly::acquireLocked(m, v);
+      std::get<1>(ret)->push_back(threadIdx);
+      (*std::get<0>(ret))[threadIdx] = threadIdx + 1;
+    }
+  };
+
+  static const size_t numThreads = 100;
+  runParallel(numThreads, dualLockWorker);
+
+  std::vector<int> result;
+  v.swapData(result);
+
+  EXPECT_EQ(result.size(), numThreads);
+  sort(result.begin(), result.end());
+
+  for (size_t i = 0; i < numThreads; ++i) {
+    EXPECT_EQ(result[i], i);
+  }
+}
+
+template <class Mutex>
+void testDualLockingShared() {
+  folly::Locked<std::vector<int>, Mutex> v;
+  folly::Locked<std::map<int, int>, Mutex> m;
+
+  auto dualLockWorker = [&](size_t threadIdx) {
+    if (threadIdx & 1) {
+      auto ret = folly::acquireLocked(v, m);
+      (void)std::get<1>(ret)->size();
+      std::get<0>(ret)->push_back(threadIdx);
+    } else {
+      auto ret = folly::acquireLocked(m, v);
+      (void)std::get<0>(ret)->size();
+      std::get<1>(ret)->push_back(threadIdx);
+    }
+  };
+
+  static const size_t numThreads = 100;
+  runParallel(numThreads, dualLockWorker);
+
+  std::vector<int> result;
+  v.swapData(result);
+
+  EXPECT_EQ(result.size(), numThreads);
+  sort(result.begin(), result.end());
+
+  for (size_t i = 0; i < numThreads; ++i) {
+    EXPECT_EQ(result[i], i);
+  }
+}
+
+template <class Mutex>
+void testTimed() {
+  folly::Locked<std::vector<int>, Mutex> v;
+  folly::Locked<uint64_t, Mutex> numTimeouts;
+
+  auto worker = [&](size_t threadIdx) {
+    // Test directly using operator-> on the lock result
+    v.contextualLock()->push_back(2 * threadIdx);
+
+    // Test using lock with a timeout
+    for (;;) {
+      auto lv = v.contextualLock(std::chrono::milliseconds(5));
+      if (!lv) {
+        ++(*numTimeouts.contextualLock());
+        continue;
+      }
+
+      // Sleep for a random time to ensure we trigger timeouts in other threads
+      randomSleep(std::chrono::milliseconds(5), std::chrono::milliseconds(15));
+      lv->push_back(2 * threadIdx + 1);
+      break;
+    }
+  };
+
+  static const size_t numThreads = 100;
+  runParallel(numThreads, worker);
+
+  std::vector<int> result;
+  v.swapData(result);
+
+  EXPECT_EQ(result.size(), 2 * numThreads);
+  sort(result.begin(), result.end());
+
+  for (size_t i = 0; i < 2 * numThreads; ++i) {
+    EXPECT_EQ(result[i], i);
+  }
+  // We generally expect a large number of number timeouts here.
+  // I'm not adding a check for it since it's theoretically possible that
+  // we might get 0 timeouts depending on the CPU scheduling if our threads
+  // don't get to run very often.
+  LOG(INFO) << "testTimedSynchronized: " << *(numTimeouts.contextualRLock())
+            << " timeouts";
+}
+
+template <class Mutex>
+void testTimedSynchronizedRW() {
+  folly::Locked<std::vector<int>, Mutex> v;
+  folly::Locked<uint64_t, Mutex> numTimeouts(0);
+
+  auto worker = [&](size_t threadIdx) {
+    // Test directly using operator-> on the lock result
+    v.wlock()->push_back(threadIdx);
+
+    // Test lock() with a timeout
+    for (;;) {
+      auto lv = v.rlock(std::chrono::milliseconds(10));
+      if (!lv) {
+        ++(*numTimeouts.wlock());
+        continue;
+      }
+
+      // Sleep while holding the lock.
+      //
+      // This will block other threads from acquiring the write lock to add
+      // their thread index to v, but it won't block threads that have entered
+      // the for loop and are trying to acquire a read lock.
+      //
+      // For lock types that give preference to readers rather than writers,
+      // this will tend to serialize all threads on the wlock() above.
+      randomSleep(std::chrono::milliseconds(5), std::chrono::milliseconds(15));
+      auto found = std::find(lv->begin(), lv->end(), threadIdx);
+      CHECK(found != lv->end());
+      break;
+    }
+  };
+
+  static const size_t numThreads = 100;
+  runParallel(numThreads, worker);
+
+  std::vector<int> result;
+  v.swapData(result);
+
+  EXPECT_EQ(result.size(), numThreads);
+  sort(result.begin(), result.end());
+
+  for (size_t i = 0; i < numThreads; ++i) {
+    EXPECT_EQ(result[i], i);
+  }
+  // We generally expect a small number of timeouts here.
+  // For locks that give readers preference over writers this should usually
+  // be 0.  With locks that give writers preference we do see a small-ish
+  // number of read timeouts.
+  LOG(INFO) << "testTimedSynchronizedRW: " << *numTimeouts.rlock()
+            << " timeouts";
+}
+
+template <class Mutex> void testConstCopy() {
+  std::vector<int> input = {1, 2, 3};
+  const folly::Locked<std::vector<int>, Mutex> v(input);
+
+  std::vector<int> result;
+
+  v.copy(&result);
+  EXPECT_EQ(result, input);
+
+  result = v.copy();
+  EXPECT_EQ(result, input);
+}
+
+struct NotCopiableNotMovable {
+  NotCopiableNotMovable(int, const char*) {}
+  NotCopiableNotMovable(const NotCopiableNotMovable&) = delete;
+  NotCopiableNotMovable& operator=(const NotCopiableNotMovable&) = delete;
+  NotCopiableNotMovable(NotCopiableNotMovable&&) = delete;
+  NotCopiableNotMovable& operator=(NotCopiableNotMovable&&) = delete;
+};
+
+template <class Mutex> void testInPlaceConstruction() {
+  // This won't compile without construct_in_place
+  folly::Locked<NotCopiableNotMovable> a(5, "a");
+}
+} // locked_tests
+} // folly

--- a/folly/test/LockedTestLib.h
+++ b/folly/test/LockedTestLib.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// We have mutex types outside of folly that we want to test with Locked.
+// Make it easy for mutex implementators to test their classes with
+// Locked by just having a test like:
+//
+// class MyMutex { ... };
+//
+// TEST(Locked, Basic) {
+//   testBasic<MyMutex>();
+// }
+//
+// ... similar for testConcurrency, testDualLocking, etc.
+
+namespace folly {
+namespace locked_tests {
+template <class Mutex> void testBasic();
+template <class Mutex> void testConcurrency();
+template <class Mutex> void testDualLocking();
+template <class Mutex>
+void testDualLockingShared();
+template <class Mutex>
+void testTimed();
+template <class Mutex>
+void testConstCopy();
+template <class Mutex>
+void testInPlaceConstruction();
+} // locked_tests
+} // folly
+
+#include <folly/test/LockedTestLib-inl.h>

--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -143,6 +143,10 @@ synchronized_test_SOURCES = SynchronizedTest.cpp
 synchronized_test_LDADD = libfollytestmain.la
 TESTS += synchronized_test
 
+lock_traits_test_SOURCES = LockTraitsTest.cpp
+lock_traits_test_LDADD = libfollytestmain.la
+TESTS += lock_traits_test
+
 concurrent_skiplist_test_SOURCES = ConcurrentSkipListTest.cpp
 concurrent_skiplist_test_LDADD = libfollytestmain.la
 TESTS += concurrent_skiplist_test

--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -147,6 +147,10 @@ lock_traits_test_SOURCES = LockTraitsTest.cpp
 lock_traits_test_LDADD = libfollytestmain.la
 TESTS += lock_traits_test
 
+locked_test_SOURCES = LockedTest.cpp
+locked_test_LDADD = libfollytestmain.la
+TESTS += locked_test
+
 concurrent_skiplist_test_SOURCES = ConcurrentSkipListTest.cpp
 concurrent_skiplist_test_LDADD = libfollytestmain.la
 TESTS += concurrent_skiplist_test

--- a/folly/test/SynchronizedTest.cpp
+++ b/folly/test/SynchronizedTest.cpp
@@ -31,28 +31,27 @@ namespace {
 template <class Mutex>
 class SynchronizedTest : public testing::Test {};
 
-using SynchronizedTestTypes = testing::Types
-  < folly::SharedMutexReadPriority
-  , folly::SharedMutexWritePriority
-  , std::mutex
-  , std::recursive_mutex
-#if FOLLY_SYNCHRONIZED_HAVE_TIMED_MUTEXES
-  , std::timed_mutex
-  , std::recursive_timed_mutex
+using SynchronizedTestTypes = testing::Types<
+    folly::SharedMutexReadPriority,
+    folly::SharedMutexWritePriority,
+    std::mutex,
+    std::recursive_mutex,
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+    std::timed_mutex,
+    std::recursive_timed_mutex,
 #endif
-  , boost::mutex
-  , boost::recursive_mutex
-#if FOLLY_SYNCHRONIZED_HAVE_TIMED_MUTEXES
-  , boost::timed_mutex
-  , boost::recursive_timed_mutex
+    boost::mutex,
+    boost::recursive_mutex,
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+    boost::timed_mutex,
+    boost::recursive_timed_mutex,
 #endif
-  , boost::shared_mutex
-  , folly::SpinLock
 #ifdef RW_SPINLOCK_USE_X86_INTRINSIC_
-  , folly::RWTicketSpinLock32
-  , folly::RWTicketSpinLock64
+    folly::RWTicketSpinLock32,
+    folly::RWTicketSpinLock64,
 #endif
-  >;
+    boost::shared_mutex,
+    folly::SpinLock>;
 TYPED_TEST_CASE(SynchronizedTest, SynchronizedTestTypes);
 
 TYPED_TEST(SynchronizedTest, Basic) {
@@ -78,21 +77,20 @@ TYPED_TEST(SynchronizedTest, ConstCopy) {
 template <class Mutex>
 class SynchronizedTimedTest : public testing::Test {};
 
-using SynchronizedTimedTestTypes = testing::Types
-  < folly::SharedMutexReadPriority
-  , folly::SharedMutexWritePriority
-#if FOLLY_SYNCHRONIZED_HAVE_TIMED_MUTEXES
-  , std::timed_mutex
-  , std::recursive_timed_mutex
-  , boost::timed_mutex
-  , boost::recursive_timed_mutex
-  , boost::shared_mutex
+using SynchronizedTimedTestTypes = testing::Types<
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+    std::timed_mutex,
+    std::recursive_timed_mutex,
+    boost::timed_mutex,
+    boost::recursive_timed_mutex,
+    boost::shared_mutex,
 #endif
 #ifdef RW_SPINLOCK_USE_X86_INTRINSIC_
-  , folly::RWTicketSpinLock32
-  , folly::RWTicketSpinLock64
+    folly::RWTicketSpinLock32,
+    folly::RWTicketSpinLock64,
 #endif
-  >;
+    folly::SharedMutexReadPriority,
+    folly::SharedMutexWritePriority>;
 TYPED_TEST_CASE(SynchronizedTimedTest, SynchronizedTimedTestTypes);
 
 TYPED_TEST(SynchronizedTimedTest, TimedSynchronized) {
@@ -102,17 +100,16 @@ TYPED_TEST(SynchronizedTimedTest, TimedSynchronized) {
 template <class Mutex>
 class SynchronizedTimedWithConstTest : public testing::Test {};
 
-using SynchronizedTimedWithConstTestTypes = testing::Types
-  < folly::SharedMutexReadPriority
-  , folly::SharedMutexWritePriority
-#if FOLLY_SYNCHRONIZED_HAVE_TIMED_MUTEXES
-  , boost::shared_mutex
+using SynchronizedTimedWithConstTestTypes = testing::Types<
+#if FOLLY_LOCK_TRAITS_HAVE_TIMED_MUTEXES
+    boost::shared_mutex,
 #endif
 #ifdef RW_SPINLOCK_USE_X86_INTRINSIC_
-  , folly::RWTicketSpinLock32
-  , folly::RWTicketSpinLock64
+    folly::RWTicketSpinLock32,
+    folly::RWTicketSpinLock64,
 #endif
-  >;
+    folly::SharedMutexReadPriority,
+    folly::SharedMutexWritePriority>;
 TYPED_TEST_CASE(
     SynchronizedTimedWithConstTest, SynchronizedTimedWithConstTestTypes);
 


### PR DESCRIPTION
These two commits add a new `Locked<T>` class.  `Locked<T>` is basically like `Synchronized<T>`, with a few API tweaks.  The major differences are:

- It eliminates the `SYNCHRONIZED` macro.  Apart from the normal issues with preprocessor macros, `SYNCHRONIZED` also has some issues when used inside for/while loops, and can also trigger false positive compiler warnings in some cases.
- When using shared mutex types, it makes the choice to acquire a shared vs exclusive lock more explicit.  This helps avoid some anti-patterns mentioned in the Synchronized docs where callers could unintentionally acquire an exclusive lock when they only needed shared access.
- It defaults to a non-shared mutex type (`std::mutex`).  The `RWLocked` alias provides a shared mutex type by default (`folly::SharedMutex`) for users that need separate read/write locking.

This isn't quite ready to go as is (in particular the tests currently require at least gcc-4.9.  I'll update them to make sure they continue to work with gcc-4.8).

I'm interested to get any feedback, but especially on the following items:

- Should this new API simply replace Synchronized<T> instead of being defined as a new Locked<T> type?  Logically it's pretty much the same thing, but the API isn't quite compatible.  Internally at FB we are fine code-modding all existing Synchronized users to OldSynchronized or something, and then adding this new class as Synchronized<T>.  However, this may cause a bit more pain for open source users, who will have to do their own code mods immediately.  Using the new Locked<T> name gives users a slightly longer transition period, but it does introduce a new name for what is largely the same thing.
- There was some discussion about the `wlock()` and `rlock()` method names for `RWLocked<T>`, as opposed to `lock()` and `lockShared()`.  One argument against the latter is that `lock()` is slightly more ambiguous--with a shared mutex type should it acquire an exclusive lock on a non-const object and a shared lock on a const object?  The `wlock()` and `rlock()` names avoid this ambiguity.
- I dropped swap() and the move constructor and assignment operators, since it seemed potentially confusing that these operate only on the data and not the mutex.  I also dropped the copy constructor/assignment as well, since this also would have allowed things like `vector<Locked<int>>`, which doesn't really seem like a sound construction due to object invalidation on vector resizing.  `Locked<T>` can still be copy/move constructed or assigned from another `T` object, just not `Locked<T>`.  That said, I'm open to adding these operators back if there is a compelling argument to keep them.