### PR TITLE
Add libfollytestmain.la to mallctl's LDADD

### DIFF
--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -290,6 +290,7 @@ ssl_test_LDADD = libfollytestmain.la -lcrypto
 TESTS += ssl_test
 
 mallctl_helper_test_SOURCES = MallctlHelperTest.cpp
+mallctl_helper_test_LDADD = libfollytestmain.la
 TESTS += mallctl_helper_test
 
 check_PROGRAMS += $(TESTS)


### PR DESCRIPTION
Fixes make check problem for MallctlHelperTest.

Previous make check output:

MallctlHelperTest.o: In function `MallctlHelperTest_valid_read_Test::TestBody()':
MallctlHelperTest.cpp:(.text+0x25): undefined reference to `testing::internal::AlwaysTrue()'
MallctlHelperTest.cpp:(.text+0x2e): undefined reference to `testing::internal::AlwaysTrue()'
MallctlHelperTest.cpp:(.text+0x51): undefined reference to `testing::Message::Message()'
MallctlHelperTest.cpp:(.text+0x72): undefined reference to `testing::internal::AssertHelper::AssertHelper(testing::TestPartResult::Type, char const*, int, char const*)'
MallctlHelperTest.cpp:(.text+0x85): undefined reference to `testing::internal::AssertHelper::operator=(testing::Message const&) const'
MallctlHelperTest.cpp:(.text+0x91): undefined reference to `testing::internal::AssertHelper::~AssertHelper()'
MallctlHelperTest.cpp:(.text+0xe4): undefined reference to `testing::Message::Message()'
MallctlHelperTest.cpp:(.text+0x111): undefined reference to `testing::internal::AssertHelper::AssertHelper(testing::TestPartResult::Type, char const*, int, char const*)'
MallctlHelperTest.cpp:(.text+0x124): undefined reference to `testing::internal::AssertHelper::operator=(testing::Message const&) const'
MallctlHelperTest.cpp:(.text+0x130): undefined reference to `testing::internal::AssertHelper::~AssertHelper()'
MallctlHelperTest.cpp:(.text+0x180): undefined reference to `testing::internal::AssertHelper::~AssertHelper()'
MallctlHelperTest.cpp:(.text+0x1ab): undefined reference to `testing::internal::AssertHelper::~AssertHelper()'