### PR TITLE
Fix joining threads twice when exiting EventBaseTest.RunInThread normally

### DIFF
--- a/folly/io/async/test/EventBaseTest.cpp
+++ b/folly/io/async/test/EventBaseTest.cpp
@@ -1176,11 +1176,6 @@ TEST(EventBaseTest, RunInThread) {
   for (uint32_t n = 0; n < numThreads; ++n) {
     ASSERT_EQ(expectedValues[n], opsPerThread);
   }
-
-  // Wait on all of the threads.
-  for (auto& thread: threads) {
-    thread.join();
-  }
 }
 
 //  This test simulates some calls, and verifies that the waiting happens by


### PR DESCRIPTION
10e9cd3 set up SCOPE_EXIT to join threads (wait for them to exit) on
exceptions. However, it is also called on normal exit. Remove the
original code at the end for joining threads.

This fixes EventBaseTest regression.