### PR TITLE
Enable bug workaround also for MSVC 2017.4

### DIFF
--- a/folly/stats/Histogram.h
+++ b/folly/stats/Histogram.h
@@ -480,12 +480,12 @@ class Histogram {
 
 } // namespace folly
 
-// MSVC 2017 Update 3 has an issue with explicitly instantiating templated
+// MSVC 2017 Update 3/4 has an issue with explicitly instantiating templated
 // functions with default arguments inside templated classes when compiled
 // with /permissive- (the default for the CMake build), so we directly include
 // the -defs as if it were -inl, and don't provide the explicit instantiations.
 // https://developercommunity.visualstudio.com/content/problem/81223/incorrect-error-c5037-with-permissive.html
-#if defined(_MSC_VER) && _MSC_FULL_VER >= 191125506 && _MSC_FULL_VER < 191125542
+#if defined(_MSC_VER) && _MSC_FULL_VER >= 191125506 && _MSC_FULL_VER <= 191125547 
 #define FOLLY_MSVC_USE_WORKAROUND_FOR_C5037 1
 #else
 #define FOLLY_MSVC_USE_WORKAROUND_FOR_C5037 0


### PR DESCRIPTION
Workaround a bug in template instantiation in MSVC 2017 U3/4 with /permissive-

https://developercommunity.visualstudio.com/content/problem/81223/incorrect-error-c5037-with-permissive.html

/cc @Orvid 