### PR TITLE
Fix compilation on Linux systems without vDSO support

### DIFF
--- a/folly/ClockGettimeWrappers.cpp
+++ b/folly/ClockGettimeWrappers.cpp
@@ -48,7 +48,7 @@ static int64_t clock_gettime_ns_fallback(clockid_t clock) {
 int (*clock_gettime)(clockid_t, timespec* ts) = &::clock_gettime;
 int64_t (*clock_gettime_ns)(clockid_t) = &clock_gettime_ns_fallback;
 
-#ifdef __linux__
+#ifdef FOLLY_HAVE_LINUX_VDSO
 
 namespace {
 

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -289,11 +289,16 @@ if test "$folly_cv_lib_libatomic" = no; then
                   [Please install the GNU Atomic library])])
 fi
 
+if test "$build_os" = "linux-gnu"; then
+  AC_HAVE_LIBRARY([dl],[],[AC_MSG_ERROR(
+                  [Folly depends on libdl])])
+fi
+
 AC_CACHE_CHECK(
   [for liblinux-vdso support],
   [folly_cv_lib_liblinux_vdso],
   [AC_RUN_IFELSE(
-    [AC_LANG_PROGRAM[
+    [AC_LANG_SOURCE[
       #include <dlfcn.h>
       int main() {
         void *h = dlopen("linux-vdso.so.1", RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);


### PR DESCRIPTION
Problems:
- The vDSO check code in configure.ac is broken, and will always fail (uses AC_LANG_PROGRAM but with arguments in the AC_LANG_SOURCE style)
- On Linux, using dlopen/dlsym requires -ldl (libdl) during the link phase. This check was missing and this argument was not added to the linker arguments.
- On a Linux system without vDSO support, libfolly.so still uses vDSO in ClockGettimeWrappers.cpp

Solution:
- Switched to AC_LANG_SOURCE
- Required libdl to exist when build target is Linux. This also adds this dependency to libfolly.la, resulting in fixing a dependency issue for Proxygen (recent Proxygen build would have issues in building examples due to failing linking step due to missing dlopen / dlsym / dlclose symbols)
- In ClockGettimeWrappers.cpp, checking if `__linux__` is set is not sufficient to determine that the system has vDSO support. The autoconf script already exposes a correct check: FOLLY_HAVE_LINUX_VDSO (this is already used in folly/detail/CacheLocality.cpp), so switched to that one.

