### PR TITLE
Fix usingJEMalloc() with MS VC++ compiler

### DIFF
--- a/folly/memory/Malloc.h
+++ b/folly/memory/Malloc.h
@@ -189,8 +189,13 @@ FOLLY_MALLOC_NOINLINE inline bool usingJEMalloc() noexcept {
       return false;
     }
 
+#if defined(__GNUC__) || defined(__clang__)
     /* Avoid optimizing away the malloc.  */
     asm volatile("" ::"m"(ptr) : "memory");
+#elif defined(_MSC_VER)
+    detail::useCharPointer(&reinterpret_cast<char const volatile&>(ptr));
+    _ReadWriteBarrier();
+#endif
 
     return (origAllocated != *counter);
   }();

--- a/folly/memory/detail/MallocImpl.cpp
+++ b/folly/memory/detail/MallocImpl.cpp
@@ -16,6 +16,16 @@
 
 #include <folly/memory/detail/MallocImpl.h>
 
+namespace folly {
+
+namespace detail {
+
+void useCharPointer(char const volatile*) {}
+
+}
+
+}
+
 extern "C" {
 
 #ifdef _MSC_VER

--- a/folly/memory/detail/MallocImpl.h
+++ b/folly/memory/detail/MallocImpl.h
@@ -20,6 +20,16 @@
 
 #include <folly/Portability.h>
 
+namespace folly {
+
+namespace detail {
+
+void useCharPointer(char const volatile*);
+
+}
+
+}
+
 extern "C" {
 
 #if FOLLY_HAVE_WEAK_SYMBOLS


### PR DESCRIPTION
`asm volatile` only works in Gcc and Clang compilers and MSVC can't optimize away `malloc`

/cc @pixelb @Orvid