### PR TITLE
Fix build in linux

### DIFF
--- a/folly/portability/SysMembarrier.cpp
+++ b/folly/portability/SysMembarrier.cpp
@@ -26,6 +26,8 @@
 #define FOLLY_USE_SYS_MEMBARRIER 1
 #if !defined(__NR_membarrier)
 #define __NR_membarrier 324
+#endif
+#if !defined(MEMBARRIER_CMD_QUERY)
 #define MEMBARRIER_CMD_QUERY 0
 #define MEMBARRIER_CMD_SHARED 1
 #endif


### PR DESCRIPTION
The macro `__NR_membarrier` is in `unistd.h`, but `MEMBARRIER_CMD_QUERY`
and `MEMBARRIER_CMD_SHARED` is in `linux/membarrier.h` rather than
`unistd.h`. So we must check them seperately.