### PR TITLE
Consolidate namespace for using GFlags.

### DIFF
--- a/folly/init/Init.cpp
+++ b/folly/init/Init.cpp
@@ -39,7 +39,7 @@ void init(int* argc, char*** argv, bool removeFlags) {
   google::InstallFailureSignalHandler();
 #endif
 
-  google::ParseCommandLineFlags(argc, argv, removeFlags);
+  gflags::ParseCommandLineFlags(argc, argv, removeFlags);
 
   auto programName = argc && argv && *argc > 0 ? (*argv)[0] : "unknown";
   google::InitGoogleLogging(programName);

--- a/folly/test/AtomicUnorderedMapTest.cpp
+++ b/folly/test/AtomicUnorderedMapTest.cpp
@@ -397,7 +397,7 @@ BENCHMARK(fast_map_64) {
 
 int main(int argc, char ** argv) {
   testing::InitGoogleTest(&argc, argv);
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   int rv = RUN_ALL_TESTS();
   folly::runBenchmarksOnFlag();
   return rv;

--- a/folly/test/SparseByteSetBench.cpp
+++ b/folly/test/SparseByteSetBench.cpp
@@ -151,7 +151,7 @@ void setup_rand_bench() {
 }
 
 int main(int argc, char** argv) {
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   setup_rand_bench();
   runBenchmarks();
   return 0;


### PR DESCRIPTION
Default namespace for GFlags has been changed from "google" to "gflags".

See: https://github.com/gflags/gflags/commit/d9d06b9.