### PR TITLE
fix bootstrap on osx

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,6 @@ You may also use `folly/build/bootstrap-osx-homebrew.sh` to build against `maste
 ```
   cd folly
   ./build/bootstrap-osx-homebrew.sh
-  make
-  make check
 ```
 
 #### OS X (MacPorts)

--- a/folly/build/bootstrap-osx-homebrew.sh
+++ b/folly/build/bootstrap-osx-homebrew.sh
@@ -8,22 +8,53 @@ set -e
 BASE_DIR="$(cd "$(dirname -- "$0")"/.. ; pwd)"  # folly/folly
 cd "$BASE_DIR"
 
-brewget() {
+# brew install alias
+brew_install() {
     brew install $@ || brew upgrade $@
 }
 
-# tool dependencies: autotools and scons (for double-conversion)
-brewget autoconf automake libtool
+# install deps
+install_deps() {
+	# folly deps
+	dependencies=(autoconf automake libtool pkg-config double-conversion glog gflags boost libevent xz snappy lz4 jemalloc openssl)
 
-# dependencies
-brewget glog gflags boost libevent double-conversion
-
-autoreconf -i
-./configure
-
-pushd test
-test -e gtest-1.7.0.zip || {
-    curl -O https://googletest.googlecode.com/files/gtest-1.7.0.zip
-    unzip gtest-1.7.0.zip
+	# fetch deps
+	for dependency in ${dependencies[@]}; do
+		brew_install ${dependency}
+	done
 }
+
+# set env flags
+export_flags() {
+	# fetch opt dirs
+	OPT_GFLAGS=$(brew --prefix gflags)
+	OPT_OPENSSL=$(brew --prefix openssl)
+
+	# export LDFLAGS
+	export LDFLAGS=-L${OPT_OPENSSL}/lib
+	export CPPFLAGS=-I${OPT_OPENSSL}/include
+	export GFLAGS_LIBS=-L${OPT_GFLAGS}/lib
+	export GFLAGS_CFLAGS=-I${OPT_GFLAGS}/include
+}
+
+# now the fun part
+install_deps
+export_flags
+autoreconf -ivf
+./configure --disable-silent-rules --disable-dependency-tracking
+
+# fetch googletest, if doesn't exist
+pushd test
+GTEST_VER=1.7.0
+GTEST_DIR=gtest-${GTEST_VER}
+if [ ! -d ${GTEST_DIR} ]; then
+	mkdir ${GTEST_DIR}
+    curl -SL \
+    	https://github.com/google/googletest/archive/release-${GTEST_VER}.tar.gz | \
+    	tar -xvzf - --strip-components=1 -C ${GTEST_DIR}
+fi
 popd
+
+# make, test, install
+make
+make install


### PR DESCRIPTION
 * include all dependencies
 * update `autoconf` & `configure` with correct params
 * include `make` & `make install` in the bootstrap for a better user experience
 * fixes #332