### PR TITLE
Add missing include

### DIFF
--- a/folly/String.h
+++ b/folly/String.h
@@ -20,6 +20,7 @@
 #include <exception>
 #include <stdarg.h>
 #include <string>
+#include <vector>
 #include <boost/type_traits.hpp>
 #include <boost/regex/pending/unicode_iterator.hpp>
 


### PR DESCRIPTION
String.h references std::vector, but it is not included.