### PR TITLE
cmake: add config check for openmp support

### DIFF
--- a/CMake/FollyCompilerUnix.cmake
+++ b/CMake/FollyCompilerUnix.cmake
@@ -8,7 +8,6 @@ function(apply_folly_compile_options_to_target THETARGET)
     PUBLIC
       -g
       -std=gnu++14
-      -fopenmp
       -finput-charset=UTF-8
       -fsigned-char
       -Werror

--- a/CMake/FollyConfigChecks.cmake
+++ b/CMake/FollyConfigChecks.cmake
@@ -41,6 +41,11 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
   if (COMPILER_HAS_F_ALIGNED_NEW)
     list(APPEND FOLLY_CXX_FLAGS -faligned-new)
   endif()
+
+  CHECK_CXX_COMPILER_FLAG(-fopenmp COMPILER_HAS_F_OPENMP)
+  if (COMPILER_HAS_F_OPENMP)
+      list(APPEND FOLLY_CXX_FLAGS -fopenmp)
+  endif()
 endif()
 
 check_symbol_exists(pthread_atfork pthread.h FOLLY_HAVE_PTHREAD_ATFORK)


### PR DESCRIPTION
Some compilers such as Apple Clang do not support the compiler flag `-fopenmp`. So, do not add it by default to the list of `CXX_FLAGS` that are expected for *every* compiler to support. Instead, check if the `CXX_COMPILER` specified by `CMake` supports `-fopenmp` by using `CHECK_CXX_COMPILER_FLAG`.