### PR TITLE
Several fixes to the "SWMRList" example in experimental/hazptr.

### DIFF
--- a/folly/experimental/hazptr/example/SWMRList.h
+++ b/folly/experimental/hazptr/example/SWMRList.h
@@ -56,7 +56,7 @@ class SWMRListSet {
   hazptr_domain& domain_;
 
   /* Used by the single writer */
-  void locate_lower_bound(const T v, std::atomic<Node*>*& prev) const {
+  void locate_lower_bound(const T& v, std::atomic<Node*>*& prev) const {
     auto curr = prev->load();
     while (curr) {
       if (curr->elem_ >= v) break;
@@ -78,16 +78,16 @@ class SWMRListSet {
     }
   }
 
-  bool add(const T v) {
+  bool add(T v) {
     auto prev = &head_;
     locate_lower_bound(v, prev);
     auto curr = prev->load();
     if (curr && curr->elem_ == v) return false;
-    prev->store(new Node(v, curr));
+    prev->store(new Node(std::move(v), curr));
     return true;
   }
 
-  bool remove(const T v) {
+  bool remove(const T& v) {
     auto prev = &head_;
     locate_lower_bound(v, prev);
     auto curr = prev->load();
@@ -97,7 +97,7 @@ class SWMRListSet {
     return true;
   }
   /* Used by readers */
-  bool contains(const T val) const {
+  bool contains(const T& val) const {
     /* Acquire two hazard pointers for hand-over-hand traversal. */
     hazptr_owner<Node> hptr_prev(domain_);
     hazptr_owner<Node> hptr_curr(domain_);

--- a/folly/experimental/hazptr/example/SWMRList.h
+++ b/folly/experimental/hazptr/example/SWMRList.h
@@ -92,7 +92,9 @@ class SWMRListSet {
     locate_lower_bound(v, prev);
     auto curr = prev->load();
     if (!curr || curr->elem_ != v) return false;
-    prev->store(curr->next_.load());
+    Node *curr_next = curr->next_.load();
+    prev->store(curr_next);  // Patch up the actual list...
+    curr->next_.store(nullptr);  // ...and only then null out the removed node.
     curr->retire(domain_);
     return true;
   }


### PR DESCRIPTION
commit 4deb5497373c81b2718ad661a13310454d2212d8

    Fix a correctness bug in "SWMRList.h".
    
    Thanks to Maged for the tip! The old code omitted setting a removed node's
    "next" pointer to `nullptr`, which meant that if the writer removed node
    A and then node B = A->next while the reader was looking at B, then the reader
    might happily keep chasing pointers B->next, B->next->next,... without ever
    noticing that it was now on a "dead branch" of the linked list.
    
    (And then there's a bit of a trick: you really do have to remove the node
    first and *then* set its "next" pointer to null, because if you do the null
    assignment first, you'll truncate the list, which means that some readers
    will see a truncated list and return the wrong answer. I've added comments
    to try to explain this to future-me.)
    
    Style nit: Avoid doing multiple atomic operations on the same line of code.

commit af03649a9b207240ac34359284c3eb14c51c6182

    Modernize the parameter-passing conventions in SWMRList.h.
    
    Pass `T`s by const reference, except in `add` where we're likely to want to
    make a copy of the `T` anyway. In that case it would be more "STL-correct"
    to supply two different overloads `add(T&&)` and `add(const T&)`, but this
    is just an example so it makes sense to keep things simple.

commit 525f487312a9ba69b19bea0be153b219b7f722f0

    Fix an undefined behavior in SWMRList example.
    
    Searching an empty SWMRList<int> always invokes undefined behavior by
    comparing an uninitialized `T elem` against `val` on the final line of
    the `contains` function. Besides, this patch allows SWMRList to work
    with `T`s that aren't default-constructible or even copy-constructible.