### PR TITLE
Fix SUPPLY_MISSING_INT128_TRAITS

### DIFF
--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -171,7 +171,7 @@ static_assert(
       [folly_cv_prog_cc_int128traits=no])
     ])
   if test "$folly_cv_prog_cc_int128traits" = "no"; then
-    AC_DEFINE([FOLLY_SUPPLY_MISSING_INT128_TRAITS], [1], [Define if we need the standard integer traits defined for the type `__int128'.])
+    AC_DEFINE([SUPPLY_MISSING_INT128_TRAITS], [1], [Define if we need the standard integer traits defined for the type `__int128'.])
   fi
 fi
 


### PR DESCRIPTION
The original code `AC_DEFINE([FOLLY_SUPPLY_MISSING_INT128_TRAITS...` resulted in defining the constant FOLLY_FOLLY_SUPPLY_MISSING_INT128_TRAITS in folly-config.h. This patch fix the name of the constant so that the name match with what appear in Traits.h.