### PR TITLE
Re-enable io tests

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -1,7 +1,7 @@
 if FOLLY_TESTMAIN
-SUBDIRS = . experimental init test
+SUBDIRS = . experimental init test io/test
 else
-SUBDIRS = . test
+SUBDIRS = . test io/test
 endif
 
 ACLOCAL_AMFLAGS = -I m4

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -634,6 +634,7 @@ FB_FILTER_PKG_LIBS([$AM_LDFLAGS $LIBS])
 
 # Output
 AC_CONFIG_FILES([Makefile
+                 io/test/Makefile
                  libfolly.pc
                  test/Makefile
                  test/function_benchmark/Makefile

--- a/folly/experimental/io/test/Makefile.am
+++ b/folly/experimental/io/test/Makefile.am
@@ -1,12 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
 
-TESTS = iobuf_test \
-        iobuf_cursor_test
+TESTS =
 
 check_PROGRAMS = $(TESTS)
-
-iobuf_test_SOURCES = IOBufTest.cpp
-iobuf_test_LDADD = $(top_builddir)/libfollyio.la
-
-iobuf_cursor_test_SOURCES = IOBufCursorTest.cpp
-iobuf_cursor_test_LDADD = $(top_builddir)/libfollyio.la $(top_builddir)/libfollybenchmark.la

--- a/folly/io/test/.gitignore
+++ b/folly/io/test/.gitignore
@@ -1,0 +1,3 @@
+*.log
+*.trs
+*-test

--- a/folly/io/test/Makefile.am
+++ b/folly/io/test/Makefile.am
@@ -1,0 +1,33 @@
+ACLOCAL_AMFLAGS = -I m4
+
+CPPFLAGS = -I$(top_srcdir)/test/gtest-1.8.0/googletest/include
+ldadd = $(top_builddir)/test/libfollytestmain.la
+
+TESTS = $(check_PROGRAMS)
+
+check_PROGRAMS = compression-test \
+		 iobuf-test \
+		 iobuf-cursor-test \
+		 iobuf-queue-test \
+		 record-io-test \
+		 shutdown-socket-set-test
+
+iobuf_test_SOURCES = IOBufTest.cpp
+iobuf_test_LDADD = $(ldadd)
+
+iobuf_cursor_test_SOURCES = IOBufCursorTest.cpp
+iobuf_cursor_test_LDADD = $(ldadd)
+
+compression_test_SOURCES = CompressionTest.cpp
+compression_test_LDADD = $(top_builddir)/libfolly.la \
+			 $(top_builddir)/test/libgtest.la \
+			 $(top_builddir)/libfollybenchmark.la
+
+iobuf_queue_test_SOURCES = IOBufQueueTest.cpp
+iobuf_queue_test_LDADD = $(ldadd)
+
+record_io_test_SOURCES = RecordIOTest.cpp
+record_io_test_LDADD = $(ldadd)
+
+shutdown_socket_set_test_SOURCES = ShutdownSocketSetTest.cpp
+shutdown_socket_set_test_LDADD = $(ldadd)

--- a/folly/io/test/Makefile.am
+++ b/folly/io/test/Makefile.am
@@ -3,14 +3,16 @@ ACLOCAL_AMFLAGS = -I m4
 CPPFLAGS = -I$(top_srcdir)/test/gtest-1.8.0/googletest/include
 ldadd = $(top_builddir)/test/libfollytestmain.la
 
-TESTS = $(check_PROGRAMS)
+# compression-test takes several minutes, so it's not run automatically.
+TESTS = \
+	iobuf-test \
+	iobuf-cursor-test \
+	iobuf-queue-test \
+	record-io-test \
+	shutdown-socket-set-test
 
-check_PROGRAMS = compression-test \
-		 iobuf-test \
-		 iobuf-cursor-test \
-		 iobuf-queue-test \
-		 record-io-test \
-		 shutdown-socket-set-test
+check_PROGRAMS = $(TESTS) \
+		 compression-test
 
 iobuf_test_SOURCES = IOBufTest.cpp
 iobuf_test_LDADD = $(ldadd)


### PR DESCRIPTION
Looks like some tests for the `io` directory were left behind when they were moved out of `experimental`. Re-enabled them in the new location, except for the compression test because it takes a lot longer. It's still built and can be executed manually.

Also added some preprocessor guards around compression codecs that might not be compiled in (and would therefore fail during test SetUp).