### PR TITLE
s/PortabilityTimeTest.cpp/TimeTest.cpp

### DIFF
--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -229,7 +229,7 @@ indestructible_test_SOURCES = IndestructibleTest.cpp
 indestructible_test_LDADD = libfollytestmain.la
 TESTS += indestructible_test
 
-portability_time_test_SOURCES = ../portability/test/PortabilityTimeTest.cpp
+portability_time_test_SOURCES = ../portability/test/TimeTest.cpp
 portability_time_test_LDADD = libfollytestmain.la
 TESTS += portability_time_test
 


### PR DESCRIPTION
The test file in `../portability/test` is named `TimeTest.cpp`. Makefile refers to it as `PortabilityTimeTest.cpp`. Possibly a typo. Or the test file should be renamed to `PortabilityTimeTest.cpp`.