### PR TITLE
Fix for facebook/folly issue #440

### DIFF
--- a/folly/futures/test/FutureTest.cpp
+++ b/folly/futures/test/FutureTest.cpp
@@ -823,8 +823,8 @@ TEST(Future, RequestContext) {
   };
 
   Promise<int> p1, p2;
+  NewThreadExecutor e;
   {
-    NewThreadExecutor e;
     folly::RequestContextScopeGuard rctx;
     RequestContext::get()->setContextData(
         "key", folly::make_unique<MyRequestData>(true));


### PR DESCRIPTION
Fix scope of NewThreadExecutor 
