### PR TITLE
Fix build failure on macOS Sierra and OS X El Capitan using Xcode 8

### DIFF
--- a/folly/Benchmark.h
+++ b/folly/Benchmark.h
@@ -57,7 +57,8 @@ namespace detail {
  * resolution of this clock will be very coarse, which will cause the
  * benchmarks to fail.
  */
-enum Clock { DEFAULT_CLOCK_ID = CLOCK_REALTIME };
+using Clock = clockid_t;
+static constexpr Clock DEFAULT_CLOCK_ID = CLOCK_REALTIME;
 
 typedef std::pair<uint64_t, unsigned int> TimeIterPair;
 

--- a/folly/portability/Time.h
+++ b/folly/portability/Time.h
@@ -21,15 +21,38 @@
 
 #include <folly/portability/Config.h>
 
+#ifdef __APPLE__
+#include <Availability.h>
+#define FOLLY_HAVE_CLOCK_GETTIME_DEFINITION \
+    ((defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \
+      defined(__MAC_10_12) && \
+      __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_10_12) || \
+     (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && \
+      defined(__IPHONE_10_0) && \
+      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_10_0) || \
+     (defined(__TV_OS_VERSION_MAX_ALLOWED) && \
+      defined(__TVOS_10_0) && \
+      __TV_OS_VERSION_MAX_ALLOWED >= __TVOS_10_0) || \
+     (defined(__WATCH_OS_VERSION_MAX_ALLOWED) && \
+      defined(__WATCHOS_3_0) && \
+      __WATCH_OS_VERSION_MAX_ALLOWED >= __WATCHOS_3_0))
+#else
+#define FOLLY_HAVE_CLOCK_GETTIME_DEFINITION FOLLY_HAVE_CLOCK_GETTIME
+#endif
+
 // These aren't generic implementations, so we can only declare them on
 // platforms we support.
 #if !FOLLY_HAVE_CLOCK_GETTIME && (defined(__MACH__) || defined(_WIN32))
+
+#if !FOLLY_HAVE_CLOCK_GETTIME_DEFINITION
 #define CLOCK_REALTIME 0
 #define CLOCK_MONOTONIC 1
 #define CLOCK_PROCESS_CPUTIME_ID 2
 #define CLOCK_THREAD_CPUTIME_ID 3
 
 typedef uint8_t clockid_t;
+#endif
+
 extern "C" int clock_gettime(clockid_t clk_id, struct timespec* ts);
 extern "C" int clock_getres(clockid_t clk_id, struct timespec* ts);
 #endif


### PR DESCRIPTION
- [x] Fix `candidate function not viable` on macOS Sierra.

> Unlike Linux, Apple defines `clockid_t` as an enum type.  To avoid the compilation error caused by invalid conversion from `folly::detail::Clock` to `clockid_t`, `DEFAULT_CLOCK_ID` should not be defined as an enumerator of a new enum type named `Clock`.
> 
> This fixes #486.
- [x] Fix build on OS X El Capitan using Xcode 8 (w/ macOS Sierra SDK).

> `clock_gettime` and its related type definitions (i.e. `clockid_t`) are available in macOS Sierra SDK, iOS 10 SDK, tvOS 10 SDK and watchOS 3 SDK.
> 
> However, if these new SDKs are used to build folly on/for an older system, `clockid_t` and `CLOCK_*` will become redefined.
> 
> This fixes #484.
> This also fixes Homebrew/homebrew-core#5426.
