### PR TITLE
Add exception_tracer to OSS build

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -1,8 +1,13 @@
 if FOLLY_TESTMAIN
-SUBDIRS = . experimental init test io/test experimental/io/test
-else
-SUBDIRS = . experimental test io/test experimental/io/test
+MAYBE_INIT = init
 endif
+
+if EXCEPTION_TRACER
+MAYBE_EXCEPTION_TRACER = experimental/exception_tracer
+endif
+
+SUBDIRS = . experimental $(MAYBE_INIT) test io/test experimental/io/test \
+	  $(MAYBE_EXCEPTION_TRACER)
 
 ACLOCAL_AMFLAGS = -I m4
 
@@ -109,6 +114,11 @@ nobase_follyinclude_HEADERS = \
 	experimental/EventCount.h \
 	experimental/Instructions.h \
 	experimental/bser/Bser.h \
+	experimental/exception_tracer/ExceptionAbi.h \
+	experimental/exception_tracer/ExceptionCounterLib.h \
+	experimental/exception_tracer/ExceptionTracer.h \
+	experimental/exception_tracer/ExceptionTracerLib.h \
+	experimental/exception_tracer/StackTrace.h \
 	experimental/FunctionScheduler.h \
 	experimental/FutureDAG.h \
 	experimental/io/FsUtil.h \

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -580,6 +580,10 @@ AS_IF([test "x${mobile}" = "xyes"], [
               [Define to 1 for compiler guards for mobile targets.])
 ])
 
+AC_ARG_ENABLE([exception-tracer],
+    AS_HELP_STRING([--enable-exception-tracer], [enables building exception tracer]),
+    [build_exception_tracer=${enableval}], [build_exception_tracer=no])
+
 # Include directory that contains "folly" so #include <folly/Foo.h> works
 AM_CPPFLAGS='-I$(top_srcdir)/..'
 AM_CPPFLAGS="$AM_CPPFLAGS $BOOST_CPPFLAGS $OPENSSL_INCLUDES"
@@ -606,6 +610,7 @@ AM_CONDITIONAL([HAVE_EXTRANDOM_SFMT19937],
 AM_CONDITIONAL([FOLLY_TESTMAIN], [test "x${use_follytestmain}" = "xyes"])
 AM_CONDITIONAL([HAVE_LIBDWARF], [test "x${have_libdwarf}" = "xyes"])
 AM_CONDITIONAL([HAVE_BOOST_CONTEXT], [test "x${ax_cv_boost_context}" = "xyes"])
+AM_CONDITIONAL([EXCEPTION_TRACER], [test "x${build_exception_tracer}" = "xyes"])
 
 # remove pkg-config deps from dependent libraries
 # (at least for pkg-config file purposes)
@@ -621,4 +626,7 @@ AC_CONFIG_FILES([Makefile
                  experimental/io/test/Makefile
                  experimental/symbolizer/Makefile
                  init/Makefile])
+
+AM_COND_IF([EXCEPTION_TRACER],
+           [AC_CONFIG_FILES([experimental/exception_tracer/Makefile])])
 AC_OUTPUT

--- a/folly/experimental/exception_tracer/Makefile.am
+++ b/folly/experimental/exception_tracer/Makefile.am
@@ -1,0 +1,13 @@
+SUBDIRS = .
+
+lib_LTLIBRARIES = libfollyexception_tracer.la
+
+libfollyexception_tracer_la_SOURCES = \
+	ExceptionCounterLib.cpp \
+	ExceptionStackTraceLib.cpp \
+	ExceptionTracer.cpp \
+	ExceptionTracerLib.cpp \
+	StackTrace.cpp
+
+libfollyexception_tracer_la_LIBADD = $(top_builddir)/libfolly.la $(top_builddir)/experimental/symbolizer/libfollysymbolizer.la
+libfollyexception_tracer_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(LT_VERSION)


### PR DESCRIPTION
What it says on the tin. Add the exception_tracer library to the folly OSS build, enabled with `--enable-exception-tracer`.