### PR TITLE
Move NOMINMAX, WIN32_LEAN_AND_MEAN and _WINSOCK_DEPRECATED_NO_WARNINGS defines from FollyCompiler.cmake into portability/Windows.h

### DIFF
--- a/CMake/FindGMock.cmake
+++ b/CMake/FindGMock.cmake
@@ -1,6 +1,7 @@
 #
 # Find libgmock
 #
+#  LIBGMOCK_DEFINES     - List of defines when using libgmock.
 #  LIBGMOCK_INCLUDE_DIR - where to find gmock/gmock.h, etc.
 #  LIBGMOCK_LIBRARY     - List of libraries when using libgmock.
 #  LIBGMOCK_FOUND       - True if libgmock found.
@@ -15,9 +16,14 @@ FIND_PATH(LIBGMOCK_INCLUDE_DIR gmock/gmock.h)
 
 FIND_LIBRARY(LIBGMOCK_LIBRARY gmock_main)
 
+# There isn't currently an easy way to determine if a library was compiled as
+# a shared library on Windows, so just assume we've been built against a shared
+# build of gmock for now.
+SET(LIBGMOCK_DEFINES "GTEST_LINKED_AS_SHARED_LIBRARY=1" CACHE STRING "")
+
 # handle the QUIETLY and REQUIRED arguments and set LIBGMOCK_FOUND to TRUE if
 # all listed variables are TRUE
 INCLUDE(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBGMOCK DEFAULT_MSG LIBGMOCK_LIBRARY LIBGMOCK_INCLUDE_DIR)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LIBGMOCK DEFAULT_MSG LIBGMOCK_DEFINES LIBGMOCK_LIBRARY LIBGMOCK_INCLUDE_DIR)
 
-MARK_AS_ADVANCED(LIBGMOCK_LIBRARY LIBGMOCK_INCLUDE_DIR)
+MARK_AS_ADVANCED(LIBGMOCK_DEFINES LIBGMOCK_LIBRARY LIBGMOCK_INCLUDE_DIR)

--- a/CMake/FollyCompiler.cmake
+++ b/CMake/FollyCompiler.cmake
@@ -1,7 +1,9 @@
 # Some additional configuration options.
 option(MSVC_ENABLE_ALL_WARNINGS "If enabled, pass /Wall to the compiler." ON)
+option(MSVC_ENABLE_CPP_LATEST "If enabled, pass /std:c++latest to the compiler" ON)
 option(MSVC_ENABLE_DEBUG_INLINING "If enabled, enable inlining in the debug configuration. This allows /Zc:inline to be far more effective." OFF)
 option(MSVC_ENABLE_FAST_LINK "If enabled, pass /DEBUG:FASTLINK to the linker. This makes linking faster, but the gtest integration for Visual Studio can't currently handle the .pdbs generated." OFF)
+option(MSVC_ENABLE_LEAN_AND_MEAN_WINDOWS "If enabled, define WIN32_LEAN_AND_MEAN to include a smaller subset of Windows.h" ON)
 option(MSVC_ENABLE_LTCG "If enabled, use Link Time Code Generation for Release builds." OFF)
 option(MSVC_ENABLE_PARALLEL_BUILD "If enabled, build multiple source files in parallel." ON)
 option(MSVC_ENABLE_STATIC_ANALYSIS "If enabled, do more complex static analysis and generate warnings appropriately." OFF)
@@ -9,6 +11,15 @@ option(MSVC_USE_STATIC_RUNTIME "If enabled, build against the static, rather tha
 
 # Alas, option() doesn't support string values.
 set(MSVC_FAVORED_ARCHITECTURE "blend" CACHE STRING "One of 'blend', 'AMD64', 'INTEL64', or 'ATOM'. This tells the compiler to generate code optimized to run best on the specified architecture.")
+# Add a pretty drop-down selector for these values when using the GUI.
+set_property(
+  CACHE MSVC_FAVORED_ARCHITECTURE
+  PROPERTY STRINGS
+    blend
+    AMD64
+    ATOM
+    INTEL64
+)
 # Validate, and then add the favored architecture.
 if (NOT MSVC_FAVORED_ARCHITECTURE STREQUAL "blend" AND NOT MSVC_FAVORED_ARCHITECTURE STREQUAL "AMD64" AND NOT MSVC_FAVORED_ARCHITECTURE STREQUAL "INTEL64" AND NOT MSVC_FAVORED_ARCHITECTURE STREQUAL "ATOM")
   message(FATAL_ERROR "MSVC_FAVORED_ARCHITECTURE must be set to one of exactly, 'blend', 'AMD64', 'INTEL64', or 'ATOM'! Got '${MSVC_FAVORED_ARCHITECTURE}' instead!")
@@ -46,7 +57,6 @@ function(apply_folly_compile_options_to_target THETARGET)
   # The general options passed:
   target_compile_options(${THETARGET}
     PUBLIC
-      #/std:c++latest # Build in C++17 mode
       /EHa # Enable both SEH and C++ Exceptions.
       /Zc:referenceBinding # Disallow temporaries from binding to non-const lvalue references.
       /Zc:rvalueCast # Enforce the standard rules for explicit type conversion.
@@ -54,6 +64,8 @@ function(apply_folly_compile_options_to_target THETARGET)
       /Zc:strictStrings # Don't allow conversion from a string literal to mutable characters.
       /Zc:threadSafeInit # Enable thread-safe function-local statics initialization.
       /Zc:throwingNew # Assume operator new throws on failure.
+
+      $<$<BOOL:${MSVC_ENABLE_CPP_LATEST}>:/std:c++latest> # Build in C++ Latest mode if requested.
 
       # This is only supported by MSVC 2017
       $<$<BOOL:${MSVC_IS_2017}>:/permissive-> # Be mean, don't allow bad non-standard stuff (C++/CLI, __declspec, etc. are all left intact).
@@ -223,12 +235,14 @@ function(apply_folly_compile_options_to_target THETARGET)
   # And the extra defines:
   target_compile_definitions(${THETARGET}
     PUBLIC
-      _HAS_AUTO_PTR_ETC=1 # We're building in C++ 17 mode, but certain dependencies (Boost) still have dependencies on unary_function and binary_function, so we have to make sure not to remove them.
       _CRT_NONSTDC_NO_WARNINGS # Don't deprecate posix names of functions.
       _CRT_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
       _SCL_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
       
-      _STL_EXTRA_DISABLED_WARNINGS=4365\ 4774\ 4775\ 4987
+      _STL_EXTRA_DISABLED_WARNINGS=4774\ 4987
+
+      $<$<BOOL:${MSVC_ENABLE_CPP_LATEST}>:"_HAS_AUTO_PTR_ETC=1"> # We're building in C++ 17 or greater mode, but certain dependencies (Boost) still have dependencies on unary_function and binary_function, so we have to make sure not to remove them.
+      $<$<BOOL:${MSVC_ENABLE_LEAN_AND_MEAN_WINDOWS}>:"WIN32_LEAN_AND_MEAN"> # Don't include most of Windows.h
   )
 
   # Ignore a warning about an object file not defining any symbols,

--- a/CMake/FollyCompiler.cmake
+++ b/CMake/FollyCompiler.cmake
@@ -224,12 +224,9 @@ function(apply_folly_compile_options_to_target THETARGET)
   target_compile_definitions(${THETARGET}
     PUBLIC
       _HAS_AUTO_PTR_ETC=1 # We're building in C++ 17 mode, but certain dependencies (Boost) still have dependencies on unary_function and binary_function, so we have to make sure not to remove them.
-      NOMINMAX # This is needed because, for some absurd reason, one of the windows headers tries to define "min" and "max" as macros, which messes up most uses of std::numeric_limits.
       _CRT_NONSTDC_NO_WARNINGS # Don't deprecate posix names of functions.
       _CRT_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
       _SCL_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
-      _WINSOCK_DEPRECATED_NO_WARNINGS # Don't deprecate pieces of winsock
-      WIN32_LEAN_AND_MEAN # Don't include most of Windows.h
       
       _STL_EXTRA_DISABLED_WARNINGS=4365\ 4774\ 4775\ 4987
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,10 @@ if (BUILD_TESTS)
     ${FOLLY_DIR}/io/async/test/UndelayedDestruction.h
     ${FOLLY_DIR}/io/async/test/Util.h
   )
+  target_compile_definitions(folly_test_support
+    PUBLIC
+      ${LIBGMOCK_DEFINES}
+  )
   target_include_directories(folly_test_support
     PUBLIC
       ${LIBGMOCK_INCLUDE_DIR}

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Folly is published on Github at https://github.com/facebook/folly
 
 #### Dependencies
 
-folly requires gcc 4.8+ and a version of boost compiled with C++11 support.
+folly requires gcc 4.9+ and a version of boost compiled with C++14 support.
 
 Please download googletest from
 https://github.com/google/googletest/archive/release-1.8.0.tar.gz and unpack it into the

--- a/folly/Checksum.cpp
+++ b/folly/Checksum.cpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <stdexcept>
 
-#if FOLLY_X64 && (__SSE4_2__ || defined(__clang__) || __GNUC_PREREQ(4, 9))
+#if FOLLY_SSE_PREREQ(4, 2)
 #include <nmmintrin.h>
 #endif
 
@@ -31,7 +31,7 @@ namespace detail {
 
 uint32_t
 crc32c_sw(const uint8_t* data, size_t nbytes, uint32_t startingChecksum);
-#if FOLLY_X64 && (__SSE4_2__ || defined(__clang__) || __GNUC_PREREQ(4, 9))
+#if FOLLY_SSE_PREREQ(4, 2)
 
 // Fast SIMD implementation of CRC-32C for x86 with SSE 4.2
 FOLLY_TARGET_ATTRIBUTE("sse4.2")
@@ -107,6 +107,11 @@ bool crc32_hw_supported() {
 #else
 
 uint32_t crc32c_hw(const uint8_t *data, size_t nbytes,
+    uint32_t startingChecksum) {
+  throw std::runtime_error("crc32_hw is not implemented on this platform");
+}
+
+uint32_t crc32_hw(const uint8_t *data, size_t nbytes,
     uint32_t startingChecksum) {
   throw std::runtime_error("crc32_hw is not implemented on this platform");
 }

--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -1141,9 +1141,9 @@ public:
 
 #ifndef _LIBSTDCXX_FBSTRING
   // This is defined for compatibility with std::string
-  /* implicit */ basic_fbstring(const std::string& str)
-      : store_(str.data(), str.size()) {
-  }
+  template <typename A2>
+  /* implicit */ basic_fbstring(const std::basic_string<E, T, A2>& str)
+      : store_(str.data(), str.size()) {}
 #endif
 
   basic_fbstring(const basic_fbstring& str,
@@ -1205,13 +1205,14 @@ public:
 
 #ifndef _LIBSTDCXX_FBSTRING
   // Compatibility with std::string
-  basic_fbstring & operator=(const std::string & rhs) {
+  template <typename A2>
+  basic_fbstring& operator=(const std::basic_string<E, T, A2>& rhs) {
     return assign(rhs.data(), rhs.size());
   }
 
   // Compatibility with std::string
-  std::string toStdString() const {
-    return std::string(data(), size());
+  std::basic_string<E, T, A> toStdString() const {
+    return std::basic_string<E, T, A>(data(), size());
   }
 #else
   // A lot of code in fbcode still uses this method, so keep it here for now.

--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -58,13 +58,6 @@
 #include <folly/Traits.h>
 #include <folly/portability/BitsFunctexcept.h>
 
-#if FOLLY_HAVE_DEPRECATED_ASSOC
-#ifdef _GLIBCXX_SYMVER
-#include <ext/hash_set>
-#include <ext/hash_map>
-#endif
-#endif
-
 // When used in folly, assertions are not disabled.
 #define FBSTRING_ASSERT(expr) assert(expr)
 
@@ -2873,16 +2866,6 @@ namespace std {
 FOLLY_FBSTRING_HASH
 
 }  // namespace std
-
-#if FOLLY_HAVE_DEPRECATED_ASSOC
-#if defined(_GLIBCXX_SYMVER) && !defined(__BIONIC__)
-namespace __gnu_cxx {
-
-FOLLY_FBSTRING_HASH
-
-}  // namespace __gnu_cxx
-#endif // _GLIBCXX_SYMVER && !__BIONIC__
-#endif // FOLLY_HAVE_DEPRECATED_ASSOC
 
 #undef FOLLY_FBSTRING_HASH
 #undef FOLLY_FBSTRING_HASH1

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -149,6 +149,7 @@ nobase_follyinclude_HEADERS = \
 	experimental/symbolizer/StackTrace.h \
 	experimental/symbolizer/Symbolizer.h \
 	experimental/Select64.h \
+	experimental/StampedPtr.h \
 	experimental/StringKeyedCommon.h \
 	experimental/StringKeyedMap.h \
 	experimental/StringKeyedSet.h \

--- a/folly/PackedSyncPtr.h
+++ b/folly/PackedSyncPtr.h
@@ -18,8 +18,8 @@
 
 #include <folly/Portability.h>
 
-#if !FOLLY_X64 && !FOLLY_PPC64
-# error "PackedSyncPtr is x64 and ppc64 specific code."
+#if !FOLLY_X64 && !FOLLY_PPC64 && !FOLLY_A64
+# error "PackedSyncPtr is x64, ppc64 or aarch64 specific code."
 #endif
 
 /*

--- a/folly/PicoSpinLock.h
+++ b/folly/PicoSpinLock.h
@@ -171,7 +171,9 @@ struct PicoSpinLock {
 
 #undef FB_DOBTS
 #elif FOLLY_A64
-    ret = __atomic_fetch_or(&lock_, 1 << Bit, __ATOMIC_SEQ_CST);
+    ret =
+        !(__atomic_fetch_or(&lock_, kLockBitMask_, __ATOMIC_SEQ_CST) &
+          kLockBitMask_);
 #elif FOLLY_PPC64
 #define FB_DOBTS(size)                                 \
     asm volatile("\teieio\n"                           \
@@ -252,7 +254,7 @@ struct PicoSpinLock {
 
 #undef FB_DOBTR
 #elif FOLLY_A64
-    __atomic_fetch_and(&lock_, ~(1 << Bit), __ATOMIC_SEQ_CST);
+    __atomic_fetch_and(&lock_, ~kLockBitMask_, __ATOMIC_SEQ_CST);
 #elif FOLLY_PPC64
 #define FB_DOBTR(size)                                 \
     asm volatile("\teieio\n"                           \

--- a/folly/String.h
+++ b/folly/String.h
@@ -24,13 +24,6 @@
 #include <boost/type_traits.hpp>
 #include <boost/regex/pending/unicode_iterator.hpp>
 
-#ifdef FOLLY_HAVE_DEPRECATED_ASSOC
-#ifdef _GLIBCXX_SYMVER
-#include <ext/hash_set>
-#include <ext/hash_map>
-#endif
-#endif
-
 #include <unordered_set>
 #include <unordered_map>
 

--- a/folly/configure.ac
+++ b/folly/configure.ac
@@ -28,13 +28,6 @@ AM_INIT_AUTOMAKE([foreign dist-bzip2 nostdinc subdir-objects])
 
 AC_CONFIG_MACRO_DIR([m4])
 
-AX_CONFIG_FEATURE_DEFAULT_DISABLED
-AX_CONFIG_FEATURE(
-        [deprecated-assoc],
-        [supports deprecated associative containers (hash_map/hash_set)],
-        [HAVE_DEPRECATED_ASSOC],
-        [Define if you want to support deprecated associative containers])
-
 AC_PROG_INSTALL
 AM_PROG_LIBTOOL
 

--- a/folly/detail/ChecksumDetail.cpp
+++ b/folly/detail/ChecksumDetail.cpp
@@ -115,6 +115,8 @@
 namespace folly {
 namespace detail {
 
+#if FOLLY_SSE_PREREQ(4, 2)
+
 uint32_t
 crc32_hw_aligned(uint32_t remainder, const __m128i* p, size_t vec_count) {
   /* Constants precomputed by gen_crc32_multipliers.c.  Do not edit! */
@@ -269,5 +271,7 @@ _128_bits_at_a_time:
   x0 = _mm_clmulepi64_si128(_mm_and_si128(x0, mask32), barrett_reduction_constants, 0x10);
   return _mm_cvtsi128_si32(_mm_srli_si128(_mm_xor_si128(x0, x1), 4));
 }
+
+#endif
 }
 } // namespace

--- a/folly/detail/ChecksumDetail.h
+++ b/folly/detail/ChecksumDetail.h
@@ -16,7 +16,12 @@
 
 #pragma once
 
+#include <folly/Portability.h>
+
+#if FOLLY_SSE_PREREQ(4, 2)
 #include <immintrin.h>
+#endif
+
 #include <stdint.h>
 #include <cstddef>
 
@@ -68,8 +73,10 @@ uint32_t crc32c_sw(const uint8_t* data, size_t nbytes,
 uint32_t
 crc32_hw(const uint8_t* data, size_t nbytes, uint32_t startingChecksum = ~0U);
 
+#if FOLLY_SSE_PREREQ(4, 2)
 uint32_t
 crc32_hw_aligned(uint32_t remainder, const __m128i* p, size_t vec_count);
+#endif
 
 /**
  * Check whether a hardware-accelerated CRC-32 implementation is

--- a/folly/experimental/EnvUtil.h
+++ b/folly/experimental/EnvUtil.h
@@ -98,7 +98,7 @@ namespace test {
 // of its destruction.
 struct EnvVarSaver {
   EnvVarSaver()
-      : state_(make_unique<experimental::EnvironmentState>(
+      : state_(std::make_unique<experimental::EnvironmentState>(
             experimental::EnvironmentState::fromCurrentEnvironment())) {}
 
   EnvVarSaver(EnvVarSaver&& other) noexcept : state_(std::move(other.state_)) {}

--- a/folly/experimental/JSONSchema.cpp
+++ b/folly/experimental/JSONSchema.cpp
@@ -117,7 +117,7 @@ struct SchemaValidator final : IValidator, public Validator {
     // We break apart the constructor and actually loading the schema so that
     // we can handle the case where a schema refers to itself, e.g. via
     // "$ref": "#".
-    auto v = make_unique<SchemaValidator>();
+    auto v = std::make_unique<SchemaValidator>();
     v->loadSchema(context, schema);
     return v;
   }
@@ -667,7 +667,7 @@ void SchemaValidator::loadSchema(SchemaValidatorContext& context,
     if (p->isString() && p->stringPiece()[0] == '#') {
       auto it = context.refs.find(p->getString());
       if (it != context.refs.end()) {
-        validators_.emplace_back(make_unique<RefValidator>(it->second));
+        validators_.emplace_back(std::make_unique<RefValidator>(it->second));
         return;
       }
 
@@ -704,7 +704,7 @@ void SchemaValidator::loadSchema(SchemaValidatorContext& context,
       // future references to it will just see that pointer and won't try to
       // keep parsing further.
       if (s) {
-        auto v = make_unique<SchemaValidator>();
+        auto v = std::make_unique<SchemaValidator>();
         context.refs[p->getString()] = v.get();
         v->loadSchema(context, *s);
         validators_.emplace_back(std::move(v));
@@ -715,34 +715,34 @@ void SchemaValidator::loadSchema(SchemaValidatorContext& context,
 
   // Numeric validators
   if (const auto* p = schema.get_ptr("multipleOf")) {
-    validators_.emplace_back(make_unique<MultipleOfValidator>(*p));
+    validators_.emplace_back(std::make_unique<MultipleOfValidator>(*p));
   }
   if (const auto* p = schema.get_ptr("maximum")) {
-    validators_.emplace_back(
-        make_unique<ComparisonValidator>(*p,
-                                         schema.get_ptr("exclusiveMaximum"),
-                                         ComparisonValidator::Type::MAX));
+    validators_.emplace_back(std::make_unique<ComparisonValidator>(
+        *p,
+        schema.get_ptr("exclusiveMaximum"),
+        ComparisonValidator::Type::MAX));
   }
   if (const auto* p = schema.get_ptr("minimum")) {
-    validators_.emplace_back(
-        make_unique<ComparisonValidator>(*p,
-                                         schema.get_ptr("exclusiveMinimum"),
-                                         ComparisonValidator::Type::MIN));
+    validators_.emplace_back(std::make_unique<ComparisonValidator>(
+        *p,
+        schema.get_ptr("exclusiveMinimum"),
+        ComparisonValidator::Type::MIN));
   }
 
   // String validators
   if (const auto* p = schema.get_ptr("maxLength")) {
     validators_.emplace_back(
-        make_unique<SizeValidator<std::greater_equal<int64_t>>>(
+        std::make_unique<SizeValidator<std::greater_equal<int64_t>>>(
             *p, dynamic::Type::STRING));
   }
   if (const auto* p = schema.get_ptr("minLength")) {
     validators_.emplace_back(
-        make_unique<SizeValidator<std::less_equal<int64_t>>>(
+        std::make_unique<SizeValidator<std::less_equal<int64_t>>>(
             *p, dynamic::Type::STRING));
   }
   if (const auto* p = schema.get_ptr("pattern")) {
-    validators_.emplace_back(make_unique<StringPatternValidator>(*p));
+    validators_.emplace_back(std::make_unique<StringPatternValidator>(*p));
   }
 
   // Array validators
@@ -750,20 +750,20 @@ void SchemaValidator::loadSchema(SchemaValidatorContext& context,
   const auto* additionalItems = schema.get_ptr("additionalItems");
   if (items || additionalItems) {
     validators_.emplace_back(
-        make_unique<ArrayItemsValidator>(context, items, additionalItems));
+        std::make_unique<ArrayItemsValidator>(context, items, additionalItems));
   }
   if (const auto* p = schema.get_ptr("maxItems")) {
     validators_.emplace_back(
-        make_unique<SizeValidator<std::greater_equal<int64_t>>>(
+        std::make_unique<SizeValidator<std::greater_equal<int64_t>>>(
             *p, dynamic::Type::ARRAY));
   }
   if (const auto* p = schema.get_ptr("minItems")) {
     validators_.emplace_back(
-        make_unique<SizeValidator<std::less_equal<int64_t>>>(
+        std::make_unique<SizeValidator<std::less_equal<int64_t>>>(
             *p, dynamic::Type::ARRAY));
   }
   if (const auto* p = schema.get_ptr("uniqueItems")) {
-    validators_.emplace_back(make_unique<ArrayUniqueValidator>(*p));
+    validators_.emplace_back(std::make_unique<ArrayUniqueValidator>(*p));
   }
 
   // Object validators
@@ -771,46 +771,47 @@ void SchemaValidator::loadSchema(SchemaValidatorContext& context,
   const auto* patternProperties = schema.get_ptr("patternProperties");
   const auto* additionalProperties = schema.get_ptr("additionalProperties");
   if (properties || patternProperties || additionalProperties) {
-    validators_.emplace_back(make_unique<PropertiesValidator>(
+    validators_.emplace_back(std::make_unique<PropertiesValidator>(
         context, properties, patternProperties, additionalProperties));
   }
   if (const auto* p = schema.get_ptr("maxProperties")) {
     validators_.emplace_back(
-        make_unique<SizeValidator<std::greater_equal<int64_t>>>(
+        std::make_unique<SizeValidator<std::greater_equal<int64_t>>>(
             *p, dynamic::Type::OBJECT));
   }
   if (const auto* p = schema.get_ptr("minProperties")) {
     validators_.emplace_back(
-        make_unique<SizeValidator<std::less_equal<int64_t>>>(
+        std::make_unique<SizeValidator<std::less_equal<int64_t>>>(
             *p, dynamic::Type::OBJECT));
   }
   if (const auto* p = schema.get_ptr("required")) {
-    validators_.emplace_back(make_unique<RequiredValidator>(*p));
+    validators_.emplace_back(std::make_unique<RequiredValidator>(*p));
   }
 
   // Misc validators
   if (const auto* p = schema.get_ptr("dependencies")) {
-    validators_.emplace_back(make_unique<DependencyValidator>(context, *p));
+    validators_.emplace_back(
+        std::make_unique<DependencyValidator>(context, *p));
   }
   if (const auto* p = schema.get_ptr("enum")) {
-    validators_.emplace_back(make_unique<EnumValidator>(*p));
+    validators_.emplace_back(std::make_unique<EnumValidator>(*p));
   }
   if (const auto* p = schema.get_ptr("type")) {
-    validators_.emplace_back(make_unique<TypeValidator>(*p));
+    validators_.emplace_back(std::make_unique<TypeValidator>(*p));
   }
   if (const auto* p = schema.get_ptr("allOf")) {
-    validators_.emplace_back(make_unique<AllOfValidator>(context, *p));
+    validators_.emplace_back(std::make_unique<AllOfValidator>(context, *p));
   }
   if (const auto* p = schema.get_ptr("anyOf")) {
-    validators_.emplace_back(make_unique<AnyOfValidator>(
+    validators_.emplace_back(std::make_unique<AnyOfValidator>(
         context, *p, AnyOfValidator::Type::ONE_OR_MORE));
   }
   if (const auto* p = schema.get_ptr("oneOf")) {
-    validators_.emplace_back(make_unique<AnyOfValidator>(
+    validators_.emplace_back(std::make_unique<AnyOfValidator>(
         context, *p, AnyOfValidator::Type::EXACTLY_ONE));
   }
   if (const auto* p = schema.get_ptr("not")) {
-    validators_.emplace_back(make_unique<NotValidator>(context, *p));
+    validators_.emplace_back(std::make_unique<NotValidator>(context, *p));
   }
 }
 
@@ -1014,7 +1015,7 @@ folly::Singleton<Validator> schemaValidator([]() {
 Validator::~Validator() = default;
 
 std::unique_ptr<Validator> makeValidator(const dynamic& schema) {
-  auto v = make_unique<SchemaValidator>();
+  auto v = std::make_unique<SchemaValidator>();
   SchemaValidatorContext context(schema);
   context.refs["#"] = v.get();
   v->loadSchema(context, schema);

--- a/folly/experimental/StampedPtr.h
+++ b/folly/experimental/StampedPtr.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <assert.h>
+#include <stdint.h>
+
+namespace folly {
+
+/**
+ * StampedPtr packs both a pointer to T and a uint16_t into a 64-bit value,
+ * exploiting the fact that current addresses are limited to 48 bits on
+ * all current x86-64 and ARM64 processors.
+ *
+ * For both x86-64 and ARM64, 64-bit pointers have a canonical
+ * form in which the upper 16 bits are equal to bit 47.  Intel has
+ * announced a 57-bit addressing mode (see https://software.intel.com/
+ * sites/default/files/managed/2b/80/5-level_paging_white_paper.pdf),
+ * but it is not yet available.  The first problematic platform will
+ * probably be ARMv8.2, which supports 52-bit virtual addresses.
+ *
+ * This code works on all of the platforms I have available for test,
+ * and probably on all currently-shipping platforms that have a hope of
+ * compiling folly.  Rather than enumerating the supported platforms via
+ * ifdef, this code dynamically validates its packing assumption in debug
+ * builds on each call to a mutating function.  Presumably by the time we
+ * are running this process in an operating system image that can address
+ * more than 256TB of memory, RAM cost and the latency of 128-bit CAS
+ * will have improved enough that this optimization is no longer impactful.
+ *
+ * A common approach to this kind of packing seems to be to just assume
+ * the top 16 bits are zero, but https://github.com/LuaJIT/LuaJIT/issues/49
+ * indicates that ARM64 platforms in the wild are actually setting bit 47
+ * in their stack addresses.  That means that we need to extend bit 47 to
+ * do the right thing (it's not expensive, it compiles to one instruction
+ * on x86-64 and arm64).
+ *
+ * Compare to PackedSyncPtr and DiscriminatedPtr, which perform similar
+ * packing but add additional functionality.  The name is taken from
+ * Java's AtomicStampedReference.  Unlike PackedSyncPtr, which tries to
+ * act pointer-like, this class acts more like a pair whose elements are
+ * named ptr and stamp.  It also allows direct access to the internal
+ * raw field: since we're already at the metal you might want to play
+ * additional games.  It is guaranteed that a zero raw value gets decoded
+ * as a (ptr,stamp) of (nullptr,0).
+ */
+template <typename T>
+struct StampedPtr {
+  /**
+   * The packing is not guaranteed, except that it is guaranteed that
+   * raw == 0 iff ptr() == nullptr && stamp() == 0.
+   */
+  uint64_t raw;
+
+  /* IMPORTANT: default initialization doesn't result in a sane state */
+
+  T* ptr() const {
+    return unpackPtr(raw);
+  }
+
+  uint16_t stamp() const {
+    return unpackStamp(raw);
+  }
+
+  void set(T* ptr, uint16_t stamp) {
+    raw = pack(ptr, stamp);
+  }
+
+  void setPtr(T* ptr) {
+    raw = pack(ptr, unpackStamp(raw));
+  }
+
+  void setStamp(uint16_t stamp) {
+    raw = pack(unpackPtr(raw), stamp);
+  }
+
+  static T* unpackPtr(uint64_t raw) {
+    // Canonical form means we need to extend bit 47 of the pointer to
+    // bits 48..63 (unless the operating system never hands those pointers
+    // to us, which is difficult to prove).  Signed right-shift of a
+    // negative number is implementation-defined in C++ (not undefined!),
+    // but actually does the right thing on all the platforms I can find.
+    auto extended = static_cast<int64_t>(raw) >> kInternalStampBits;
+    return reinterpret_cast<T*>(static_cast<intptr_t>(extended));
+  }
+
+  static uint16_t unpackStamp(uint64_t raw) {
+    return static_cast<uint16_t>(raw);
+  }
+
+  static uint64_t pack(T* ptr, uint16_t stamp) {
+    auto shifted = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr))
+        << kInternalStampBits;
+    uint64_t raw = shifted | stamp;
+    assert(unpackPtr(raw) == ptr);
+    assert(unpackStamp(raw) == stamp);
+    return raw;
+  }
+
+ private:
+  // On 32-bit platforms it works okay to store a ptr in the top 48
+  // bits of a 64-bit value, but it will result in unnecessary work.
+  // If we align the pointer part at word granularity when we have the
+  // space then no shifting will ever be needed.
+  static constexpr unsigned kInternalStampBits = sizeof(void*) == 4 ? 32 : 16;
+};
+
+template <typename T>
+StampedPtr<T> makeStampedPtr(T* ptr, uint16_t stamp) {
+  return StampedPtr<T>{StampedPtr<T>::pack(ptr, stamp)};
+}
+
+} // namespace folly

--- a/folly/experimental/StampedPtr.h
+++ b/folly/experimental/StampedPtr.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <assert.h>
+#include <folly/SafeAssert.h>
+
 #include <stdint.h>
 
 namespace folly {
@@ -106,8 +107,8 @@ struct StampedPtr {
     auto shifted = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr))
         << kInternalStampBits;
     uint64_t raw = shifted | stamp;
-    assert(unpackPtr(raw) == ptr);
-    assert(unpackStamp(raw) == stamp);
+    FOLLY_SAFE_DCHECK(unpackPtr(raw) == ptr, "ptr mismatch.");
+    FOLLY_SAFE_DCHECK(unpackStamp(raw) == stamp, "stamp mismatch.");
     return raw;
   }
 

--- a/folly/experimental/ThreadedRepeatingFunctionRunner.cpp
+++ b/folly/experimental/ThreadedRepeatingFunctionRunner.cpp
@@ -23,20 +23,13 @@ namespace folly {
 ThreadedRepeatingFunctionRunner::ThreadedRepeatingFunctionRunner() {}
 
 ThreadedRepeatingFunctionRunner::~ThreadedRepeatingFunctionRunner() {
-  stopAndWarn("ThreadedRepeatingFunctionRunner");
-}
-
-void ThreadedRepeatingFunctionRunner::stopAndWarn(
-    const std::string& class_of_destructor) {
   if (stopImpl()) {
     LOG(ERROR)
         << "ThreadedRepeatingFunctionRunner::stop() should already have been "
-        << "called, since the " << class_of_destructor << " destructor is now "
-        << "running. This is unsafe because it means that its threads "
-        << "may be accessing class state that was already destroyed "
-        << "(e.g. derived class members, or members that were declared after "
-        << "the " << class_of_destructor << ") .";
-    stop();
+        << "called, since we are now in the Runner's destructor. This is "
+        << "because it means that its threads may be accessing object state "
+        << "that was already destroyed -- e.g. members that were declared "
+        << "after the ThreadedRepeatingFunctionRunner.";
   }
 }
 

--- a/folly/experimental/ThreadedRepeatingFunctionRunner.h
+++ b/folly/experimental/ThreadedRepeatingFunctionRunner.h
@@ -120,7 +120,8 @@ class ThreadedRepeatingFunctionRunner final {
   /**
    * Run your noexcept function `f` in a background loop, sleeping between
    * calls for a duration returned by `f`.  Optionally waits for
-   * `initialSleep` before calling `f` for the first time.
+   * `initialSleep` before calling `f` for the first time.  Names the thread
+   * using up to the first 15 chars of `name`.
    *
    * DANGER: If a non-final class has a ThreadedRepeatingFunctionRunner
    * member (which, by the way, must be declared last in the class), then
@@ -130,6 +131,7 @@ class ThreadedRepeatingFunctionRunner final {
    * your threads.
    */
   void add(
+      std::string name,
       RepeatingFn f,
       std::chrono::milliseconds initialSleep = std::chrono::milliseconds(0));
 

--- a/folly/experimental/observer/detail/ObserverManager.cpp
+++ b/folly/experimental/observer/detail/ObserverManager.cpp
@@ -166,8 +166,8 @@ class ObserverManager::NextQueue {
 };
 
 ObserverManager::ObserverManager() {
-  currentQueue_ = make_unique<CurrentQueue>();
-  nextQueue_ = make_unique<NextQueue>(*this);
+  currentQueue_ = std::make_unique<CurrentQueue>();
+  nextQueue_ = std::make_unique<NextQueue>(*this);
 }
 
 ObserverManager::~ObserverManager() {

--- a/folly/experimental/symbolizer/Symbolizer.cpp
+++ b/folly/experimental/symbolizer/Symbolizer.cpp
@@ -385,7 +385,7 @@ StackTracePrinter::StackTracePrinter(size_t minSignalSafeElfCacheSize, int fd)
           fd,
           SymbolizePrinter::COLOR_IF_TTY,
           size_t(64) << 10), // 64KiB
-      addresses_(make_unique<FrameArray<kMaxStackTraceDepth>>()) {}
+      addresses_(std::make_unique<FrameArray<kMaxStackTraceDepth>>()) {}
 
 void StackTracePrinter::flush() {
   printer_.flush();

--- a/folly/experimental/test/AtomicSharedPtrTest.cpp
+++ b/folly/experimental/test/AtomicSharedPtrTest.cpp
@@ -156,7 +156,7 @@ TEST(AtomicSharedPtr, DeterministicTest) {
       fooptr(foo);
   std::vector<std::thread> threads(FLAGS_num_threads);
   for (int tid = 0; tid < FLAGS_num_threads; ++tid) {
-    threads[tid] = DSched::thread([&, tid]() {
+    threads[tid] = DSched::thread([&]() {
       for (int i = 0; i < 1000; i++) {
         auto l = fooptr.load();
         EXPECT_TRUE(l.get() != nullptr);

--- a/folly/experimental/test/EnvUtilTest.cpp
+++ b/folly/experimental/test/EnvUtilTest.cpp
@@ -45,7 +45,7 @@ TEST(EnvVarSaverTest, ExampleNew) {
   PCHECK(0 == unsetenv(key));
   EXPECT_EQ(nullptr, getenv(key));
 
-  auto saver = make_unique<EnvVarSaver>();
+  auto saver = std::make_unique<EnvVarSaver>();
   PCHECK(0 == setenv(key, "blah", true));
   EXPECT_STREQ("blah", getenv(key));
   saver = nullptr;
@@ -57,7 +57,7 @@ TEST(EnvVarSaverTest, ExampleExisting) {
   EXPECT_NE(nullptr, getenv(key));
   auto value = std::string{getenv(key)};
 
-  auto saver = make_unique<EnvVarSaver>();
+  auto saver = std::make_unique<EnvVarSaver>();
   PCHECK(0 == setenv(key, "blah", true));
   EXPECT_STREQ("blah", getenv(key));
   saver = nullptr;
@@ -180,7 +180,7 @@ TEST(EnvVarSaverTest, ExampleDeleting) {
   EXPECT_NE(nullptr, getenv(key));
   auto value = std::string{getenv(key)};
 
-  auto saver = make_unique<EnvVarSaver>();
+  auto saver = std::make_unique<EnvVarSaver>();
   PCHECK(0 == unsetenv(key));
   EXPECT_EQ(nullptr, getenv(key));
   saver = nullptr;

--- a/folly/experimental/test/RefCountTest.cpp
+++ b/folly/experimental/test/RefCountTest.cpp
@@ -36,29 +36,29 @@ void basicTest() {
   std::vector<std::thread> ts;
   folly::Baton<> threadBatons[numThreads];
   for (size_t t = 0; t < numThreads; ++t) {
-    ts.emplace_back([&count, &b, &got0, numIters, t, &threadBatons]() {
-        for (size_t i = 0; i < numIters; ++i) {
-          auto ret = ++count;
+    ts.emplace_back([&count, &b, &got0, t, &threadBatons] {
+      for (size_t i = 0; i < numIters; ++i) {
+        auto ret = ++count;
 
-          EXPECT_TRUE(ret > 1);
-          if (i == 0) {
-            threadBatons[t].post();
-          }
+        EXPECT_TRUE(ret > 1);
+        if (i == 0) {
+          threadBatons[t].post();
         }
+      }
 
-        if (t == 0) {
-          b.post();
+      if (t == 0) {
+        b.post();
+      }
+
+      for (size_t i = 0; i < numIters; ++i) {
+        auto ret = --count;
+
+        if (ret == 0) {
+          ++got0;
+          EXPECT_EQ(numIters - 1, i);
         }
-
-        for (size_t i = 0; i < numIters; ++i) {
-          auto ret = --count;
-
-          if (ret == 0) {
-            ++got0;
-            EXPECT_EQ(numIters - 1, i);
-          }
-        }
-      });
+      }
+    });
   }
 
   for (size_t t = 0; t < numThreads; ++t) {

--- a/folly/experimental/test/StampedPtrTest.cpp
+++ b/folly/experimental/test/StampedPtrTest.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/experimental/StampedPtr.h>
+
+#include <folly/portability/GTest.h>
+
+TEST(StampedPtr, Basic) {
+  folly::StampedPtr<char> sp;
+  char target[10];
+  sp.set(target, 10);
+  EXPECT_EQ(sp.ptr(), target);
+  EXPECT_EQ(sp.stamp(), 10);
+  sp.setStamp(sp.stamp() + 1);
+  EXPECT_EQ(sp.stamp(), 11);
+  sp.setPtr(target + 1);
+  EXPECT_EQ(sp.ptr(), target + 1);
+
+  uint64_t raw = sp.raw;
+  sp.raw = 0;
+  EXPECT_NE(sp.stamp(), 11);
+  sp.raw = raw;
+  EXPECT_EQ(sp.stamp(), 11);
+  EXPECT_EQ(sp.ptr(), target + 1);
+}
+
+TEST(StampedPtr, Zero) {
+  folly::StampedPtr<char> sp{0};
+  EXPECT_TRUE(sp.ptr() == nullptr);
+  EXPECT_EQ(sp.stamp(), 0);
+}
+
+TEST(StampedPtr, Void) {
+  folly::StampedPtr<void> sp;
+  char target[10];
+  sp.set(target, 10);
+  EXPECT_EQ(sp.ptr(), target);
+}
+
+TEST(StampedPtr, Make) {
+  auto sp = folly::makeStampedPtr("abc", 0xffff);
+  EXPECT_EQ(*sp.ptr(), 'a');
+  EXPECT_EQ(sp.stamp(), 0xffff);
+
+  double x;
+  auto sp2 = folly::makeStampedPtr(&x, 0);
+  EXPECT_EQ(sp2.ptr(), &x);
+  EXPECT_EQ(sp2.stamp(), 0);
+}
+
+TEST(StampedPtr, Const) {
+  folly::StampedPtr<const char> sp{};
+  char target;
+  sp.setPtr(&target);
+}
+
+TEST(StampedPtr, BitExtension) {
+  //                                 fedcba9876543210
+  auto lo = static_cast<uintptr_t>(0x00007fff672333ecLL);
+  auto hi = static_cast<uintptr_t>(0xfffffffff72333ecLL);
+  ASSERT_TRUE(static_cast<intptr_t>(lo) > 0);
+  ASSERT_TRUE(static_cast<intptr_t>(hi) < 0);
+
+  folly::StampedPtr<char> sp{0};
+  sp.setPtr(reinterpret_cast<char*>(lo));
+  EXPECT_EQ(sp.ptr(), reinterpret_cast<char*>(lo));
+  sp.setPtr(reinterpret_cast<char*>(hi));
+  EXPECT_EQ(sp.ptr(), reinterpret_cast<char*>(hi));
+}

--- a/folly/experimental/test/ThreadedRepeatingFunctionRunnerTest.cpp
+++ b/folly/experimental/test/ThreadedRepeatingFunctionRunnerTest.cpp
@@ -27,7 +27,7 @@ struct Foo {
   }
 
   void start() {
-    runner_.add([this]() {
+    runner_.add("Foo", [this]() {
       ++data;
       return std::chrono::seconds(0);
     });
@@ -45,7 +45,7 @@ struct FooLongSleep {
   }
 
   void start() {
-    runner_.add([this]() {
+    runner_.add("FooLongSleep", [this]() {
       data.store(1);
       return 1000h; // Test would time out if we waited
     });

--- a/folly/fibers/FiberManagerMap.cpp
+++ b/folly/fibers/FiberManagerMap.cpp
@@ -63,11 +63,12 @@ class GlobalCache {
     auto& fmPtrRef = map_[&evb];
 
     if (!fmPtrRef) {
-      auto loopController = make_unique<EventBaseLoopController>();
+      auto loopController = std::make_unique<EventBaseLoopController>();
       loopController->attachEventBase(evb);
       evb.runOnDestruction(new EventBaseOnDestructionCallback<EventBaseT>(evb));
 
-      fmPtrRef = make_unique<FiberManager>(std::move(loopController), opts);
+      fmPtrRef =
+          std::make_unique<FiberManager>(std::move(loopController), opts);
     }
 
     return *fmPtrRef;

--- a/folly/fibers/test/FibersTest.cpp
+++ b/folly/fibers/test/FibersTest.cpp
@@ -1545,15 +1545,15 @@ TEST(FiberManager, nestedFiberManagers) {
 }
 
 TEST(FiberManager, semaphore) {
-  constexpr size_t kTasks = 10;
-  constexpr size_t kIterations = 10000;
-  constexpr size_t kNumTokens = 10;
+  static constexpr size_t kTasks = 10;
+  static constexpr size_t kIterations = 10000;
+  static constexpr size_t kNumTokens = 10;
 
   Semaphore sem(kNumTokens);
   int counterA = 0;
   int counterB = 0;
 
-  auto task = [&sem, kNumTokens](int& counter, folly::fibers::Baton& baton) {
+  auto task = [&sem](int& counter, folly::fibers::Baton& baton) {
     FiberManager manager(std::make_unique<EventBaseLoopController>());
     folly::EventBase evb;
     dynamic_cast<EventBaseLoopController&>(manager.loopController())

--- a/folly/fibers/test/FibersTest.cpp
+++ b/folly/fibers/test/FibersTest.cpp
@@ -414,7 +414,7 @@ TEST(FiberManager, addTasksVoid) {
       manager.addTask([&]() {
         std::vector<std::function<void()>> funcs;
         for (size_t i = 0; i < 3; ++i) {
-          funcs.push_back([i, &pendingFibers]() {
+          funcs.push_back([&pendingFibers]() {
             await([&pendingFibers](Promise<int> promise) {
               pendingFibers.push_back(std::move(promise));
             });
@@ -679,7 +679,7 @@ TEST(FiberManager, collectNThrow) {
       manager.addTask([&]() {
         std::vector<std::function<int()>> funcs;
         for (size_t i = 0; i < 3; ++i) {
-          funcs.push_back([i, &pendingFibers]() -> size_t {
+          funcs.push_back([&pendingFibers]() -> size_t {
             await([&pendingFibers](Promise<int> promise) {
               pendingFibers.push_back(std::move(promise));
             });
@@ -718,7 +718,7 @@ TEST(FiberManager, collectNVoid) {
       manager.addTask([&]() {
         std::vector<std::function<void()>> funcs;
         for (size_t i = 0; i < 3; ++i) {
-          funcs.push_back([i, &pendingFibers]() {
+          funcs.push_back([&pendingFibers]() {
             await([&pendingFibers](Promise<int> promise) {
               pendingFibers.push_back(std::move(promise));
             });
@@ -754,7 +754,7 @@ TEST(FiberManager, collectNVoidThrow) {
       manager.addTask([&]() {
         std::vector<std::function<void()>> funcs;
         for (size_t i = 0; i < 3; ++i) {
-          funcs.push_back([i, &pendingFibers]() {
+          funcs.push_back([&pendingFibers]() {
             await([&pendingFibers](Promise<int> promise) {
               pendingFibers.push_back(std::move(promise));
             });
@@ -832,7 +832,7 @@ TEST(FiberManager, collectAllVoid) {
       manager.addTask([&]() {
         std::vector<std::function<void()>> funcs;
         for (size_t i = 0; i < 3; ++i) {
-          funcs.push_back([i, &pendingFibers]() {
+          funcs.push_back([&pendingFibers]() {
             await([&pendingFibers](Promise<int> promise) {
               pendingFibers.push_back(std::move(promise));
             });
@@ -1553,8 +1553,7 @@ TEST(FiberManager, semaphore) {
   int counterA = 0;
   int counterB = 0;
 
-  auto task = [&sem, kTasks, kIterations, kNumTokens](
-      int& counter, folly::fibers::Baton& baton) {
+  auto task = [&sem, kNumTokens](int& counter, folly::fibers::Baton& baton) {
     FiberManager manager(std::make_unique<EventBaseLoopController>());
     folly::EventBase evb;
     dynamic_cast<EventBaseLoopController&>(manager.loopController())
@@ -1733,7 +1732,7 @@ TEST(FiberManager, doubleBatchDispatchTest) {
 template <typename ExecutorT>
 void batchDispatchExceptionHandling(ExecutorT& executor, int i) {
   thread_local BatchDispatcher<int, int, ExecutorT> batchDispatcher(
-      executor, [=, &executor](std::vector<int> &&) -> std::vector<int> {
+      executor, [](std::vector<int> &&) -> std::vector<int> {
         throw std::runtime_error("Surprise!!");
       });
 

--- a/folly/futures/test/BarrierTest.cpp
+++ b/folly/futures/test/BarrierTest.cpp
@@ -112,7 +112,7 @@ TEST(BarrierTest, Random) {
   //
   // At the end, we verify that exactly one future returning true was seen
   // for each iteration.
-  constexpr uint32_t numIterations = 1;
+  static constexpr uint32_t numIterations = 1;
   auto numThreads = folly::Random::rand32(30, 91);
 
   struct ThreadInfo {

--- a/folly/futures/test/BarrierTest.cpp
+++ b/folly/futures/test/BarrierTest.cpp
@@ -137,23 +137,21 @@ TEST(BarrierTest, Random) {
 
   for (auto& tinfo : threads) {
     auto pinfo = &tinfo;
-    tinfo.thread = std::thread(
-        [numIterations, pinfo, &barrier] () {
-          std::vector<folly::Future<bool>> futures;
-          futures.reserve(pinfo->numFutures);
-          for (uint32_t i = 0; i < numIterations; ++i, ++pinfo->iteration) {
-            futures.clear();
-            for (uint32_t j = 0; j < pinfo->numFutures; ++j) {
-              futures.push_back(barrier.wait());
-              auto nanos = folly::Random::rand32(10 * 1000 * 1000);
-              /* sleep override */
-              std::this_thread::sleep_for(std::chrono::nanoseconds(nanos));
-            }
-            auto results = folly::collect(futures).get();
-            pinfo->trueSeen[i] =
-              std::count(results.begin(), results.end(), true);
-          }
-        });
+    tinfo.thread = std::thread([pinfo, &barrier] {
+      std::vector<folly::Future<bool>> futures;
+      futures.reserve(pinfo->numFutures);
+      for (uint32_t i = 0; i < numIterations; ++i, ++pinfo->iteration) {
+        futures.clear();
+        for (uint32_t j = 0; j < pinfo->numFutures; ++j) {
+          futures.push_back(barrier.wait());
+          auto nanos = folly::Random::rand32(10 * 1000 * 1000);
+          /* sleep override */
+          std::this_thread::sleep_for(std::chrono::nanoseconds(nanos));
+        }
+        auto results = folly::collect(futures).get();
+        pinfo->trueSeen[i] = std::count(results.begin(), results.end(), true);
+      }
+    });
   }
 
   for (auto& tinfo : threads) {

--- a/folly/futures/test/FutureSplitterTest.cpp
+++ b/folly/futures/test/FutureSplitterTest.cpp
@@ -108,7 +108,7 @@ TEST(FutureSplitter, splitFutureMoveAssignable) {
 
 TEST(FutureSplitter, splitFutureScope) {
   Promise<int> p;
-  auto pSP = make_unique<FutureSplitter<int>>(p.getFuture());
+  auto pSP = std::make_unique<FutureSplitter<int>>(p.getFuture());
   auto f1 = pSP->getFuture();
   EXPECT_FALSE(f1.isReady());
   pSP.reset();

--- a/folly/futures/test/FutureTest.cpp
+++ b/folly/futures/test/FutureTest.cpp
@@ -618,7 +618,10 @@ TEST(Future, finishBigLambda) {
   EXPECT_EQ(bulk_data[0], 0);
 
   Promise<int> p;
-  auto f = p.getFuture().then([x, bulk_data](Try<int>&& t) { *x = t.value(); });
+  auto f = p.getFuture().then([x, bulk_data](Try<int>&& t) {
+    (void)bulk_data;
+    *x = t.value();
+  });
 
   // The callback hasn't executed
   EXPECT_EQ(0, *x);

--- a/folly/gen/test/ParallelMapTest.cpp
+++ b/folly/gen/test/ParallelMapTest.cpp
@@ -100,20 +100,22 @@ TEST(Pmap, Rvalues) {
   // apply
   {
     auto mapResult
-      = seq(1)
-      | map([](int x) { return make_unique<int>(x); })
-      | map([](std::unique_ptr<int> x) { return make_unique<int>(*x * *x); })
-      | map([](std::unique_ptr<int> x) { return *x; })
-      | take(1000)
-      | sum;
+        = seq(1)
+        | map([](int x) { return std::make_unique<int>(x); })
+        | map([](std::unique_ptr<int> x) {
+            return std::make_unique<int>(*x * *x); })
+        | map([](std::unique_ptr<int> x) { return *x; })
+        | take(1000)
+        | sum;
 
     auto pmapResult
-      = seq(1)
-      | pmap([](int x) { return make_unique<int>(x); })
-      | pmap([](std::unique_ptr<int> x) { return make_unique<int>(*x * *x); })
-      | pmap([](std::unique_ptr<int> x) { return *x; })
-      | take(1000)
-      | sum;
+        = seq(1)
+        | pmap([](int x) { return std::make_unique<int>(x); })
+        | pmap([](std::unique_ptr<int> x) {
+            return std::make_unique<int>(*x * *x); })
+        | pmap([](std::unique_ptr<int> x) { return *x; })
+        | take(1000)
+        | sum;
 
     EXPECT_EQ(pmapResult, mapResult);
   }
@@ -121,18 +123,20 @@ TEST(Pmap, Rvalues) {
   // foreach
   {
     auto mapResult
-      = seq(1, 1000)
-      | map([](int x) { return make_unique<int>(x); })
-      | map([](std::unique_ptr<int> x) { return make_unique<int>(*x * *x); })
-      | map([](std::unique_ptr<int> x) { return *x; })
-      | sum;
+        = seq(1, 1000)
+        | map([](int x) { return std::make_unique<int>(x); })
+        | map([](std::unique_ptr<int> x) {
+            return std::make_unique<int>(*x * *x); })
+        | map([](std::unique_ptr<int> x) { return *x; })
+        | sum;
 
     auto pmapResult
-      = seq(1, 1000)
-      | pmap([](int x) { return make_unique<int>(x); })
-      | pmap([](std::unique_ptr<int> x) { return make_unique<int>(*x * *x); })
-      | pmap([](std::unique_ptr<int> x) { return *x; })
-      | sum;
+        = seq(1, 1000)
+        | pmap([](int x) { return std::make_unique<int>(x); })
+        | pmap([](std::unique_ptr<int> x) {
+            return std::make_unique<int>(*x * *x); })
+        | pmap([](std::unique_ptr<int> x) { return *x; })
+        | sum;
 
     EXPECT_EQ(pmapResult, mapResult);
   }

--- a/folly/io/Compression.cpp
+++ b/folly/io/Compression.cpp
@@ -194,7 +194,7 @@ class NoCompressionCodec final : public Codec {
 };
 
 std::unique_ptr<Codec> NoCompressionCodec::create(int level, CodecType type) {
-  return make_unique<NoCompressionCodec>(level, type);
+  return std::make_unique<NoCompressionCodec>(level, type);
 }
 
 NoCompressionCodec::NoCompressionCodec(int level, CodecType type)
@@ -323,7 +323,7 @@ class LZ4Codec final : public Codec {
 };
 
 std::unique_ptr<Codec> LZ4Codec::create(int level, CodecType type) {
-  return make_unique<LZ4Codec>(level, type);
+  return std::make_unique<LZ4Codec>(level, type);
 }
 
 LZ4Codec::LZ4Codec(int level, CodecType type) : Codec(type) {
@@ -468,7 +468,7 @@ class LZ4FrameCodec final : public Codec {
 /* static */ std::unique_ptr<Codec> LZ4FrameCodec::create(
     int level,
     CodecType type) {
-  return make_unique<LZ4FrameCodec>(level, type);
+  return std::make_unique<LZ4FrameCodec>(level, type);
 }
 
 static constexpr uint32_t kLZ4FrameMagicLE = 0x184D2204;
@@ -666,7 +666,7 @@ class SnappyCodec final : public Codec {
 };
 
 std::unique_ptr<Codec> SnappyCodec::create(int level, CodecType type) {
-  return make_unique<SnappyCodec>(level, type);
+  return std::make_unique<SnappyCodec>(level, type);
 }
 
 SnappyCodec::SnappyCodec(int level, CodecType type) : Codec(type) {
@@ -820,7 +820,7 @@ bool ZlibCodec::canUncompress(const IOBuf* data, Optional<uint64_t>) const {
 }
 
 std::unique_ptr<Codec> ZlibCodec::create(int level, CodecType type) {
-  return make_unique<ZlibCodec>(level, type);
+  return std::make_unique<ZlibCodec>(level, type);
 }
 
 ZlibCodec::ZlibCodec(int level, CodecType type) : Codec(type) {
@@ -1109,7 +1109,7 @@ bool LZMA2Codec::canUncompress(const IOBuf* data, Optional<uint64_t>) const {
 }
 
 std::unique_ptr<Codec> LZMA2Codec::create(int level, CodecType type) {
-  return make_unique<LZMA2Codec>(level, type);
+  return std::make_unique<LZMA2Codec>(level, type);
 }
 
 LZMA2Codec::LZMA2Codec(int level, CodecType type) : Codec(type) {
@@ -1353,7 +1353,7 @@ bool ZSTDCodec::canUncompress(const IOBuf* data, Optional<uint64_t>) const {
 }
 
 std::unique_ptr<Codec> ZSTDCodec::create(int level, CodecType type) {
-  return make_unique<ZSTDCodec>(level, type);
+  return std::make_unique<ZSTDCodec>(level, type);
 }
 
 ZSTDCodec::ZSTDCodec(int level, CodecType type) : Codec(type) {
@@ -1568,7 +1568,7 @@ class Bzip2Codec final : public Codec {
 /* static */ std::unique_ptr<Codec> Bzip2Codec::create(
     int level,
     CodecType type) {
-  return make_unique<Bzip2Codec>(level, type);
+  return std::make_unique<Bzip2Codec>(level, type);
 }
 
 Bzip2Codec::Bzip2Codec(int level, CodecType type) : Codec(type) {
@@ -1817,7 +1817,7 @@ void AutomaticCodec::addCodecIfSupported(CodecType type) {
 
 /* static */ std::unique_ptr<Codec> AutomaticCodec::create(
     std::vector<std::unique_ptr<Codec>> customCodecs) {
-  return make_unique<AutomaticCodec>(std::move(customCodecs));
+  return std::make_unique<AutomaticCodec>(std::move(customCodecs));
 }
 
 AutomaticCodec::AutomaticCodec(std::vector<std::unique_ptr<Codec>> customCodecs)

--- a/folly/io/Cursor.h
+++ b/folly/io/Cursor.h
@@ -439,7 +439,7 @@ class CursorBase {
 
   size_t cloneAtMost(std::unique_ptr<folly::IOBuf>& buf, size_t len) {
     if (!buf) {
-      buf = make_unique<folly::IOBuf>();
+      buf = std::make_unique<folly::IOBuf>();
     }
     return cloneAtMost(*buf, len);
   }

--- a/folly/io/IOBuf.cpp
+++ b/folly/io/IOBuf.cpp
@@ -258,7 +258,7 @@ unique_ptr<IOBuf> IOBuf::createCombined(uint64_t capacity) {
 }
 
 unique_ptr<IOBuf> IOBuf::createSeparate(uint64_t capacity) {
-  return make_unique<IOBuf>(CREATE, capacity);
+  return std::make_unique<IOBuf>(CREATE, capacity);
 }
 
 unique_ptr<IOBuf> IOBuf::createChain(
@@ -309,9 +309,9 @@ unique_ptr<IOBuf> IOBuf::takeOwnership(void* buf, uint64_t capacity,
     //
     // Note that we always pass freeOnError as false to the constructor.
     // If the constructor throws we'll handle it below.  (We have to handle
-    // allocation failures from make_unique too.)
-    return make_unique<IOBuf>(TAKE_OWNERSHIP, buf, capacity, length,
-                              freeFn, userData, false);
+    // allocation failures from std::make_unique too.)
+    return std::make_unique<IOBuf>(
+        TAKE_OWNERSHIP, buf, capacity, length, freeFn, userData, false);
   } catch (...) {
     takeOwnershipError(freeOnError, buf, freeFn, userData);
     throw;
@@ -332,7 +332,7 @@ IOBuf::IOBuf(WrapBufferOp op, ByteRange br)
 }
 
 unique_ptr<IOBuf> IOBuf::wrapBuffer(const void* buf, uint64_t capacity) {
-  return make_unique<IOBuf>(WRAP_BUFFER, buf, capacity);
+  return std::make_unique<IOBuf>(WRAP_BUFFER, buf, capacity);
 }
 
 IOBuf IOBuf::wrapBufferAsValue(const void* buf, uint64_t capacity) {
@@ -506,15 +506,15 @@ void IOBuf::prependChain(unique_ptr<IOBuf>&& iobuf) {
 }
 
 unique_ptr<IOBuf> IOBuf::clone() const {
-  return make_unique<IOBuf>(cloneAsValue());
+  return std::make_unique<IOBuf>(cloneAsValue());
 }
 
 unique_ptr<IOBuf> IOBuf::cloneOne() const {
-  return make_unique<IOBuf>(cloneOneAsValue());
+  return std::make_unique<IOBuf>(cloneOneAsValue());
 }
 
 unique_ptr<IOBuf> IOBuf::cloneCoalesced() const {
-  return make_unique<IOBuf>(cloneCoalescedAsValue());
+  return std::make_unique<IOBuf>(cloneCoalescedAsValue());
 }
 
 IOBuf IOBuf::cloneAsValue() const {

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -1552,7 +1552,9 @@ void AsyncSocket::handleErrMessages() noexcept {
     }
 
     for (struct cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
-         cmsg != nullptr && cmsg->cmsg_len != 0;
+         cmsg != nullptr &&
+           cmsg->cmsg_len != 0 &&
+           errMessageCallback_ != nullptr;
          cmsg = CMSG_NXTHDR(&msg, cmsg)) {
       errMessageCallback_->errMessage(*cmsg);
     }

--- a/folly/io/async/EventBaseThread.cpp
+++ b/folly/io/async/EventBaseThread.cpp
@@ -51,7 +51,7 @@ void EventBaseThread::start() {
   if (th_) {
     return;
   }
-  th_ = make_unique<ScopedEventBaseThread>(ebm_);
+  th_ = std::make_unique<ScopedEventBaseThread>(ebm_);
 }
 
 void EventBaseThread::stop() {

--- a/folly/io/async/test/EventBaseTest.cpp
+++ b/folly/io/async/test/EventBaseTest.cpp
@@ -1189,7 +1189,7 @@ TEST(EventBaseTest, RunInEventBaseThreadAndWait) {
   vector<unique_ptr<atomic<size_t>>> atoms(c);
   for (size_t i = 0; i < c; ++i) {
     auto& atom = atoms.at(i);
-    atom = make_unique<atomic<size_t>>(0);
+    atom = std::make_unique<atomic<size_t>>(0);
   }
   vector<thread> threads;
   for (size_t i = 0; i < c; ++i) {

--- a/folly/io/async/test/EventBaseTest.cpp
+++ b/folly/io/async/test/EventBaseTest.cpp
@@ -1809,7 +1809,7 @@ TEST(EventBaseTest, LoopKeepAliveWithLoopForever) {
     /* sleep override */
     std::this_thread::sleep_for(std::chrono::milliseconds(30));
     ASSERT_FALSE(done) << "Loop terminated early";
-    ev->runInEventBaseThread([&ev, keepAlive = std::move(keepAlive) ]{});
+    ev->runInEventBaseThread([keepAlive = std::move(keepAlive)]{});
   }
 
   evThread.join();

--- a/folly/io/async/test/HHWheelTimerSlowTests.cpp
+++ b/folly/io/async/test/HHWheelTimerSlowTests.cpp
@@ -307,7 +307,7 @@ TEST_F(HHWheelTimerTest, Stress) {
         runtimeouts++;
         /* sleep override */ usleep(1000);
         LOG(INFO) << "Ran " << runtimeouts << " timeouts of " << timeoutcount;
-        timeouts[i].fn = [&, i]() {
+        timeouts[i].fn = [&]() {
           runtimeouts++;
           LOG(INFO) << "Ran " << runtimeouts << " timeouts of " << timeoutcount;
         };

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -83,8 +83,8 @@ class RandomDataHolder : public DataHolder {
 
 RandomDataHolder::RandomDataHolder(size_t sizeLog2)
   : DataHolder(sizeLog2) {
-  constexpr size_t numThreadsLog2 = 3;
-  constexpr size_t numThreads = size_t(1) << numThreadsLog2;
+  static constexpr size_t numThreadsLog2 = 3;
+  static constexpr size_t numThreads = size_t(1) << numThreadsLog2;
 
   uint32_t seed = randomNumberSeed();
 

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -91,15 +91,14 @@ RandomDataHolder::RandomDataHolder(size_t sizeLog2)
   std::vector<std::thread> threads;
   threads.reserve(numThreads);
   for (size_t t = 0; t < numThreads; ++t) {
-    threads.emplace_back(
-        [this, seed, t, numThreadsLog2, sizeLog2] () {
-          std::mt19937 rng(seed + t);
-          size_t countLog2 = sizeLog2 - numThreadsLog2;
-          size_t start = size_t(t) << countLog2;
-          for (size_t i = 0; i < countLog2; ++i) {
-            this->data_[start + i] = rng();
-          }
-        });
+    threads.emplace_back([this, seed, t, sizeLog2] {
+      std::mt19937 rng(seed + t);
+      size_t countLog2 = sizeLog2 - numThreadsLog2;
+      size_t start = size_t(t) << countLog2;
+      for (size_t i = 0; i < countLog2; ++i) {
+        this->data_[start + i] = rng();
+      }
+    });
   }
 
   for (auto& t : threads) {

--- a/folly/io/test/CompressionTest.cpp
+++ b/folly/io/test/CompressionTest.cpp
@@ -488,7 +488,7 @@ namespace {
 class CustomCodec : public Codec {
  public:
   static std::unique_ptr<Codec> create(std::string prefix, CodecType type) {
-    return make_unique<CustomCodec>(std::move(prefix), type);
+    return std::make_unique<CustomCodec>(std::move(prefix), type);
   }
   explicit CustomCodec(std::string prefix, CodecType type)
       : Codec(CodecType::USER_DEFINED),

--- a/folly/portability/BitsFunctexcept.cpp
+++ b/folly/portability/BitsFunctexcept.cpp
@@ -26,7 +26,7 @@
 
 FOLLY_NAMESPACE_STD_BEGIN
 
-#if _LIBCPP_VERSION < 4000 && !FOLLY_SKIP_LIBCPP_4000_THROW_BACKPORTS
+#if _LIBCPP_VERSION < 4000
 void __throw_length_error(char const* msg) {
   throw std::length_error(msg);
 }

--- a/folly/portability/BitsFunctexcept.h
+++ b/folly/portability/BitsFunctexcept.h
@@ -29,7 +29,7 @@
 
 FOLLY_NAMESPACE_STD_BEGIN
 
-#if _LIBCPP_VERSION < 4000 && !FOLLY_SKIP_LIBCPP_4000_THROW_BACKPORTS
+#if _LIBCPP_VERSION < 4000
 [[noreturn]] void __throw_length_error(char const* msg); // @nolint
 [[noreturn]] void __throw_logic_error(char const* msg);
 [[noreturn]] void __throw_out_of_range(char const* msg);

--- a/folly/portability/PThread.h
+++ b/folly/portability/PThread.h
@@ -112,7 +112,7 @@ inline int pthread_attr_getguardsize(
   return 0;
 }
 
-#include <xstddef>
+#include <functional>
 namespace std {
 template <>
 struct hash<pthread_t> {

--- a/folly/portability/Time.cpp
+++ b/folly/portability/Time.cpp
@@ -215,7 +215,7 @@ extern "C" int clock_gettime(clockid_t clock_id, struct timespec* tp) {
   }
 
   const auto unanosToTimespec = [](timespec* tp, unsigned_nanos t) -> int {
-    static constexpr unsigned_nanos one_sec(std::chrono::seconds(1));
+    static constexpr unsigned_nanos one_sec{std::chrono::seconds(1)};
     tp->tv_sec =
         time_t(std::chrono::duration_cast<std::chrono::seconds>(t).count());
     tp->tv_nsec = long((t % one_sec).count());

--- a/folly/portability/Windows.h
+++ b/folly/portability/Windows.h
@@ -37,6 +37,22 @@
 #include <direct.h> // nolint
 #endif
 
+#ifndef _WINDOWS_
+// This is needed because, for some absurd reason, one of the windows headers
+// tries to define "min" and "max" as macros, which messes up most uses of
+// std::numeric_limits.
+#define NOMINMAX
+// Don't include most of Windows.h
+#define WIN32_LEAN_AND_MEAN
+#else
+#error "Folly headers must be included before including Windows.h"
+#endif
+
+#ifndef _WINSOCK2API_
+// Don't deprecate pieces of winsock
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+#endif
+
 #include <WinSock2.h>
 #include <Windows.h>
 

--- a/folly/test/AHMIntStressTest.cpp
+++ b/folly/test/AHMIntStressTest.cpp
@@ -108,17 +108,15 @@ TEST(AHMIntStressTest, Test) {
 
   std::vector<std::thread> threads;
   for (int threadId = 0; threadId < 64; ++threadId) {
-    threads.emplace_back(
-      [objs,threadId] {
-        for (int recycles = 0; recycles < 500; ++recycles) {
-          for (int i = 0; i < 10; i++) {
-            auto val = objs->get(i);
-          }
-
-          objs->archive();
+    threads.emplace_back([objs] {
+      for (int recycles = 0; recycles < 500; ++recycles) {
+        for (int i = 0; i < 10; i++) {
+          auto val = objs->get(i);
         }
+
+        objs->archive();
       }
-    );
+    });
   }
 
   for (auto& t : threads) t.join();

--- a/folly/test/AtomicHashMapTest.cpp
+++ b/folly/test/AtomicHashMapTest.cpp
@@ -403,7 +403,7 @@ namespace {
 inline KeyT randomizeKey(int key) {
   // We deterministically randomize the key to more accurately simulate
   // real-world usage, and to avoid pathalogical performance patterns (e.g.
-  // those related to __gnu_cxx::hash<int64_t>()(1) == 1).
+  // those related to std::hash<int64_t>()(1) == 1).
   //
   // Use a hash function we don't normally use for ints to avoid interactions.
   return folly::hash::jenkins_rev_mix32(key);

--- a/folly/test/AtomicLinkedListTest.cpp
+++ b/folly/test/AtomicLinkedListTest.cpp
@@ -133,12 +133,11 @@ TEST(AtomicIntrusiveLinkedList, Stress) {
 
   std::vector<std::thread> threads;
   for (size_t threadId = 0; threadId < kNumThreads; ++threadId) {
-    threads.emplace_back(
-        [threadId, kNumThreads, kNumElements, &list, &elements]() {
-          for (size_t id = 0; id < kNumElements; ++id) {
-            list.insertHead(&elements[threadId + kNumThreads * id]);
-          }
-        });
+    threads.emplace_back([threadId, &list, &elements] {
+      for (size_t id = 0; id < kNumElements; ++id) {
+        list.insertHead(&elements[threadId + kNumThreads * id]);
+      }
+    });
   }
 
   std::vector<size_t> ids;

--- a/folly/test/AtomicLinkedListTest.cpp
+++ b/folly/test/AtomicLinkedListTest.cpp
@@ -121,8 +121,8 @@ TEST(AtomicIntrusiveLinkedList, Move) {
 }
 
 TEST(AtomicIntrusiveLinkedList, Stress) {
-  constexpr size_t kNumThreads = 32;
-  constexpr size_t kNumElements = 100000;
+  static constexpr size_t kNumThreads = 32;
+  static constexpr size_t kNumElements = 100000;
 
   std::vector<TestIntrusiveObject> elements;
   for (size_t i = 0; i < kNumThreads * kNumElements; ++i) {

--- a/folly/test/FunctionTest.cpp
+++ b/folly/test/FunctionTest.cpp
@@ -322,7 +322,10 @@ TEST(Function, NonCopyableLambda) {
   (void)fooData; // suppress gcc warning about fooData not being used
 
   auto functor = std::bind(
-      [fooData](std::unique_ptr<int>& up) mutable { return ++*up; },
+      [fooData](std::unique_ptr<int>& up) mutable {
+        (void)fooData;
+        return ++*up;
+      },
       std::move(unique_ptr_int));
 
   EXPECT_EQ(901, functor());

--- a/folly/test/MPMCPipelineTest.cpp
+++ b/folly/test/MPMCPipelineTest.cpp
@@ -81,7 +81,7 @@ TEST(MPMCPipeline, MultiThreaded) {
   std::vector<std::thread> threads;
   threads.reserve(numThreadsPerStage * 2 + 1);
   for (size_t i = 0; i < numThreadsPerStage; ++i) {
-    threads.emplace_back([&a, i] () {
+    threads.emplace_back([&a] {
       for (;;) {
         int val;
         auto ticket = a.blockingReadStage<0>(val);
@@ -97,7 +97,7 @@ TEST(MPMCPipeline, MultiThreaded) {
   }
 
   for (size_t i = 0; i < numThreadsPerStage; ++i) {
-    threads.emplace_back([&a, i] () {
+    threads.emplace_back([&a] {
       for (;;) {
         std::string val;
         auto ticket = a.blockingReadStage<1>(val);

--- a/folly/test/MPMCQueueTest.cpp
+++ b/folly/test/MPMCQueueTest.cpp
@@ -482,18 +482,16 @@ void runMtProdConsDeterministic(long seed) {
   // we use the Bench method, but perf results are meaningless under DSched
   DSched sched(DSched::uniform(seed));
 
-  vector<unique_ptr<WriteMethodCaller<MPMCQueue<int, DeterministicAtomic,
-                                                Dynamic>>>> callers;
-  callers.emplace_back(make_unique<BlockingWriteCaller<MPMCQueue<int,
-                       DeterministicAtomic, Dynamic>>>());
-  callers.emplace_back(make_unique<WriteIfNotFullCaller<MPMCQueue<int,
-                       DeterministicAtomic, Dynamic>>>());
-  callers.emplace_back(make_unique<WriteCaller<MPMCQueue<int,
-                       DeterministicAtomic, Dynamic>>>());
-  callers.emplace_back(make_unique<TryWriteUntilCaller<MPMCQueue<int,
-                       DeterministicAtomic, Dynamic>>>(milliseconds(1)));
-  callers.emplace_back(make_unique<TryWriteUntilCaller<MPMCQueue<int,
-                       DeterministicAtomic, Dynamic>>>(seconds(2)));
+  using QueueType = MPMCQueue<int, DeterministicAtomic, Dynamic>;
+
+  vector<unique_ptr<WriteMethodCaller<QueueType>>> callers;
+  callers.emplace_back(std::make_unique<BlockingWriteCaller<QueueType>>());
+  callers.emplace_back(std::make_unique<WriteIfNotFullCaller<QueueType>>());
+  callers.emplace_back(std::make_unique<WriteCaller<QueueType>>());
+  callers.emplace_back(
+      std::make_unique<TryWriteUntilCaller<QueueType>>(milliseconds(1)));
+  callers.emplace_back(
+      std::make_unique<TryWriteUntilCaller<QueueType>>(seconds(2)));
   size_t cap;
 
   for (const auto& caller : callers) {
@@ -562,18 +560,16 @@ void runMtProdConsDeterministicDynamic(
   // we use the Bench method, but perf results are meaningless under DSched
   DSched sched(DSched::uniform(seed));
 
-  vector<unique_ptr<WriteMethodCaller<MPMCQueue<int, DeterministicAtomic,
-                                                true>>>> callers;
-  callers.emplace_back(make_unique<BlockingWriteCaller<MPMCQueue<int,
-                       DeterministicAtomic, true>>>());
-  callers.emplace_back(make_unique<WriteIfNotFullCaller<MPMCQueue<int,
-                       DeterministicAtomic, true>>>());
-  callers.emplace_back(make_unique<WriteCaller<MPMCQueue<int,
-                       DeterministicAtomic, true>>>());
-  callers.emplace_back(make_unique<TryWriteUntilCaller<MPMCQueue<int,
-                       DeterministicAtomic, true>>>(milliseconds(1)));
-  callers.emplace_back(make_unique<TryWriteUntilCaller<MPMCQueue<int,
-                       DeterministicAtomic, true>>>(seconds(2)));
+  using QueueType = MPMCQueue<int, DeterministicAtomic, true>;
+
+  vector<unique_ptr<WriteMethodCaller<QueueType>>> callers;
+  callers.emplace_back(std::make_unique<BlockingWriteCaller<QueueType>>());
+  callers.emplace_back(std::make_unique<WriteIfNotFullCaller<QueueType>>());
+  callers.emplace_back(std::make_unique<WriteCaller<QueueType>>());
+  callers.emplace_back(
+      std::make_unique<TryWriteUntilCaller<QueueType>>(milliseconds(1)));
+  callers.emplace_back(
+      std::make_unique<TryWriteUntilCaller<QueueType>>(seconds(2)));
 
   for (const auto& caller : callers) {
     LOG(INFO) <<
@@ -628,39 +624,29 @@ TEST(MPMCQueue, mt_prod_cons_deterministic_dynamic_with_arguments) {
 
 template <bool Dynamic = false>
 void runMtProdCons() {
+  using QueueType = MPMCQueue<int, std::atomic, Dynamic>;
+
   int n = 100000;
   setFromEnv(n, "NUM_OPS");
-  vector<unique_ptr<WriteMethodCaller<MPMCQueue<int, std::atomic, Dynamic>>>>
+  vector<unique_ptr<WriteMethodCaller<QueueType>>>
     callers;
-  callers.emplace_back(make_unique<BlockingWriteCaller<MPMCQueue<int,
-                       std::atomic, Dynamic>>>());
-  callers.emplace_back(make_unique<WriteIfNotFullCaller<MPMCQueue<int,
-                       std::atomic, Dynamic>>>());
-  callers.emplace_back(make_unique<WriteCaller<MPMCQueue<int, std::atomic,
-                       Dynamic>>>());
-  callers.emplace_back(make_unique<TryWriteUntilCaller<MPMCQueue<int,
-                       std::atomic, Dynamic>>>(milliseconds(1)));
-  callers.emplace_back(make_unique<TryWriteUntilCaller<MPMCQueue<int,
-                       std::atomic, Dynamic>>>(seconds(2)));
+  callers.emplace_back(std::make_unique<BlockingWriteCaller<QueueType>>());
+  callers.emplace_back(std::make_unique<WriteIfNotFullCaller<QueueType>>());
+  callers.emplace_back(std::make_unique<WriteCaller<QueueType>>());
+  callers.emplace_back(
+      std::make_unique<TryWriteUntilCaller<QueueType>>(milliseconds(1)));
+  callers.emplace_back(
+      std::make_unique<TryWriteUntilCaller<QueueType>>(seconds(2)));
   for (const auto& caller : callers) {
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(10)),
-                          1, 1, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(10)),
-                          10, 1, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(10)),
-                          1, 10, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(10)),
-                          10, 10, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(10000)),
-                          1, 1, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(10000)),
-                          10, 1, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(10000)),
-                          1, 10, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(10000)),
-                          10, 10, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, std::atomic, Dynamic>(100000)),
-                          32, 100, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10)), 1, 1, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10)), 10, 1, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10)), 1, 10, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10)), 10, 10, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10000)), 1, 1, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10000)), 10, 1, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10000)), 1, 10, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10000)), 10, 10, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(100000)), 32, 100, n, *caller);
   }
 }
 
@@ -674,38 +660,27 @@ TEST(MPMCQueue, mt_prod_cons_dynamic) {
 
 template <bool Dynamic = false>
 void runMtProdConsEmulatedFutex() {
+  using QueueType = MPMCQueue<int, EmulatedFutexAtomic, Dynamic>;
+
   int n = 100000;
-  vector<unique_ptr<WriteMethodCaller<MPMCQueue<int, EmulatedFutexAtomic,
-                                                Dynamic>>>> callers;
-  callers.emplace_back(make_unique<BlockingWriteCaller<MPMCQueue<int,
-                       EmulatedFutexAtomic, Dynamic>>>());
-  callers.emplace_back(make_unique<WriteIfNotFullCaller<MPMCQueue<int,
-                       EmulatedFutexAtomic, Dynamic>>>());
-  callers.emplace_back(make_unique<WriteCaller<MPMCQueue<int,
-                       EmulatedFutexAtomic, Dynamic>>>());
-  callers.emplace_back(make_unique<TryWriteUntilCaller<MPMCQueue<int,
-                       EmulatedFutexAtomic, Dynamic>>>(milliseconds(1)));
-  callers.emplace_back(make_unique<TryWriteUntilCaller<MPMCQueue<int,
-                       EmulatedFutexAtomic, Dynamic>>>(seconds(2)));
+  vector<unique_ptr<WriteMethodCaller<QueueType>>> callers;
+  callers.emplace_back(std::make_unique<BlockingWriteCaller<QueueType>>());
+  callers.emplace_back(std::make_unique<WriteIfNotFullCaller<QueueType>>());
+  callers.emplace_back(std::make_unique<WriteCaller<QueueType>>());
+  callers.emplace_back(
+      std::make_unique<TryWriteUntilCaller<QueueType>>(milliseconds(1)));
+  callers.emplace_back(
+      std::make_unique<TryWriteUntilCaller<QueueType>>(seconds(2)));
   for (const auto& caller : callers) {
-    LOG(INFO) << PC_BENCH(
-      (MPMCQueue<int, EmulatedFutexAtomic, Dynamic>(10)), 1, 1, n, *caller);
-    LOG(INFO) << PC_BENCH(
-      (MPMCQueue<int, EmulatedFutexAtomic, Dynamic>(10)), 10, 1, n, *caller);
-    LOG(INFO) << PC_BENCH(
-      (MPMCQueue<int, EmulatedFutexAtomic, Dynamic>(10)), 1, 10, n, *caller);
-    LOG(INFO) << PC_BENCH(
-      (MPMCQueue<int, EmulatedFutexAtomic, Dynamic>(10)), 10, 10, n, *caller);
-    LOG(INFO) << PC_BENCH(
-      (MPMCQueue<int, EmulatedFutexAtomic, Dynamic>(10000)), 1, 1, n, *caller);
-    LOG(INFO) << PC_BENCH(
-      (MPMCQueue<int, EmulatedFutexAtomic, Dynamic>(10000)), 10, 1, n, *caller);
-    LOG(INFO) << PC_BENCH(
-      (MPMCQueue<int, EmulatedFutexAtomic, Dynamic>(10000)), 1, 10, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, EmulatedFutexAtomic, Dynamic>
-                           (10000)), 10, 10, n, *caller);
-    LOG(INFO) << PC_BENCH((MPMCQueue<int, EmulatedFutexAtomic, Dynamic>
-                           (100000)), 32, 100, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10)), 1, 1, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10)), 10, 1, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10)), 1, 10, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10)), 10, 10, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10000)), 1, 1, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10000)), 10, 1, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10000)), 1, 10, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(10000)), 10, 10, n, *caller);
+    LOG(INFO) << PC_BENCH((QueueType(100000)), 32, 100, n, *caller);
   }
 }
 

--- a/folly/test/SingletonThreadLocalTest.cpp
+++ b/folly/test/SingletonThreadLocalTest.cpp
@@ -40,7 +40,7 @@ FooSingletonTL theFooSingleton;
 }
 
 TEST(SingletonThreadLocalTest, OneSingletonPerThread) {
-  const std::size_t targetThreadCount{64};
+  static constexpr std::size_t targetThreadCount{64};
   std::atomic<std::size_t> completedThreadCount{0};
   Synchronized<std::unordered_set<Foo*>> fooAddresses{};
   std::vector<std::thread> threads{};

--- a/folly/test/SingletonThreadLocalTest.cpp
+++ b/folly/test/SingletonThreadLocalTest.cpp
@@ -44,14 +44,13 @@ TEST(SingletonThreadLocalTest, OneSingletonPerThread) {
   std::atomic<std::size_t> completedThreadCount{0};
   Synchronized<std::unordered_set<Foo*>> fooAddresses{};
   std::vector<std::thread> threads{};
-  auto threadFunction =
-      [&fooAddresses, targetThreadCount, &completedThreadCount] {
-        fooAddresses.wlock()->emplace(&FooSingletonTL::get());
-        ++completedThreadCount;
-        while (completedThreadCount < targetThreadCount) {
-          std::this_thread::yield();
-        }
-      };
+  auto threadFunction = [&fooAddresses, &completedThreadCount] {
+    fooAddresses.wlock()->emplace(&FooSingletonTL::get());
+    ++completedThreadCount;
+    while (completedThreadCount < targetThreadCount) {
+      std::this_thread::yield();
+    }
+  };
   {
     for (std::size_t threadCount{0}; threadCount < targetThreadCount;
          ++threadCount) {

--- a/folly/test/SmallLocksBenchmark.cpp
+++ b/folly/test/SmallLocksBenchmark.cpp
@@ -106,7 +106,7 @@ static void runContended(size_t numOps, size_t numThreads) {
   SimpleBarrier runbarrier(totalthreads + 1);
 
   for (size_t t = 0; t < totalthreads; ++t) {
-    threads[t] = std::thread([&, t, totalthreads] {
+    threads[t] = std::thread([&, t] {
       lockstruct* lock = &locks[t % threadgroups];
       runbarrier.wait();
       for (size_t op = 0; op < numOps; op += 1) {
@@ -159,7 +159,7 @@ static void runFairness() {
   SimpleBarrier runbarrier(totalthreads + 1);
 
   for (size_t t = 0; t < totalthreads; ++t) {
-    threads[t] = std::thread([&, t, totalthreads] {
+    threads[t] = std::thread([&, t] {
       lockstruct* lock = &locks[t % threadgroups];
       long value = 0;
       std::chrono::microseconds max(0);

--- a/folly/test/ThreadLocalTest.cpp
+++ b/folly/test/ThreadLocalTest.cpp
@@ -313,10 +313,12 @@ TEST(ThreadLocalPtr, AccessAllThreadsCounter) {
   std::atomic<int> totalAtomic(0);
   std::vector<std::thread> threads;
   for (int i = 0; i < kNumThreads; ++i) {
-    threads.push_back(std::thread([&,i]() {
+    threads.push_back(std::thread([&]() {
       stci.add(1);
       totalAtomic.fetch_add(1);
-      while (run.load()) { usleep(100); }
+      while (run.load()) {
+        usleep(100);
+      }
     }));
   }
   while (totalAtomic.load() != kNumThreads) { usleep(100); }


### PR DESCRIPTION
Move NOMINMAX, WIN32_LEAN_AND_MEAN and _WINSOCK_DEPRECATED_NO_WARNINGS defines from FollyCompiler.cmake into portability/Windows.h, this way these definitions can be picked up from non-cmake projects.