### PR TITLE
fix typo in comments. s/unitialized/uninitialized/g

### DIFF
--- a/folly/Optional.h
+++ b/folly/Optional.h
@@ -265,7 +265,7 @@ class Optional {
 
   struct StorageTriviallyDestructible {
     // The union trick allows to initialize the Optional's memory,
-    // so that compiler/tools don't complain about unitialized memory,
+    // so that compiler/tools don't complain about uninitialized memory,
     // without actually calling Value's default constructor.
     // The rest of the implementation enforces that hasValue/value are
     // synchronized.

--- a/folly/Try.h
+++ b/folly/Try.h
@@ -35,7 +35,7 @@ class TryException : public std::logic_error {
 
 class UsingUninitializedTry : public TryException {
  public:
-  UsingUninitializedTry() : TryException("Using unitialized try") {}
+  UsingUninitializedTry() : TryException("Using uninitialized try") {}
 };
 
 /*

--- a/folly/fibers/FiberManagerInternal.h
+++ b/folly/fibers/FiberManagerInternal.h
@@ -362,7 +362,7 @@ class FiberManager : public ::folly::Executor {
   FiberTailQueue readyFibers_; /**< queue of fibers ready to be executed */
   FiberTailQueue yieldedFibers_; /**< queue of fibers which have yielded
                                       execution */
-  FiberTailQueue fibersPool_; /**< pool of unitialized Fiber objects */
+  FiberTailQueue fibersPool_; /**< pool of uninitialized Fiber objects */
 
   GlobalFiberTailQueue allFibers_; /**< list of all Fiber objects owned */
 


### PR DESCRIPTION
`unitialized` seems to be typo.