### PR TITLE
Add ConcurrentHashMap installable

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -489,6 +489,8 @@ libfolly_la_SOURCES = \
 	detail/Futex.cpp \
 	detail/StaticSingletonManager.cpp \
 	detail/ThreadLocalDetail.cpp \
+	experimental/hazptr/hazptr.cpp \
+	experimental/hazptr/memory_resource.cpp \
 	hash/SpookyHashV1.cpp \
 	hash/SpookyHashV2.cpp \
 	GroupVarint.cpp \

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -57,7 +57,7 @@ nobase_follyinclude_HEADERS = \
 	CpuId.h \
 	CPortability.h \
 	concurrency/ConcurrentHashMap.h \
-    concurrency/detail/ConcurrentHashMap-detail.h \
+	concurrency/detail/ConcurrentHashMap-detail.h \
 	concurrency/CacheLocality.h \
 	concurrency/CoreCachedSharedPtr.h \
 	detail/AtomicHashUtils.h \
@@ -100,10 +100,10 @@ nobase_follyinclude_HEADERS = \
 	Expected.h \
 	concurrency/AtomicSharedPtr.h \
 	concurrency/detail/AtomicSharedPtr-detail.h \
-    experimental/hazptr/hazptr.h \
+	experimental/hazptr/hazptr.h \
 	experimental/hazptr/debug.h \
-    experimental/hazptr/hazptr-impl.h \
-    experimental/hazptr/memory_resource.h \
+	experimental/hazptr/hazptr-impl.h \
+	experimental/hazptr/memory_resource.h \
 	experimental/AsymmetricMemoryBarrier.h \
 	experimental/AutoTimer.h \
 	experimental/ThreadedRepeatingFunctionRunner.h \

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -57,7 +57,7 @@ nobase_follyinclude_HEADERS = \
 	CpuId.h \
 	CPortability.h \
 	concurrency/ConcurrentHashMap.h \
-  concurrency/detail/ConcurrentHashMap-detail.h \
+    concurrency/detail/ConcurrentHashMap-detail.h \
 	concurrency/CacheLocality.h \
 	concurrency/CoreCachedSharedPtr.h \
 	detail/AtomicHashUtils.h \
@@ -100,10 +100,10 @@ nobase_follyinclude_HEADERS = \
 	Expected.h \
 	concurrency/AtomicSharedPtr.h \
 	concurrency/detail/AtomicSharedPtr-detail.h \
-  experimental/hazptr/hazptr.h \
+    experimental/hazptr/hazptr.h \
 	experimental/hazptr/debug.h \
-  experimental/hazptr/hazptr-impl.h \
-  experimental/hazptr/memory_resource.h \
+    experimental/hazptr/hazptr-impl.h \
+    experimental/hazptr/memory_resource.h \
 	experimental/AsymmetricMemoryBarrier.h \
 	experimental/AutoTimer.h \
 	experimental/ThreadedRepeatingFunctionRunner.h \

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -56,6 +56,8 @@ nobase_follyinclude_HEADERS = \
 	CppAttributes.h \
 	CpuId.h \
 	CPortability.h \
+	concurrency/ConcurrentHashMap.h \
+  concurrency/detail/ConcurrentHashMap-detail.h \
 	concurrency/CacheLocality.h \
 	concurrency/CoreCachedSharedPtr.h \
 	detail/AtomicHashUtils.h \
@@ -98,6 +100,10 @@ nobase_follyinclude_HEADERS = \
 	Expected.h \
 	concurrency/AtomicSharedPtr.h \
 	concurrency/detail/AtomicSharedPtr-detail.h \
+  experimental/hazptr/hazptr.h \
+	experimental/hazptr/debug.h \
+  experimental/hazptr/hazptr-impl.h \
+  experimental/hazptr/memory_resource.h \
 	experimental/AsymmetricMemoryBarrier.h \
 	experimental/AutoTimer.h \
 	experimental/ThreadedRepeatingFunctionRunner.h \

--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -56,10 +56,10 @@ nobase_follyinclude_HEADERS = \
 	CppAttributes.h \
 	CpuId.h \
 	CPortability.h \
-	concurrency/ConcurrentHashMap.h \
-	concurrency/detail/ConcurrentHashMap-detail.h \
 	concurrency/CacheLocality.h \
+	concurrency/ConcurrentHashMap.h \
 	concurrency/CoreCachedSharedPtr.h \
+	concurrency/detail/ConcurrentHashMap-detail.h \
 	detail/AtomicHashUtils.h \
 	detail/AtomicUnorderedMapUtils.h \
 	detail/AtomicUtils.h \
@@ -100,10 +100,6 @@ nobase_follyinclude_HEADERS = \
 	Expected.h \
 	concurrency/AtomicSharedPtr.h \
 	concurrency/detail/AtomicSharedPtr-detail.h \
-	experimental/hazptr/hazptr.h \
-	experimental/hazptr/debug.h \
-	experimental/hazptr/hazptr-impl.h \
-	experimental/hazptr/memory_resource.h \
 	experimental/AsymmetricMemoryBarrier.h \
 	experimental/AutoTimer.h \
 	experimental/ThreadedRepeatingFunctionRunner.h \
@@ -125,6 +121,10 @@ nobase_follyinclude_HEADERS = \
 	experimental/exception_tracer/StackTrace.h \
 	experimental/FunctionScheduler.h \
 	experimental/FutureDAG.h \
+	experimental/hazptr/debug.h \
+	experimental/hazptr/hazptr.h \
+	experimental/hazptr/hazptr-impl.h \
+	experimental/hazptr/memory_resource.h \
 	experimental/io/FsUtil.h \
 	experimental/JemallocNodumpAllocator.h \
 	experimental/JSONSchema.h \


### PR DESCRIPTION
ConcurrentHashMap is a newly added feature and we wanted to test it in our enviornment, making it installable. 

Built & Installed on ubuntu 14 env.