### PR TITLE
Fix search name for gflags's .pc file

### DIFF
--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -102,9 +102,9 @@ AC_CACHE_CHECK(
 )
 
 if test "$folly_cv_prog_cc_gflags" != "yes"; then
-  AC_MSG_ERROR(["libgflags invalid, see config.log for details"])
+  AC_MSG_ERROR(["gflags invalid, see config.log for details"])
 fi
-FB_CHECK_PKG_CONFIG([GFLAGS], [libgflags])
+FB_CHECK_PKG_CONFIG([GFLAGS], [gflags])
 
 AC_HAVE_LIBRARY([glog],[],[AC_MSG_ERROR(
                 [Please install google-glog library])])


### PR DESCRIPTION
gflags's pkg-config file is installed by default under the name gflags.pc; however, folly has been searching for it under the name libgflags.pc.

Several package managers (Homebrew, apt) install the .pc file under its default upstream name; as such it seems appropriate for folly to look for it under that name, too.

refs Homebrew/homebrew-core#7977.