### PR TITLE
Add missing override for adjacent_tokens_only

### DIFF
--- a/folly/experimental/ProgramOptions.cpp
+++ b/folly/experimental/ProgramOptions.cpp
@@ -83,7 +83,7 @@ class GFlagValueSemanticBase : public po::value_semantic {
 
   std::string name() const override { return "arg"; }
 #if BOOST_VERSION >= 105900
-  bool adjacent_tokens_only() const {
+  bool adjacent_tokens_only() const override {
     return false;
   }
 #endif


### PR DESCRIPTION
Summary:
The UNIX builds treat all warnings as errors, and this missing `override` keyword causes a warning which is then a hard error in the build. In Boost 1.59 and later, `Boost.ProgramOptions` provides a virtual method `adjacent_tokens_only()` which the class `GFlagValueSemanticBase` wants to override. As such, mark it using `override`.