### PR TITLE
Disable part of DynamicConverterTest which fails for Clang

### DIFF
--- a/folly/test/DynamicConverterTest.cpp
+++ b/folly/test/DynamicConverterTest.cpp
@@ -383,11 +383,14 @@ TEST(DynamicConverter, construct) {
     EXPECT_EQ(d, toDynamic(c));
   }
 
+// See https://github.com/facebook/folly/issues/752
+#if !defined(__clang__)
   {
     vector<bool> vb{true, false};
     dynamic d = dynamic::array(true, false);
     EXPECT_EQ(d, toDynamic(vb));
   }
+#endif
 }
 
 TEST(DynamicConverter, errors) {


### PR DESCRIPTION
Summary:
`folly::dynamic` is missing a template specialization for construction from
`std::vector<bool>`. See issue #752 for more info. This issue definitely arises
using Clang 5.0.1 on Mac, but likely comes up in earlier Clang versions too.