### PR TITLE
Windows v10.0.16232 SDK defines MSG_ERRQUEUE, but it doesn't work in …

### DIFF
--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -40,7 +40,7 @@ namespace fsp = folly::portability::sockets;
 namespace folly {
 
 static constexpr bool msgErrQueueSupported =
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
     true;
 #else
     false;

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -42,7 +42,7 @@ namespace fsp = folly::portability::sockets;
 namespace folly {
 
 static constexpr bool msgErrQueueSupported =
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
     true;
 #else
     false;
@@ -926,7 +926,7 @@ bool AsyncSocket::containsZeroCopyBuff(folly::IOBuf* ptr) {
 }
 
 bool AsyncSocket::isZeroCopyMsg(const cmsghdr& cmsg) const {
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
   if (zeroCopyEnabled_ &&
       ((cmsg.cmsg_level == SOL_IP && cmsg.cmsg_type == IP_RECVERR) ||
        (cmsg.cmsg_level == SOL_IPV6 && cmsg.cmsg_type == IPV6_RECVERR))) {
@@ -1742,7 +1742,7 @@ void AsyncSocket::handleErrMessages() noexcept {
     return;
   }
 
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
   uint8_t ctrl[1024];
   unsigned char data;
   struct msghdr msg;

--- a/folly/io/async/test/AsyncSSLSocketTest.cpp
+++ b/folly/io/async/test/AsyncSSLSocketTest.cpp
@@ -37,7 +37,7 @@
 #include <set>
 #include <thread>
 
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
 #include <sys/utsname.h>
 #endif
 
@@ -2189,7 +2189,7 @@ TEST(AsyncSSLSocketTest, SendMsgParamsCallback) {
   cerr << "SendMsgParamsCallback test completed" << endl;
 }
 
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
 /**
  * Test connecting to, writing to, reading from, and closing the
  * connection to the SSL server.

--- a/folly/io/async/test/AsyncSSLSocketTest.h
+++ b/folly/io/async/test/AsyncSSLSocketTest.h
@@ -185,7 +185,7 @@ public WriteCallbackBase {
   }
 };
 
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
 /* copied from include/uapi/linux/net_tstamp.h */
 /* SO_TIMESTAMPING gets an integer bit field comprised of these values */
 enum SOF_TIMESTAMPING {

--- a/folly/io/async/test/AsyncSocketTest2.cpp
+++ b/folly/io/async/test/AsyncSocketTest2.cpp
@@ -2857,7 +2857,7 @@ TEST(AsyncSocketTest, EvbCallbacks) {
   socket->attachEventBase(&evb);
 }
 
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
 /* copied from include/uapi/linux/net_tstamp.h */
 /* SO_TIMESTAMPING gets an integer bit field comprised of these values */
 enum SOF_TIMESTAMPING {

--- a/folly/portability/Sockets.h
+++ b/folly/portability/Sockets.h
@@ -26,7 +26,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
-#ifdef MSG_ERRQUEUE
+#if defined(MSG_ERRQUEUE) && !defined(_WIN32)
 /* for struct sock_extended_err*/
 #include <linux/errqueue.h>
 #endif


### PR DESCRIPTION
…folly

It requires different `msghdr` structure and `recvmsg` ([Sockets.cpp](https://github.com/facebook/folly/blob/2ccbaf9e215b23a357ad6f07de0d1374597b47b8/folly/portability/Sockets.cpp#L261-L305)) doesn't support this flag yet

Compiler error: `folly/io/async/AsyncSocket.cpp(1589): error C2039: 'Control': is not a member of 'msghdr'.`

/cc @maxgeorg @Orvid 
Related to #677