### PR TITLE
Fix build in g++ 6.1.1

### DIFF
--- a/folly/fibers/Fiber.h
+++ b/folly/fibers/Fiber.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdlib>
 #include <functional>
 #include <thread>
 #include <typeinfo>
@@ -64,7 +65,7 @@ class Fiber {
   std::pair<void*, size_t> getStack() const {
     void* const stack =
         std::min<void*>(fcontext_.stackLimit(), fcontext_.stackBase());
-    const size_t size = std::abs<intptr_t>(
+    const size_t size = std::abs(
         reinterpret_cast<intptr_t>(fcontext_.stackBase()) -
         reinterpret_cast<intptr_t>(fcontext_.stackLimit()));
     return {stack, size};


### PR DESCRIPTION
In file included from fibers/Fiber.cpp:16:0:
fibers/Fiber.h: In member function ‘std::pair<void*, long unsigned int> folly::fibers::Fiber::getStack() const’:
fibers/Fiber.h:67:42: error: expected primary-expression before ‘>’ token
     const size_t size = std::abs<intptr_t>(
                                                            ^