### PR TITLE
Update googletest to 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,14 @@ Folly is published on Github at https://github.com/facebook/folly
 folly requires gcc 4.8+ and a version of boost compiled with C++11 support.
 
 Please download googletest from
-https://github.com/google/googletest/archive/release-1.7.0.zip and unzip it in the
-folly/test subdirectory.
+https://github.com/google/googletest/archive/release-1.8.0.zip and unzip it in the
+folly/test subdirectory as `gtest-1.8.0`.
+
+    (cd folly/test && \
+     rm -rf gtest-1.8.0 && \
+     wget https://github.com/google/googletest/archive/release-1.8.0.zip && \
+     unzip release-1.8.0.zip && \
+     mv googletest-release-1.8.0 gtest-1.8.0)
 
 #### Ubuntu 12.04
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ Folly is published on Github at https://github.com/facebook/folly
 folly requires gcc 4.8+ and a version of boost compiled with C++11 support.
 
 Please download googletest from
-https://github.com/google/googletest/archive/release-1.8.0.zip and unzip it in the
+https://github.com/google/googletest/archive/release-1.8.0.tar.gz and unpack it into the
 folly/test subdirectory as `gtest`:
 
     (cd folly/test && \
      rm -rf gtest && \
-     wget https://github.com/google/googletest/archive/release-1.8.0.zip && \
-     unzip release-1.8.0.zip && \
-     rm -f release-1.8.0.zip && \
+     wget https://github.com/google/googletest/archive/release-1.8.0.tar.gz && \
+     tar zxf release-1.8.0.tar.gz && \
+     rm -f release-1.8.0.tar.gz && \
      mv googletest-release-1.8.0 gtest)
 
 #### Ubuntu 12.04

--- a/README.md
+++ b/README.md
@@ -74,13 +74,14 @@ folly requires gcc 4.8+ and a version of boost compiled with C++11 support.
 
 Please download googletest from
 https://github.com/google/googletest/archive/release-1.8.0.zip and unzip it in the
-folly/test subdirectory as `gtest-1.8.0`.
+folly/test subdirectory as `gtest`:
 
     (cd folly/test && \
-     rm -rf gtest-1.8.0 && \
+     rm -rf gtest && \
      wget https://github.com/google/googletest/archive/release-1.8.0.zip && \
      unzip release-1.8.0.zip && \
-     mv googletest-release-1.8.0 gtest-1.8.0)
+     rm -f release-1.8.0.zip && \
+     mv googletest-release-1.8.0 gtest)
 
 #### Ubuntu 12.04
 

--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = . function_benchmark
 
 ACLOCAL_AMFLAGS = -I m4
 
-CPPFLAGS += -Igtest/googletest/include -Igtest/googlemock/include
+CPPFLAGS += -isystem gtest/googletest/include -isystem gtest/googlemock/include
 
 TESTS= \
 	sorted_vector_types_test \
@@ -20,7 +20,7 @@ check_LTLIBRARIES = libfollytestmain.la libgtest.la
 check_PROGRAMS =
 noinst_LTLIBRARIES = thread_local_test_lib.la
 
-libgtest_la_CPPFLAGS = -Igtest/googletest
+libgtest_la_CPPFLAGS = -isystem gtest/googletest
 libgtest_la_SOURCES = gtest/googletest/src/gtest-all.cc
 
 if FOLLY_TESTMAIN

--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = . function_benchmark
 
 ACLOCAL_AMFLAGS = -I m4
 
-CPPFLAGS += -Igtest-1.7.0/include
+CPPFLAGS += -Igtest-1.8.0/googletest/include -Igtest-1.8.0/googlemock/include
 
 TESTS= \
 	sorted_vector_types_test \
@@ -20,8 +20,8 @@ check_LTLIBRARIES = libfollytestmain.la libgtest.la
 check_PROGRAMS =
 noinst_LTLIBRARIES = thread_local_test_lib.la
 
-libgtest_la_CPPFLAGS = -Igtest-1.7.0 -Igtest-1.7.0/src
-libgtest_la_SOURCES = gtest-1.7.0/src/gtest-all.cc
+libgtest_la_CPPFLAGS = -Igtest-1.8.0/googletest
+libgtest_la_SOURCES = gtest-1.8.0/googletest/src/gtest-all.cc
 
 if FOLLY_TESTMAIN
 libfollytestmain_la_CPPFLAGS = $(AM_CPPFLAGS) $(libgtest_la_CPPFLAGS)
@@ -29,7 +29,7 @@ libfollytestmain_la_SOURCES = $(libgtest_la_SOURCES) common/TestMain.cpp
 libfollytestmain_la_LIBADD = $(top_builddir)/init/libfollyinit.la $(top_builddir)/libfolly.la
 else
 libfollytestmain_la_CPPFLAGS = $(libgtest_la_CPPFLAGS)
-libfollytestmain_la_SOURCES = $(libgtest_la_SOURCES) gtest-1.7.0/src/gtest_main.cc
+libfollytestmain_la_SOURCES = $(libgtest_la_SOURCES) gtest-1.8.0/googletest/src/gtest_main.cc
 libfollytestmain_la_LIBADD = $(top_builddir)/libfolly.la
 endif
 

--- a/folly/test/Makefile.am
+++ b/folly/test/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = . function_benchmark
 
 ACLOCAL_AMFLAGS = -I m4
 
-CPPFLAGS += -Igtest-1.8.0/googletest/include -Igtest-1.8.0/googlemock/include
+CPPFLAGS += -Igtest/googletest/include -Igtest/googlemock/include
 
 TESTS= \
 	sorted_vector_types_test \
@@ -20,8 +20,8 @@ check_LTLIBRARIES = libfollytestmain.la libgtest.la
 check_PROGRAMS =
 noinst_LTLIBRARIES = thread_local_test_lib.la
 
-libgtest_la_CPPFLAGS = -Igtest-1.8.0/googletest
-libgtest_la_SOURCES = gtest-1.8.0/googletest/src/gtest-all.cc
+libgtest_la_CPPFLAGS = -Igtest/googletest
+libgtest_la_SOURCES = gtest/googletest/src/gtest-all.cc
 
 if FOLLY_TESTMAIN
 libfollytestmain_la_CPPFLAGS = $(AM_CPPFLAGS) $(libgtest_la_CPPFLAGS)
@@ -29,7 +29,7 @@ libfollytestmain_la_SOURCES = $(libgtest_la_SOURCES) common/TestMain.cpp
 libfollytestmain_la_LIBADD = $(top_builddir)/init/libfollyinit.la $(top_builddir)/libfolly.la
 else
 libfollytestmain_la_CPPFLAGS = $(libgtest_la_CPPFLAGS)
-libfollytestmain_la_SOURCES = $(libgtest_la_SOURCES) gtest-1.8.0/googletest/src/gtest_main.cc
+libfollytestmain_la_SOURCES = $(libgtest_la_SOURCES) gtest/googletest/src/gtest_main.cc
 libfollytestmain_la_LIBADD = $(top_builddir)/libfolly.la
 endif
 


### PR DESCRIPTION
`make check` was failing because <gmock.h> is included but not supplied. Updating to googletest 1.8.0 includes both googletest & googlemock, so `make check` now runs (and passes).