### PR TITLE
hazptr: Replace friend "swap" with a member function and a non-friend

### DIFF
--- a/folly/experimental/hazptr/hazptr-impl.h
+++ b/folly/experimental/hazptr/hazptr-impl.h
@@ -123,12 +123,17 @@ inline void hazptr_owner<T>::clear() const noexcept {
 }
 
 template <typename T>
-inline void swap(hazptr_owner<T>& lhs, hazptr_owner<T>& rhs) noexcept {
+inline void hazptr_owner<T>::swap(hazptr_owner<T>& rhs) noexcept {
   DEBUG_PRINT(
-    &lhs << " " <<  lhs.hazptr_ << " " << lhs.domain_ << " -- "
+    this << " " <<  this->hazptr_ << " " << this->domain_ << " -- "
     << &rhs << " " << rhs.hazptr_ << " " << rhs.domain_);
-  std::swap(lhs.domain_, rhs.domain_);
-  std::swap(lhs.hazptr_, rhs.hazptr_);
+  std::swap(this->domain_, rhs.domain_);
+  std::swap(this->hazptr_, rhs.hazptr_);
+}
+
+template <typename T>
+inline void swap(hazptr_owner<T>& lhs, hazptr_owner<T>& rhs) noexcept {
+  lhs.swap(rhs);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/folly/experimental/hazptr/hazptr.h
+++ b/folly/experimental/hazptr/hazptr.h
@@ -146,8 +146,9 @@ template <typename T> class hazptr_owner {
   /* Clear the hazard pointer */
   void clear() const noexcept;
 
+  void swap(hazptr_owner&) noexcept;
+
  private:
-  friend void swap<T>(hazptr_owner&, hazptr_owner&) noexcept;
 
   hazptr_domain* domain_;
   hazptr_rec* hazptr_;


### PR DESCRIPTION
This matches what the STL does with e.g. std::vector::swap() and std::shared_ptr::swap().

http://en.cppreference.com/w/cpp/container/vector/swap
http://en.cppreference.com/w/cpp/memory/shared_ptr/swap

Should be relatively uncontroversial, I would think.