### PR TITLE
Use more libstdc++ specific macro

### DIFF
--- a/folly/experimental/symbolizer/Symbolizer.cpp
+++ b/folly/experimental/symbolizer/Symbolizer.cpp
@@ -23,7 +23,7 @@
 #include <cstdlib>
 #include <iostream>
 
-#ifdef __GNUC__
+#ifdef __GLIBCXX__
 #include <ext/stdio_filebuf.h>
 #include <ext/stdio_sync_filebuf.h>
 #endif


### PR DESCRIPTION
- The __GNUC__ macro is used by other compilers like Clang and
  ICC, but ext/stdio_filebuf.h is a libstdc++ only extension.

fixes #636 