### PR TITLE
Futures cannot use Fibers without Boost::Context

### DIFF
--- a/folly/futures/Future-inl.h
+++ b/folly/futures/Future-inl.h
@@ -28,7 +28,7 @@
 #include <folly/futures/detail/Core.h>
 #include <folly/futures/Timekeeper.h>
 
-#if FOLLY_MOBILE || defined(__APPLE__)
+#if !HAVE_BOOST_CONTEXT || (FOLLY_MOBILE || defined(__APPLE__))
 #define FOLLY_FUTURE_USING_FIBER 0
 #else
 #define FOLLY_FUTURE_USING_FIBER 1


### PR DESCRIPTION
Fixes build with Boost 1.61, where Boost::Context API changed and folly
now relies on an implementation detail.
#463
