### PR TITLE
Add support for OpenSSL 1.0

### DIFF
--- a/folly/io/async/SSLContext.cpp
+++ b/folly/io/async/SSLContext.cpp
@@ -149,16 +149,7 @@ void SSLContext::setClientECCurvesList(
 }
 
 void SSLContext::setServerECCurve(const std::string& curveName) {
-  bool validCall = false;
-#if OPENSSL_VERSION_NUMBER >= 0x0090800fL
-#ifndef OPENSSL_NO_ECDH
-  validCall = true;
-#endif
-#endif
-  if (!validCall) {
-    throw std::runtime_error("Elliptic curve encryption not allowed");
-  }
-
+#if OPENSSL_VERSION_NUMBER >= 0x0090800fL && !defined(OPENSSL_NO_ECDH)
   EC_KEY* ecdh = nullptr;
   int nid;
 
@@ -180,6 +171,9 @@ void SSLContext::setServerECCurve(const std::string& curveName) {
 
   SSL_CTX_set_tmp_ecdh(ctx_, ecdh);
   EC_KEY_free(ecdh);
+#else
+  throw std::runtime_error("Elliptic curve encryption not allowed");
+#endif
 }
 
 void SSLContext::setX509VerifyParam(

--- a/folly/portability/OpenSSL.cpp
+++ b/folly/portability/OpenSSL.cpp
@@ -37,7 +37,19 @@ int BIO_meth_set_write(BIO_METHOD* biom, int (*write)(BIO*, const char*, int)) {
   return 1;
 }
 
-#elif FOLLY_OPENSSL_IS_102 || FOLLY_OPENSSL_IS_101
+#elif FOLLY_OPENSSL_IS_102 || FOLLY_OPENSSL_IS_101 || FOLLY_OPENSSL_IS_100
+
+#if FOLLY_OPENSSL_IS_100
+uint32_t SSL_CIPHER_get_id(const SSL_CIPHER *c) {
+  return c->id;
+}
+
+int TLS1_get_client_version(const SSL* s) {
+  return (s->client_version >> 8) == TLS1_VERSION_MAJOR ? s->client_version : 0;
+}
+
+#endif
+
 int SSL_CTX_up_ref(SSL_CTX* ctx) {
   return CRYPTO_add(&ctx->references, 1, CRYPTO_LOCK_SSL_CTX);
 }

--- a/folly/portability/OpenSSL.h
+++ b/folly/portability/OpenSSL.h
@@ -21,6 +21,7 @@
 
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+#include <cstdint>
 
 namespace folly {
 namespace ssl {
@@ -29,6 +30,9 @@ namespace ssl {
 // OPENSSL_VERSION_NUMBER to maintain compatibility. The following variables are
 // intended to be specific to OpenSSL.
 #if !defined(OPENSSL_IS_BORINGSSL)
+#define FOLLY_OPENSSL_IS_100                \
+  (OPENSSL_VERSION_NUMBER >= 0x10000003L && \
+   OPENSSL_VERSION_NUMBER < 0x1000105fL)
 #define FOLLY_OPENSSL_IS_101                \
   (OPENSSL_VERSION_NUMBER >= 0x1000105fL && \
    OPENSSL_VERSION_NUMBER < 0x1000200fL)
@@ -69,7 +73,14 @@ int TLS1_get_client_version(SSL* s);
 int BIO_meth_set_read(BIO_METHOD* biom, int (*read)(BIO*, char*, int));
 int BIO_meth_set_write(BIO_METHOD* biom, int (*write)(BIO*, const char*, int));
 
-#elif FOLLY_OPENSSL_IS_102 || FOLLY_OPENSSL_IS_101
+#elif FOLLY_OPENSSL_IS_102 || FOLLY_OPENSSL_IS_101 || FOLLY_OPENSSL_IS_100
+
+#if FOLLY_OPENSSL_IS_100
+
+uint32_t SSL_CIPHER_get_id(const SSL_CIPHER*);
+int TLS1_get_client_version(const SSL*);
+
+#endif
 
 int SSL_CTX_up_ref(SSL_CTX* session);
 int SSL_SESSION_up_ref(SSL_SESSION* session);


### PR DESCRIPTION
I'm working on a project where the target platform is tiny a bit out of
date:

    $ openssl version
    OpenSSL 1.0.0-fips 29 Mar 2010

For various "reasons" I'm not able to update it at this time, however I
would like to use Proxygen (and hence Folly). This patch allows Folly to
compile with the above version of OpenSSL.