### PR TITLE
Improve `folly::detail::apply_tuple::sum()` compilation time

### DIFF
--- a/folly/functional/ApplyTuple.h
+++ b/folly/functional/ApplyTuple.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <functional>
+#include <initializer_list>
 #include <tuple>
 #include <utility>
 
@@ -45,7 +46,7 @@ inline constexpr std::size_t sum() {
 }
 template <typename... Args>
 inline constexpr std::size_t sum(std::size_t v1, Args... vs) {
-  return v1 + sum(vs...);
+  return ((void)std::initializer_list<std::size_t>{ (v1 += vs)... }, v1);
 }
 
 template <typename... Tuples>


### PR DESCRIPTION
Hello,

I've done some benchmarks and results are that `initializer_list` version's compilation time is better than the recursive one.

Benchmarks pseudocode:
```
for compiler in [clang, gcc]
    for implementation in [folly, initializer_list]
        for number_of_elements_to_sum in [0, 700]
             get average compilation time from 500 runs
```

`initializer_list` version can be easily compiled with g++-4.9 and `-std=c++14`: [live demo](https://gcc.godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(j:1,lang:c%2B%2B,source:'%23include+%3Cinitializer_list%3E%0A%23include+%3Cutility%3E%0A%0Ainline+constexpr+std::size_t+sum()%0A%7B%0A++++return+0%3B%0A%7D%0A%0Atemplate+%3Ctypename...+Args%3E%0Ainline+constexpr+std::size_t+sum(std::size_t+v1,+Args...+vs)%0A%7B%0A++++return+((void)std::initializer_list%3Cstd::size_t%3E%7B+(v1+%2B%3D+vs)...%7D,+v1)%3B%0A%7D%0A%0Aint+main()%0A%7B%0A++++return+sum(1,+2,+3,+4,+5)%3B%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:46.23472602529305,l:'4',m:100,n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:g490,filters:(b:'0',binary:'1',commentOnly:'0',demangle:'0',directives:'0',execute:'1',intel:'0',trim:'1'),lang:c%2B%2B,libs:!(),options:'-std%3Dc%2B%2B14+-O3+-Wall+-Wextra',source:1),l:'5',n:'0',o:'x86-64+gcc+4.9.0+(Editor+%231,+Compiler+%231)+C%2B%2B',t:'0')),k:24.950950497244254,l:'4',m:100.00000000000001,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compiler:1,editor:1),l:'5',n:'0',o:'%231+with+x86-64+gcc+4.9.0',t:'0')),k:28.81432347746272,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)

Full benchmarks code you can find in the repo: [https://github.com/stryku/initializer_list_vs_recursion](https://github.com/stryku/initializer_list_vs_recursion)

Results:
```
+-------------+------------------+-----------------+----------------------+-----------------------------------------+
|  compiler   |  implementation  | elements_to_sum | compilation_time [s] | initializer_list/folly (less is better) |
+-------------+------------------+-----------------+----------------------+-----------------------------------------+
| clang++-5.0 | folly            |               0 |         0.0277947369 | N/A                                     |
| clang++-5.0 | folly            |             700 |         0.4494450464 | N/A                                     |
| clang++-5.0 | initializer_list |               0 |         0.0278800993 | 100.31%                                 |
| clang++-5.0 | initializer_list |             700 |         0.0353267112 | 7.86%                                   |
| g++-6       | folly            |               0 |          0.017156394 | N/A                                     |
| g++-6       | folly            |             700 |         0.3842612844 | N/A                                     |
| g++-6       | initializer_list |               0 |         0.0171618567 | 100.03%                                 |
| g++-6       | initializer_list |             700 |         0.0260685649 | 6.78%                                   |
+-------------+------------------+-----------------+----------------------+-----------------------------------------+
```

What do you think?