### PR TITLE
Fix compiler warnings

### DIFF
--- a/folly/fibers/FiberManager.cpp
+++ b/folly/fibers/FiberManager.cpp
@@ -120,8 +120,6 @@ Fiber* FiberManager::getFiber() {
     maxFibersActiveLastPeriod_ = fibersActive_;
   }
   ++fiberId_;
-  bool recordStack = (options_.recordStackEvery != 0) &&
-      (fiberId_ % options_.recordStackEvery == 0);
   return fiber;
 }
 

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -19,6 +19,7 @@
 #include <folly/ExceptionWrapper.h>
 #include <folly/SocketAddress.h>
 #include <folly/io/IOBuf.h>
+#include <folly/Portability.h>
 #include <folly/portability/Fcntl.h>
 #include <folly/portability/Sockets.h>
 #include <folly/portability/SysUio.h>
@@ -662,7 +663,13 @@ void AsyncSocket::writeChain(WriteCallback* callback, unique_ptr<IOBuf>&& buf,
   constexpr size_t kSmallSizeMax = 64;
   size_t count = buf->countChainElements();
   if (count <= kSmallSizeMax) {
+
+    // suppress "warning: variable length array ‘vec’ is used [-Wvla]"
+    FOLLY_PUSH_WARNING;
+    FOLLY_GCC_DISABLE_WARNING(vla);
     iovec vec[BOOST_PP_IF(FOLLY_HAVE_VLA, count, kSmallSizeMax)];
+    FOLLY_POP_WARNING;
+
     writeChainImpl(callback, vec, count, std::move(buf), flags);
   } else {
     iovec* vec = new iovec[count];


### PR DESCRIPTION
- unused variables
- suppressing "warning: variable length array ‘vec’ is used [-Wvla]"