### PR TITLE
Fix some unused parameters

### DIFF
--- a/folly/detail/SocketFastOpen.cpp
+++ b/folly/detail/SocketFastOpen.cpp
@@ -97,7 +97,7 @@ int tfo_enable(int sockfd, size_t max_queue_size) {
       sizeof(max_queue_size));
 }
 
-bool tfo_succeeded(int sockfd) {
+bool tfo_succeeded(int /* sockfd */) {
   errno = EOPNOTSUPP;
   return false;
 }

--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -736,7 +736,11 @@ int AsyncServerSocket::createSocket(int family) {
   return fd;
 }
 
+#ifndef TCP_NOPUSH
 void AsyncServerSocket::setupSocket(int fd, int family) {
+#else
+void AsyncServerSocket::setupSocket(int fd, int) {
+#endif
   // Put the socket in non-blocking mode
   if (fcntl(fd, F_SETFL, O_NONBLOCK) != 0) {
     folly::throwSystemError(errno,

--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -736,11 +736,7 @@ int AsyncServerSocket::createSocket(int family) {
   return fd;
 }
 
-#ifndef TCP_NOPUSH
 void AsyncServerSocket::setupSocket(int fd, int family) {
-#else
-void AsyncServerSocket::setupSocket(int fd, int) {
-#endif
   // Put the socket in non-blocking mode
   if (fcntl(fd, F_SETFL, O_NONBLOCK) != 0) {
     folly::throwSystemError(errno,
@@ -795,6 +791,8 @@ void AsyncServerSocket::setupSocket(int fd, int) {
               strerror(errno);
     }
   }
+#else
+  (void) family; // to avoid unused parameter warning
 #endif
 
 #if FOLLY_ALLOW_TFO

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -922,7 +922,11 @@ bool AsyncSocket::containsZeroCopyBuf(folly::IOBuf* ptr) {
   return (idZeroCopyBufInfoMap_.find(ptr) != idZeroCopyBufInfoMap_.end());
 }
 
+#ifdef FOLLY_HAVE_MSG_ERRQUEUE
 bool AsyncSocket::isZeroCopyMsg(const cmsghdr& cmsg) const {
+#else
+bool AsyncSocket::isZeroCopyMsg(const cmsghdr&) const {
+#endif
 #ifdef FOLLY_HAVE_MSG_ERRQUEUE
   if (zeroCopyEnabled_ &&
       ((cmsg.cmsg_level == SOL_IP && cmsg.cmsg_type == IP_RECVERR) ||
@@ -936,7 +940,11 @@ bool AsyncSocket::isZeroCopyMsg(const cmsghdr& cmsg) const {
   return false;
 }
 
+#ifdef FOLLY_HAVE_MSG_ERRQUEUE
 void AsyncSocket::processZeroCopyMsg(const cmsghdr& cmsg) {
+#else
+void AsyncSocket::processZeroCopyMsg(const cmsghdr&) {
+#endif
 #ifdef FOLLY_HAVE_MSG_ERRQUEUE
   const struct sock_extended_err* serr =
       reinterpret_cast<const struct sock_extended_err*>(CMSG_DATA(&cmsg));

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -922,11 +922,7 @@ bool AsyncSocket::containsZeroCopyBuf(folly::IOBuf* ptr) {
   return (idZeroCopyBufInfoMap_.find(ptr) != idZeroCopyBufInfoMap_.end());
 }
 
-#ifdef FOLLY_HAVE_MSG_ERRQUEUE
 bool AsyncSocket::isZeroCopyMsg(const cmsghdr& cmsg) const {
-#else
-bool AsyncSocket::isZeroCopyMsg(const cmsghdr&) const {
-#endif
 #ifdef FOLLY_HAVE_MSG_ERRQUEUE
   if (zeroCopyEnabled_ &&
       ((cmsg.cmsg_level == SOL_IP && cmsg.cmsg_type == IP_RECVERR) ||
@@ -937,14 +933,11 @@ bool AsyncSocket::isZeroCopyMsg(const cmsghdr&) const {
         (serr->ee_errno == 0) && (serr->ee_origin == SO_EE_ORIGIN_ZEROCOPY));
   }
 #endif
+  (void) cmsg;
   return false;
 }
 
-#ifdef FOLLY_HAVE_MSG_ERRQUEUE
 void AsyncSocket::processZeroCopyMsg(const cmsghdr& cmsg) {
-#else
-void AsyncSocket::processZeroCopyMsg(const cmsghdr&) {
-#endif
 #ifdef FOLLY_HAVE_MSG_ERRQUEUE
   const struct sock_extended_err* serr =
       reinterpret_cast<const struct sock_extended_err*>(CMSG_DATA(&cmsg));
@@ -961,6 +954,8 @@ void AsyncSocket::processZeroCopyMsg(const cmsghdr&) {
   for (uint32_t i = lo; i <= hi; i++) {
     releaseZeroCopyBuf(i);
   }
+#else
+  (void) cmsg;
 #endif
 }
 


### PR DESCRIPTION
Summary:
Fix a few unused parameters. One was unconditional; the other two are conditional based on some configuration values set during CMake configure time.