### PR TITLE
Fix unittest compile error on futures/test/RetryingTest.cpp.

### DIFF
--- a/folly/futures/test/RetryingTest.cpp
+++ b/folly/futures/test/RetryingTest.cpp
@@ -165,7 +165,7 @@ TEST(RetryingTest, large_retries) {
   PCHECK(getrlimit(RLIMIT_AS, &oldMemLimit) == 0);
 
   rlimit newMemLimit;
-  newMemLimit.rlim_cur = std::min(1UL << 30, oldMemLimit.rlim_max);
+  newMemLimit.rlim_cur = std::min(1ULL << 30, oldMemLimit.rlim_max);
   newMemLimit.rlim_max = oldMemLimit.rlim_max;
   if (!folly::kIsSanitizeAddress) { // ASAN reserves outside of the rlimit
     PCHECK(setrlimit(RLIMIT_AS, &newMemLimit) == 0);

--- a/folly/futures/test/RetryingTest.cpp
+++ b/folly/futures/test/RetryingTest.cpp
@@ -165,7 +165,8 @@ TEST(RetryingTest, large_retries) {
   PCHECK(getrlimit(RLIMIT_AS, &oldMemLimit) == 0);
 
   rlimit newMemLimit;
-  newMemLimit.rlim_cur = std::min(1ULL << 30, oldMemLimit.rlim_max);
+  newMemLimit.rlim_cur =
+      std::min(static_cast<rlim_t>(1UL << 30), oldMemLimit.rlim_max);
   newMemLimit.rlim_max = oldMemLimit.rlim_max;
   if (!folly::kIsSanitizeAddress) { // ASAN reserves outside of the rlimit
     PCHECK(setrlimit(RLIMIT_AS, &newMemLimit) == 0);


### PR DESCRIPTION
Summary:
On MacOS compiling unittests with "make chek" shows the following compile
error:
```
../futures/test/RetryingTest.cpp:168:26: error: no matching function for call to 'min'
 newMemLimit.rlim_cur = std::min(1UL << 30, oldMemLimit.rlim_max);
```