### PR TITLE
Update String.h

### DIFF
--- a/folly/String.h
+++ b/folly/String.h
@@ -618,7 +618,7 @@ std::string stripLeftMargin(std::string s);
  * Leaves all other characters unchanged, including those with the 0x80
  * bit set.
  * @param str String to convert
- * @param len Length of str, in bytes
+ * @param length Length of str, in bytes
  */
 void toLowerAscii(char* str, size_t length);
 


### PR DESCRIPTION
Fixed typo in doc comment related to `void toLowerAscii(char* str, size_t length)`.
This fixes the annoying xCode's warning `Parameter 'len' not found in the function declaration`.