### PR TITLE
Handle 4-byte unicode code points.

### DIFF
--- a/folly/Unicode.cpp
+++ b/folly/Unicode.cpp
@@ -94,7 +94,7 @@ char32_t utf8ToCodePoint(
 
   fst <<= 1;
 
-  for (unsigned int i = 1; i != 3 && p + i < e; ++i) {
+  for (unsigned int i = 1; i != 4 && p + i < e; ++i) {
     unsigned char tmp = p[i];
 
     if ((tmp & 0xC0) != 0x80) {
@@ -116,8 +116,8 @@ char32_t utf8ToCodePoint(
           to<std::string>("folly::utf8ToCodePoint i=", i, " d=", d));
       }
 
-      // check for surrogates only needed for 3 bytes
-      if (i == 2) {
+      // check for surrogates only needed for 3rd and 4th bytes
+      if (i >= 2) {
         if ((d >= 0xD800 && d <= 0xDFFF) || d > 0x10FFFF) {
           if (skipOnError) return skip();
           throw std::runtime_error(


### PR DESCRIPTION
https://github.com/facebook/folly/pull/640
reworked to have a surrogate check for the 4th symbol.

We need it for react-native to make sure that invalid symbols will be correctly skipped in case somebody passes a corrupted string to javascript core.

Needs to be backported to 2016.09.26.00 to fix the following issue in react-native:
#10756
```
Fatal Exception: java.lang.RuntimeException: Failed to create String from JSON
       at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
       at android.os.Looper.loop(Looper.java:234)
       at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:193)
       at java.lang.Thread.run(Thread.java:818)
```
