### PR TITLE
Find dwarf.h in libdwarf subdirectory

### DIFF
--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -531,12 +531,19 @@ AC_ARG_ENABLE([follytestmain],
    [follytestmain=${enableval}], [follytestmain=no])
 
 use_follytestmain=yes
+# libdwarf used to install in /usr/include, now installs in /usr/include/libdwarf.
+AC_SEARCH_LIBS([dwarf_init], [dwarf])
+AC_CHECK_HEADERS([libdwarf/dwarf.h dwarf.h], [break])
+# Check whether we have both the library and the header
+have_libdwarf=no
+AS_IF([test "x${ac_cv_search_dwarf_init}" != xno && test "x${ac_cv_header_libdwarf_dwarf_h}" = xyes], [have_libdwarf=yes])
+AS_IF([test "x${ac_cv_search_dwarf_init}" != xno && test "x${ac_cv_header_dwarf_h}" = xyes], [have_libdwarf=yes])
 if test "x${follytestmain}" = "xyes"; then
-   AC_CHECK_HEADERS([libdwarf.h dwarf.h],, AC_MSG_ERROR([Please install libdwarf development package]))
+   AS_IF([test "x${have_libdwarf}" = xno], [AC_MSG_ERROR([Please install libdwarf development library and headers])])
    AC_CHECK_HEADERS([libelf.h elf.h],, AC_MSG_ERROR([Please install libelf development package]))
-   AC_CHECK_HEADERS([libunwind.h],, AC_MSG_ERROR([Please install libinwind development package]))
+   AC_CHECK_HEADERS([libunwind.h],, AC_MSG_ERROR([Please install libunwind development package]))
 else
-   AC_CHECK_HEADERS([libdwarf.h dwarf.h],, [use_follytestmain=no])
+   AS_IF([test "x${have_libdwarf}" = xno],, [use_follytestmain=no])
    AC_CHECK_HEADERS([libelf.h elf.h],, [use_follytestmain=no])
    AC_CHECK_HEADERS([libunwind.h],, [use_follytestmain=no])
 fi

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -540,11 +540,11 @@ AS_IF([test "x${ac_cv_search_dwarf_init}" != xno && test "x${ac_cv_header_libdwa
 AS_IF([test "x${ac_cv_search_dwarf_init}" != xno && test "x${ac_cv_header_dwarf_h}" = xyes], [have_libdwarf=yes])
 if test "x${follytestmain}" = "xyes"; then
    AS_IF([test "x${have_libdwarf}" = xno], [AC_MSG_ERROR([Please install libdwarf development library and headers])])
-   AC_CHECK_HEADERS([libelf.h elf.h],, AC_MSG_ERROR([Please install libelf development package]))
+   AC_CHECK_HEADERS([elf.h],, AC_MSG_ERROR([Please install libelf development package]))
    AC_CHECK_HEADERS([libunwind.h],, AC_MSG_ERROR([Please install libunwind development package]))
 else
    AS_IF([test "x${have_libdwarf}" = xno],, [use_follytestmain=no])
-   AC_CHECK_HEADERS([libelf.h elf.h],, [use_follytestmain=no])
+   AC_CHECK_HEADERS([elf.h],, [use_follytestmain=no])
    AC_CHECK_HEADERS([libunwind.h],, [use_follytestmain=no])
 fi
 

--- a/folly/experimental/symbolizer/Dwarf.cpp
+++ b/folly/experimental/symbolizer/Dwarf.cpp
@@ -19,7 +19,11 @@
 
 #include <type_traits>
 
-#include <dwarf.h>
+#if FOLLY_HAVE_LIBDWARF_DWARF_H
+# include <libdwarf/dwarf.h>
+#elif FOLLY_HAVE_DWARF_H
+# include <dwarf.h>
+#endif
 
 namespace folly {
 namespace symbolizer {

--- a/folly/experimental/symbolizer/Dwarf.cpp
+++ b/folly/experimental/symbolizer/Dwarf.cpp
@@ -21,7 +21,7 @@
 
 #if FOLLY_HAVE_LIBDWARF_DWARF_H
 # include <libdwarf/dwarf.h>
-#elif FOLLY_HAVE_DWARF_H
+#else
 # include <dwarf.h>
 #endif
 


### PR DESCRIPTION
libdwarf headers moved from `/usr/include` to `/usr/include/libdwarf` in [dwarfutils 20160613-2](http://metadata.ftp-master.debian.org/changelogs/main/d/dwarfutils/unstable_changelog).

Adds a check for the library as well, and fixes a tiny typo in the `libunwind` check.

No longer checks for `libdwarf.h`; only `dwarf.h` is used.