### PR TITLE
portability: handle libstdc++ redeclarations

### DIFF
--- a/folly/portability/BitsFunctexcept.h
+++ b/folly/portability/BitsFunctexcept.h
@@ -23,13 +23,18 @@
 #else
 #include <new> // Some platforms define __throw_bad_alloc() here.
 #include <folly/Portability.h>
+
 FOLLY_NAMESPACE_STD_BEGIN
 
-#if (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION < 4000) && \
-    !defined(FOLLY_SKIP_LIBCPP_4000_THROW_BACKPORTS)
+#if (defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION >= 4000)) ||                 \
+    defined(FOLLY_SKIP_LIBCPP_4000_THROW_BACKPORTS)
 [[noreturn]] void __throw_length_error(const char* msg);
 [[noreturn]] void __throw_logic_error(const char* msg);
 [[noreturn]] void __throw_out_of_range(const char* msg);
+#else
+void __throw_length_error(const char *) __attribute__((__noreturn__));
+void __throw_logic_error(const char *) __attribute__((__noreturn__));
+void __throw_out_of_range(const char *) __attribute__((__noreturn__));
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
The interfaces here are decorated with `__attribute__((__noreturn__))`
rather than the C++11 attribute `[[noreturn]]`.  The two are subtly
different in behaviour and thus do not compare equal.  The redeclaration
therefore is treated as changing the attributes (rather than just the
attribute spelling).  This will fail to compile as a result.