### PR TITLE
Patch set for bug #702

### DIFF
--- a/folly/Optional.h
+++ b/folly/Optional.h
@@ -353,7 +353,7 @@ class Optional {
     void clear() {
       if (hasValue_) {
         hasValue_ = false;
-        launder(reinterpret_cast<Value*>(value_))->~Value();
+        Launder(reinterpret_cast<Value*>(value_))->~Value();
       }
     }
   };
@@ -368,14 +368,14 @@ class Optional {
 
     Value* value_pointer() {
       if (this->hasValue_) {
-        return launder(reinterpret_cast<Value*>(this->value_));
+        return Launder(reinterpret_cast<Value*>(this->value_));
       }
       return nullptr;
     }
 
     Value const* value_pointer() const {
       if (this->hasValue_) {
-        return launder(reinterpret_cast<Value const*>(this->value_));
+        return Launder(reinterpret_cast<Value const*>(this->value_));
       }
       return nullptr;
     }
@@ -384,7 +384,7 @@ class Optional {
     Value& construct(Args&&... args) {
       new (raw_pointer()) Value(std::forward<Args>(args)...);
       this->hasValue_ = true;
-      return *launder(reinterpret_cast<Value*>(this->value_));
+      return *Launder(reinterpret_cast<Value*>(this->value_));
     }
 
    private:

--- a/folly/Replaceable.h
+++ b/folly/Replaceable.h
@@ -157,7 +157,7 @@ struct dtor_mixin<T, true, false> {
   dtor_mixin& operator=(dtor_mixin&&) = default;
   dtor_mixin& operator=(dtor_mixin const&) = default;
   ~dtor_mixin() noexcept(std::is_nothrow_destructible<T>::value) {
-    T* destruct_ptr = launder(reinterpret_cast<T*>(
+    T* destruct_ptr = Launder(reinterpret_cast<T*>(
         reinterpret_cast<Replaceable<T>*>(this)->storage_));
     destruct_ptr->~T();
   }
@@ -279,7 +279,7 @@ struct move_assignment_mixin<T, true> {
   operator=(move_assignment_mixin&& other) noexcept(
       std::is_nothrow_destructible<T>::value&&
           std::is_nothrow_move_constructible<T>::value) {
-    T* destruct_ptr = launder(reinterpret_cast<T*>(
+    T* destruct_ptr = Launder(reinterpret_cast<T*>(
         reinterpret_cast<Replaceable<T>*>(this)->storage_));
     destruct_ptr->~T();
     ::new (reinterpret_cast<Replaceable<T>*>(this)->storage_)
@@ -340,7 +340,7 @@ struct copy_assignment_mixin<T, true> {
   operator=(copy_assignment_mixin const& other) noexcept(
       std::is_nothrow_destructible<T>::value&&
           std::is_nothrow_copy_constructible<T>::value) {
-    T* destruct_ptr = launder(reinterpret_cast<T*>(
+    T* destruct_ptr = Launder(reinterpret_cast<T*>(
         reinterpret_cast<Replaceable<T>*>(this)->storage_));
     destruct_ptr->~T();
     ::new (reinterpret_cast<Replaceable<T>*>(this)->storage_)
@@ -593,14 +593,14 @@ class alignas(T) Replaceable
    */
   template <class... Args>
   T& emplace(Args&&... args) noexcept {
-    T* destruct_ptr = launder(reinterpret_cast<T*>(storage_));
+    T* destruct_ptr = Launder(reinterpret_cast<T*>(storage_));
     destruct_ptr->~T();
     return *::new (storage_) T(std::forward<Args>(args)...);
   }
 
   template <class U, class... Args>
   T& emplace(std::initializer_list<U> il, Args&&... args) noexcept {
-    T* destruct_ptr = launder(reinterpret_cast<T*>(storage_));
+    T* destruct_ptr = Launder(reinterpret_cast<T*>(storage_));
     destruct_ptr->~T();
     return *::new (storage_) T(il, std::forward<Args>(args)...);
   }
@@ -620,27 +620,27 @@ class alignas(T) Replaceable
    * Methods to access the contained object. Intended to be very unsurprising.
    */
   constexpr const T* operator->() const {
-    return launder(reinterpret_cast<T const*>(storage_));
+    return Launder(reinterpret_cast<T const*>(storage_));
   }
 
   FOLLY_CPP14_CONSTEXPR T* operator->() {
-    return launder(reinterpret_cast<T*>(storage_));
+    return Launder(reinterpret_cast<T*>(storage_));
   }
 
   constexpr const T& operator*() const & {
-    return *launder(reinterpret_cast<T const*>(storage_));
+    return *Launder(reinterpret_cast<T const*>(storage_));
   }
 
   FOLLY_CPP14_CONSTEXPR T& operator*() & {
-    return *launder(reinterpret_cast<T*>(storage_));
+    return *Launder(reinterpret_cast<T*>(storage_));
   }
 
   FOLLY_CPP14_CONSTEXPR T&& operator*() && {
-    return std::move(*launder(reinterpret_cast<T*>(storage_)));
+    return std::move(*Launder(reinterpret_cast<T*>(storage_)));
   }
 
   constexpr const T&& operator*() const && {
-    return std::move(*launder(reinterpret_cast<T const*>(storage_)));
+    return std::move(*Launder(reinterpret_cast<T const*>(storage_)));
   }
 
  private:

--- a/folly/lang/Launder.h
+++ b/folly/lang/Launder.h
@@ -26,7 +26,7 @@ namespace folly {
  * but that can't be done without specific support from the compiler.
  */
 template <typename T>
-FOLLY_NODISCARD inline T* launder(T* in) noexcept {
+FOLLY_NODISCARD inline T* Launder(T* in) noexcept {
 #if FOLLY_HAS_BUILTIN(__builtin_launder) || __GNUC__ >= 7
   // The builtin has no unwanted side-effects.
   return __builtin_launder(in);
@@ -42,15 +42,15 @@ FOLLY_NODISCARD inline T* launder(T* in) noexcept {
   return in;
 #else
   static_assert(
-      false, "folly::launder is not implemented for this environment");
+      false, "folly::Launder is not implemented for this environment");
 #endif
 }
 
 /* The standard explicitly forbids laundering these */
-void launder(void*) = delete;
-void launder(void const*) = delete;
-void launder(void volatile*) = delete;
-void launder(void const volatile*) = delete;
+void Launder(void*) = delete;
+void Launder(void const*) = delete;
+void Launder(void volatile*) = delete;
+void Launder(void const volatile*) = delete;
 template <typename T, typename... Args>
-void launder(T (*)(Args...)) = delete;
+void Launder(T (*)(Args...)) = delete;
 } // namespace folly

--- a/folly/lang/test/LaunderTest.cpp
+++ b/folly/lang/test/LaunderTest.cpp
@@ -23,6 +23,6 @@ using namespace folly;
 TEST(LaunderTest, Basics) {
   int a;
   int* pa = &a;
-  EXPECT_EQ(pa, launder(pa));
-  EXPECT_TRUE(noexcept(launder(pa)));
+  EXPECT_EQ(pa, Launder(pa));
+  EXPECT_TRUE(noexcept(Launder(pa)));
 }


### PR DESCRIPTION
It looks like a new implementation of libstdc++ or GCC 7.2.1 has the exact same signature for launder. This means that the compiler can't figure out which version to use, folly's or the native one.