### PR TITLE
Added pkg-config as required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ sudo apt-get install \
     zlib1g-dev \
     binutils-dev \
     libjemalloc-dev \
-    libssl-dev
+    libssl-dev \
+    pkg-config
 ```
 
 If advanced debugging functionality is required


### PR DESCRIPTION
Faced this problem on Ubuntu 14.04.4 LTS

```
configure:16581: error: possibly undefined macro: AC_MSG_NOTICE
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1
```
Fixed with `apt-get install pkg-config`