### PR TITLE
Move NOMINMAX define from FollyCompiler.cmake into portability/Windows.h

### DIFF
--- a/CMake/FollyCompiler.cmake
+++ b/CMake/FollyCompiler.cmake
@@ -235,7 +235,6 @@ function(apply_folly_compile_options_to_target THETARGET)
   # And the extra defines:
   target_compile_definitions(${THETARGET}
     PUBLIC
-      NOMINMAX # This is needed because, for some absurd reason, one of the windows headers tries to define "min" and "max" as macros, which messes up most uses of std::numeric_limits.
       _CRT_NONSTDC_NO_WARNINGS # Don't deprecate posix names of functions.
       _CRT_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
       _SCL_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.

--- a/folly/portability/Windows.h
+++ b/folly/portability/Windows.h
@@ -37,6 +37,15 @@
 #include <direct.h> // nolint
 #endif
 
+#ifndef _WINDOWS_
+// This is needed because, for some absurd reason, one of the windows headers
+// tries to define "min" and "max" as macros, which messes up most uses of
+// std::numeric_limits.
+#define NOMINMAX
+#else
+#error "Folly headers must be included before including Windows.h"
+#endif
+
 #include <WinSock2.h>
 #include <Windows.h>
 


### PR DESCRIPTION
This way non-cmake projects can successfully use Folly on Windows.