### PR TITLE
Re-enable io tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,13 @@ aclocal.m4
 autom4te.cache
 build-aux
 libtool
-folly/test/gtest-1.*
+folly/test/gtest
 folly/folly-config.h
-folly/test/*_benchmark
-folly/test/*_test
-folly/test/*_test_using_jemalloc
+folly/**/test/*_benchmark
+folly/**/test/*.log
+folly/**/test/*_test
+folly/**/test/*_test_using_jemalloc
+folly/**/test/*.trs
 folly/config.*
 folly/configure
 folly/libfolly.pc

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -1,5 +1,5 @@
 if FOLLY_TESTMAIN
-SUBDIRS = . experimental init test io/test
+SUBDIRS = . experimental init test io/test experimental/io/test
 else
 SUBDIRS = . test io/test
 endif

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -1,7 +1,7 @@
 if FOLLY_TESTMAIN
-SUBDIRS = . experimental init test
+SUBDIRS = . experimental init test io/test
 else
-SUBDIRS = . test
+SUBDIRS = . test io/test
 endif
 
 ACLOCAL_AMFLAGS = -I m4

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -1,7 +1,7 @@
 if FOLLY_TESTMAIN
 SUBDIRS = . experimental init test io/test experimental/io/test
 else
-SUBDIRS = . test io/test
+SUBDIRS = . experimental test io/test experimental/io/test
 endif
 
 ACLOCAL_AMFLAGS = -I m4

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -615,6 +615,7 @@ AC_CONFIG_FILES([Makefile
                  test/Makefile
                  test/function_benchmark/Makefile
                  experimental/Makefile
+                 experimental/io/test/Makefile
                  experimental/symbolizer/Makefile
                  init/Makefile])
 AC_OUTPUT

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -610,6 +610,7 @@ FB_FILTER_PKG_LIBS([$AM_LDFLAGS $LIBS])
 
 # Output
 AC_CONFIG_FILES([Makefile
+                 io/test/Makefile
                  libfolly.pc
                  test/Makefile
                  test/function_benchmark/Makefile

--- a/folly/experimental/io/test/Makefile.am
+++ b/folly/experimental/io/test/Makefile.am
@@ -1,12 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
 
-TESTS = iobuf_test \
-        iobuf_cursor_test
+TESTS =
 
 check_PROGRAMS = $(TESTS)
-
-iobuf_test_SOURCES = IOBufTest.cpp
-iobuf_test_LDADD = $(top_builddir)/libfollyio.la
-
-iobuf_cursor_test_SOURCES = IOBufCursorTest.cpp
-iobuf_cursor_test_LDADD = $(top_builddir)/libfollyio.la $(top_builddir)/libfollybenchmark.la

--- a/folly/experimental/io/test/Makefile.am
+++ b/folly/experimental/io/test/Makefile.am
@@ -1,5 +1,12 @@
 ACLOCAL_AMFLAGS = -I m4
 
-TESTS =
+CPPFLAGS = -I$(top_srcdir)/test/gtest/googletest/include
+ldadd = $(top_builddir)/test/libfollytestmain.la
 
-check_PROGRAMS = $(TESTS)
+check_PROGRAMS = \
+	fs_util_test
+
+TESTS = $(check_PROGRAMS)
+
+fs_util_test_SOURCES = FsUtilTest.cpp
+fs_util_test_LDADD = $(ldadd)

--- a/folly/io/Compression.cpp
+++ b/folly/io/Compression.cpp
@@ -1192,7 +1192,7 @@ std::unique_ptr<IOBuf> ZSTDCodec::doUncompress(
 }  // namespace
 
 typedef std::unique_ptr<Codec> (*CodecFactory)(int, CodecType);
-static CodecFactory
+static constexpr CodecFactory
     codecFactories[static_cast<size_t>(CodecType::NUM_CODEC_TYPES)] = {
         nullptr, // USER_DEFINED
         NoCompressionCodec::create,

--- a/folly/io/test/.gitignore
+++ b/folly/io/test/.gitignore
@@ -1,0 +1,3 @@
+*.log
+*.trs
+*-test

--- a/folly/io/test/.gitignore
+++ b/folly/io/test/.gitignore
@@ -1,3 +1,0 @@
-*.log
-*.trs
-*-test

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -123,7 +123,6 @@ ConstantDataHolder constantDataHolder(dataSizeLog2);
 // The intersection of the provided codecs & those that are compiled in.
 static std::vector<CodecType> supportedCodecs(std::vector<CodecType> const& v) {
   std::vector<CodecType> supported;
-  supported.reserve(v.size());
 
   std::copy_if(
       std::begin(v),
@@ -131,14 +130,12 @@ static std::vector<CodecType> supportedCodecs(std::vector<CodecType> const& v) {
       std::back_inserter(supported),
       hasCodec);
 
-  supported.shrink_to_fit();
   return supported;
 }
 
 // All compiled-in compression codecs.
 static std::vector<CodecType> const& availableCodecs() {
   static std::vector<CodecType> codecs;
-  codecs.reserve(static_cast<size_t>(CodecType::NUM_CODEC_TYPES));
 
   for (size_t i = 0; i < static_cast<size_t>(CodecType::NUM_CODEC_TYPES); ++i) {
     auto type = static_cast<CodecType>(i);
@@ -146,8 +143,6 @@ static std::vector<CodecType> const& availableCodecs() {
       codecs.push_back(type);
     }
   }
-
-  codecs.shrink_to_fit();
 
   return codecs;
 }

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -152,11 +152,7 @@ class CompressionTest
     auto tup = GetParam();
     uncompressedLength_ = uint64_t(1) << std::tr1::get<0>(tup);
     chunks_ = std::tr1::get<1>(tup);
-
-    auto codecType = std::tr1::get<2>(tup);
-    if (hasCodec(codecType)) {
-      codec_ = getCodec(codecType);
-    }
+    codec_ = getCodec(std::tr1::get<2>(tup));
   }
 
   void runSimpleIOBufTest(const DataHolder& dh);

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -134,8 +134,8 @@ static std::vector<CodecType> supportedCodecs(std::vector<CodecType> const& v) {
 }
 
 // All compiled-in compression codecs.
-static std::vector<CodecType> const& availableCodecs() {
-  static std::vector<CodecType> codecs;
+static std::vector<CodecType> availableCodecs() {
+  std::vector<CodecType> codecs;
 
   for (size_t i = 0; i < static_cast<size_t>(CodecType::NUM_CODEC_TYPES); ++i) {
     auto type = static_cast<CodecType>(i);

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -122,15 +122,29 @@ ConstantDataHolder constantDataHolder(dataSizeLog2);
 
 TEST(CompressionTestNeedsUncompressedLength, Simple) {
   EXPECT_FALSE(getCodec(CodecType::NO_COMPRESSION)->needsUncompressedLength());
+#if FOLLY_HAVE_LIBLZ4
   EXPECT_TRUE(getCodec(CodecType::LZ4)->needsUncompressedLength());
+#endif
+#if FOLLY_HAVE_LIBSNAPPY
   EXPECT_FALSE(getCodec(CodecType::SNAPPY)->needsUncompressedLength());
+#endif
+#if FOLLY_HAVE_LIBZ
   EXPECT_FALSE(getCodec(CodecType::ZLIB)->needsUncompressedLength());
+#endif
+#if FOLLY_HAVE_LIBLZ4
   EXPECT_FALSE(getCodec(CodecType::LZ4_VARINT_SIZE)->needsUncompressedLength());
+#endif
+#if FOLLY_HAVE_LIBLZMA
   EXPECT_TRUE(getCodec(CodecType::LZMA2)->needsUncompressedLength());
   EXPECT_FALSE(getCodec(CodecType::LZMA2_VARINT_SIZE)
     ->needsUncompressedLength());
+#endif
+#if FOLLY_HAVE_LIBZSTD
   EXPECT_FALSE(getCodec(CodecType::ZSTD)->needsUncompressedLength());
+#endif
+#if FOLLY_HAVE_LIBZ
   EXPECT_FALSE(getCodec(CodecType::GZIP)->needsUncompressedLength());
+#endif
 }
 
 class CompressionTest
@@ -237,15 +251,29 @@ INSTANTIATE_TEST_CASE_P(
         testing::Values(0, 1, 12, 22, 25, 27),
         testing::Values(1, 2, 3, 8, 65),
         testing::Values(
-            CodecType::NO_COMPRESSION,
+#if FOLLY_HAVE_LIBLZ4
             CodecType::LZ4,
+#endif
+#if FOLLY_HAVE_LIBSNAPPY
             CodecType::SNAPPY,
+#endif
+#if FOLLY_HAVE_LIBZ
             CodecType::ZLIB,
+#endif
+#if FOLLY_HAVE_LIBLZ4
             CodecType::LZ4_VARINT_SIZE,
+#endif
+#if FOLLY_HAVE_LIBLZMA
             CodecType::LZMA2,
             CodecType::LZMA2_VARINT_SIZE,
+#endif
+#if FOLLY_HAVE_LIBZSTD
             CodecType::ZSTD,
-            CodecType::GZIP)));
+#endif
+#if FOLLY_HAVE_LIBZ
+            CodecType::GZIP,
+#endif
+            CodecType::NO_COMPRESSION)));
 
 class CompressionVarintTest
     : public testing::TestWithParam<std::tr1::tuple<int, CodecType>> {
@@ -354,15 +382,21 @@ TEST_P(CompressionCorruptionTest, ConstantData) {
   runSimpleTest(constantDataHolder);
 }
 
+static const CodecType corruptionTestCodecs[] = {
+  // NO_COMPRESSION can't detect corruption
+  // LZ4 can't detect corruption reliably
+#if FOLLY_HAVE_LIBSNAPPY
+  CodecType::SNAPPY,
+#endif
+#if FOLLY_HAVE_LIBZ
+  CodecType::ZLIB,
+#endif
+};
+
 INSTANTIATE_TEST_CASE_P(
     CompressionCorruptionTest,
     CompressionCorruptionTest,
-    testing::Values(
-        // NO_COMPRESSION can't detect corruption
-        // LZ4 can't detect corruption reliably (sigh)
-        CodecType::SNAPPY,
-        CodecType::ZLIB));
-
+    testing::ValuesIn(corruptionTestCodecs));
 }}}  // namespaces
 
 int main(int argc, char *argv[]) {

--- a/folly/io/test/Makefile.am
+++ b/folly/io/test/Makefile.am
@@ -3,14 +3,16 @@ ACLOCAL_AMFLAGS = -I m4
 CPPFLAGS = -I$(top_srcdir)/test/gtest/googletest/include
 ldadd = $(top_builddir)/test/libfollytestmain.la
 
-TESTS = $(check_PROGRAMS)
+# compression-test takes several minutes, so it's not run automatically.
+TESTS = \
+	iobuf-test \
+	iobuf-cursor-test \
+	iobuf-queue-test \
+	record-io-test \
+	shutdown-socket-set-test
 
-check_PROGRAMS = compression-test \
-		 iobuf-test \
-		 iobuf-cursor-test \
-		 iobuf-queue-test \
-		 record-io-test \
-		 shutdown-socket-set-test
+check_PROGRAMS = $(TESTS) \
+		 compression-test
 
 iobuf_test_SOURCES = IOBufTest.cpp
 iobuf_test_LDADD = $(ldadd)

--- a/folly/io/test/Makefile.am
+++ b/folly/io/test/Makefile.am
@@ -3,16 +3,16 @@ ACLOCAL_AMFLAGS = -I m4
 CPPFLAGS = -I$(top_srcdir)/test/gtest/googletest/include
 ldadd = $(top_builddir)/test/libfollytestmain.la
 
-# compression-test takes several minutes, so it's not run automatically.
+# compression_test takes several minutes, so it's not run automatically.
 TESTS = \
-	iobuf-test \
-	iobuf-cursor-test \
-	iobuf-queue-test \
-	record-io-test \
-	shutdown-socket-set-test
+	iobuf_test \
+	iobuf_cursor_test \
+	iobuf_queue_test \
+	record_io_test \
+	shutdown_socket_set_test
 
 check_PROGRAMS = $(TESTS) \
-		 compression-test
+		 compression_test
 
 iobuf_test_SOURCES = IOBufTest.cpp
 iobuf_test_LDADD = $(ldadd)

--- a/folly/io/test/Makefile.am
+++ b/folly/io/test/Makefile.am
@@ -1,0 +1,33 @@
+ACLOCAL_AMFLAGS = -I m4
+
+CPPFLAGS = -I$(top_srcdir)/test/gtest/googletest/include
+ldadd = $(top_builddir)/test/libfollytestmain.la
+
+TESTS = $(check_PROGRAMS)
+
+check_PROGRAMS = compression-test \
+		 iobuf-test \
+		 iobuf-cursor-test \
+		 iobuf-queue-test \
+		 record-io-test \
+		 shutdown-socket-set-test
+
+iobuf_test_SOURCES = IOBufTest.cpp
+iobuf_test_LDADD = $(ldadd)
+
+iobuf_cursor_test_SOURCES = IOBufCursorTest.cpp
+iobuf_cursor_test_LDADD = $(ldadd)
+
+compression_test_SOURCES = CompressionTest.cpp
+compression_test_LDADD = $(top_builddir)/libfolly.la \
+			 $(top_builddir)/test/libgtest.la \
+			 $(top_builddir)/libfollybenchmark.la
+
+iobuf_queue_test_SOURCES = IOBufQueueTest.cpp
+iobuf_queue_test_LDADD = $(ldadd)
+
+record_io_test_SOURCES = RecordIOTest.cpp
+record_io_test_LDADD = $(ldadd)
+
+shutdown_socket_set_test_SOURCES = ShutdownSocketSetTest.cpp
+shutdown_socket_set_test_LDADD = $(ldadd)

--- a/folly/test/.gitignore
+++ b/folly/test/.gitignore
@@ -1,3 +1,0 @@
-*.log
-*.trs
-gtest*/*


### PR DESCRIPTION
Looks like some tests for the `io` directory were left behind when they were moved out of experimental. Re-enabled them in the new location, except for the compression test because it takes a lot longer. It's still built and can be executed manually.

Also added some preprocessor guards around compression codecs that might not be compiled in (and therefore fail during test SetUp).

Depends on #547 because the path to gtest appears in the new Makefile.am's `CPPFLAGS`.