### PR TITLE
Optimize toJson() Performance

### DIFF
--- a/folly/json.cpp
+++ b/folly/json.cpp
@@ -693,7 +693,6 @@ void escapeString(
     return c < 10 ? c + '0' : c - 10 + 'a';
   };
 
-  out.reserve(out.size() + input.size() + 2);
   out.push_back('\"');
 
   auto* p = reinterpret_cast<const unsigned char*>(input.begin());


### PR DESCRIPTION
Removing string::reserve() which causes O(n^2) penalty.

Fixes #477