### PR TITLE
Two changes to make folly able to build in CygWin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ folly/m4/ltoptions.m4
 folly/m4/ltsugar.m4
 folly/m4/ltversion.m4
 folly/m4/lt~obsolete.m4
-folly/generate_fingerprint_tables
+folly/generate_fingerprint_tables*
 folly/FormatTables.cpp
 folly/EscapeTables.cpp
 folly/GroupVarintTables.cpp

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -599,8 +599,8 @@ libfollybase_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(LT_VERSION)
 libfolly_la_LIBADD = libfollybase.la
 libfolly_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(LT_VERSION) -lssl
 
-FingerprintTables.cpp: generate_fingerprint_tables
-	./generate_fingerprint_tables
+FingerprintTables.cpp: generate_fingerprint_tables$(EXEEXT)
+	./generate_fingerprint_tables$(EXEEXT)
 CLEANFILES += FingerprintTables.cpp
 
 libfollybenchmark_la_SOURCES = Benchmark.cpp

--- a/folly/portability/Stdlib.cpp
+++ b/folly/portability/Stdlib.cpp
@@ -136,3 +136,31 @@ int unsetenv(const char* name) {
 }
 }
 #endif
+
+#if defined(_WIN32) || defined (__CYGWIN__) || defined(__APPLE__)
+#include <string>
+extern char **environ;
+extern "C" {
+int clearenv(void) {
+  char **env = environ;
+  while (env[0] != nullptr) {
+    size_t len = 0;
+    while (env[0][len] != '=') ++len;
+    ++len;
+    {
+      try {
+        std::string name(env[0], len);
+        name[len - 1] = '\0';
+        int result = unsetenv(name.c_str());
+        if (result != 0) {
+          return result;
+        }
+      } catch (const std::bad_alloc&) {
+        return -1;
+      }
+    }
+  }
+  return 0;
+}
+}
+#endif

--- a/folly/portability/Stdlib.h
+++ b/folly/portability/Stdlib.h
@@ -25,7 +25,7 @@
 #endif
 
 extern "C" {
-#ifdef _WIN32
+#if defined(_WIN32)
 // These are technically supposed to be defined linux/limits.h and
 // sys/param.h respectively, but Windows defines _MAX_PATH in stdlib.h,
 // so, instead of creating two headers for a single define each, we put
@@ -46,5 +46,9 @@ int unsetenv(const char* name);
 char*** _NSGetEnviron(void);
 #endif
 #define environ (*_NSGetEnviron())
+#endif
+
+#if defined(_WIN32) || defined (__CYGWIN__) || defined(__APPLE__)
+int clearenv(void);
 #endif
 }


### PR DESCRIPTION
1) Make the generate_fingerprint_tables exec have .exe as file extension on Windows platform;
2) Make an impl of clearenv() in C++ for Windows, CygWin and Apple platforms.