### PR TITLE
__throw* functions seem to be available in LLVM 4.0 or above.

### DIFF
--- a/folly/portability/BitsFunctexcept.cpp
+++ b/folly/portability/BitsFunctexcept.cpp
@@ -21,7 +21,7 @@
 
 FOLLY_NAMESPACE_STD_BEGIN
 
-#if (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 3900) && \
+#if (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 4000) && \
     !defined(FOLLY_SKIP_LIBCPP_4000_THROW_BACKPORTS)
 void __throw_length_error(const char* msg) {
   throw std::length_error(msg);

--- a/folly/portability/BitsFunctexcept.h
+++ b/folly/portability/BitsFunctexcept.h
@@ -25,7 +25,7 @@
 #include <folly/Portability.h>
 FOLLY_NAMESPACE_STD_BEGIN
 
-#if (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 3900) && \
+#if (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 4000) && \
     !defined(FOLLY_SKIP_LIBCPP_4000_THROW_BACKPORTS)
 [[noreturn]] void __throw_length_error(const char* msg);
 [[noreturn]] void __throw_logic_error(const char* msg);


### PR DESCRIPTION
__throw* functions exist in master branch but are not included in both
libc++ 3.9.0 and 3.9.1. Expect them to appear in next LLVM release
(which is 4.0).