### PR TITLE
Allow Synchronized.h use under C++11

### DIFF
--- a/folly/Synchronized.h
+++ b/folly/Synchronized.h
@@ -135,6 +135,7 @@ class SynchronizedBase<Subclass, true> {
    *     return data.getValue();
    *   });
    */
+#if __cplusplus > 201103L
   template <class Function>
   auto withWLock(Function&& function) {
     LockedGuardPtr<Subclass, LockPolicyExclusive> guardPtr(
@@ -147,6 +148,7 @@ class SynchronizedBase<Subclass, true> {
         static_cast<const Subclass*>(this));
     return function(*guardPtr);
   }
+#endif
 
   /**
    * Invoke a function while holding the lock exclusively.
@@ -157,6 +159,7 @@ class SynchronizedBase<Subclass, true> {
    * This allows scopedUnlock() to be called on the LockedPtr argument if
    * desired.
    */
+#if __cplusplus > 201103L
   template <class Function>
   auto withWLockPtr(Function&& function) {
     return function(wlock());
@@ -165,6 +168,7 @@ class SynchronizedBase<Subclass, true> {
   auto withWLockPtr(Function&& function) const {
     return function(wlock());
   }
+#endif
 
   /**
    * Invoke a function while holding an the lock in shared mode.
@@ -172,6 +176,7 @@ class SynchronizedBase<Subclass, true> {
    * A const reference to the datum will be passed into the function as its
    * only argument.
    */
+#if __cplusplus > 201103L
   template <class Function>
   auto withRLock(Function&& function) const {
     LockedGuardPtr<const Subclass, LockPolicyShared> guardPtr(
@@ -183,6 +188,7 @@ class SynchronizedBase<Subclass, true> {
   auto withRLockPtr(Function&& function) const {
     return function(rlock());
   }
+#endif
 };
 
 /**
@@ -252,6 +258,7 @@ class SynchronizedBase<Subclass, false> {
    *     return data.getValue();
    *   });
    */
+#if __cplusplus > 201103L
   template <class Function>
   auto withLock(Function&& function) {
     LockedGuardPtr<Subclass, LockPolicyExclusive> guardPtr(
@@ -264,6 +271,7 @@ class SynchronizedBase<Subclass, false> {
         static_cast<const Subclass*>(this));
     return function(*guardPtr);
   }
+#endif 
 
   /**
    * Invoke a function while holding the lock exclusively.
@@ -274,6 +282,7 @@ class SynchronizedBase<Subclass, false> {
    * This allows scopedUnlock() and getUniqueLock() to be called on the
    * LockedPtr argument.
    */
+#if __cplusplus > 201103L
   template <class Function>
   auto withLockPtr(Function&& function) {
     return function(lock());
@@ -282,6 +291,7 @@ class SynchronizedBase<Subclass, false> {
   auto withLockPtr(Function&& function) const {
     return function(lock());
   }
+#endif
 };
 
 /**


### PR DESCRIPTION
This is somewhat hacky, but it allows existing users of Synchronized.h which are still compiling under C++11 compilers to continue to work.

In my use I'm using EventBaseLocal from a C++11 compiler.

The code being conditionally disabling was added in b179601dfc42d8e3230d6477d7db8f3d5a8f64dc 
