### PR TITLE
Fix the pkg-config filter

### DIFF
--- a/folly/m4/fb_filter_pkg_libs.m4
+++ b/folly/m4/fb_filter_pkg_libs.m4
@@ -2,7 +2,7 @@ AC_DEFUN([FB_FILTER_PKG_LIBS],
   [AC_REQUIRE([AC_PROG_SED])
    deps_=`for p in $PKG_DEPS; do pkg-config --libs $p; done`
    filter_=`for l in $deps_;dnl
-     do echo $l | $SED -e 's%\(-l.*\)%-e s/\1//%' -e '/^-L/d';dnl
+     do echo $l | $SED -ne 's%\(-l.*\)%-e s/\1//%p';dnl
      done`
    PKG_LIBS=`echo $1 | $SED $filter_`
   ]


### PR DESCRIPTION
I encountered a situation where "pkg-config --libs openssl" included
some linker flags, i.e.

    $ pkg-config --libs openssl
    -Wl,-z,relro -lssl -lcrypto -ldl -lz

This resulted in these linker flags being passed to sed. This change
filters out the linker flags from the pkg-config output.