### PR TITLE
Fix format warning in StringTest.cpp

### DIFF
--- a/folly/test/StringTest.cpp
+++ b/folly/test/StringTest.cpp
@@ -48,8 +48,8 @@ TEST(StringPrintf, NumericFormats) {
   EXPECT_EQ("5000000000", stringPrintf("%lld", 5000000000LL));
   EXPECT_EQ("-5000000000", stringPrintf("%lld", -5000000000LL));
   EXPECT_EQ("-1", stringPrintf("%d", 0xffffffff));
-  EXPECT_EQ("-1", stringPrintf("%" PRId64, 0xffffffffffffffff));
-  EXPECT_EQ("-1", stringPrintf("%" PRId64, 0xffffffffffffffffUL));
+  EXPECT_EQ("-1", stringPrintf("%" PRId64, 0xffffffffffffffffLL));
+  EXPECT_EQ("-1", stringPrintf("%" PRId64, 0xffffffffffffffffULL));
 
   EXPECT_EQ("7.7", stringPrintf("%1.1f", 7.7));
   EXPECT_EQ("7.7", stringPrintf("%1.1lf", 7.7));

--- a/folly/test/StringTest.cpp
+++ b/folly/test/StringTest.cpp
@@ -48,8 +48,8 @@ TEST(StringPrintf, NumericFormats) {
   EXPECT_EQ("5000000000", stringPrintf("%lld", 5000000000LL));
   EXPECT_EQ("-5000000000", stringPrintf("%lld", -5000000000LL));
   EXPECT_EQ("-1", stringPrintf("%d", 0xffffffff));
-  EXPECT_EQ("-1", stringPrintf("%" PRId64, 0xffffffffffffffffLL));
-  EXPECT_EQ("-1", stringPrintf("%" PRId64, 0xffffffffffffffffULL));
+  EXPECT_EQ("-1", stringPrintf("%" PRId64, static_cast<int64_t>(0xffffffffffffffffLL)));
+  EXPECT_EQ("-1", stringPrintf("%" PRId64, static_cast<uint64_t>(0xffffffffffffffffULL)));
 
   EXPECT_EQ("7.7", stringPrintf("%1.1f", 7.7));
   EXPECT_EQ("7.7", stringPrintf("%1.1lf", 7.7));


### PR DESCRIPTION
Summary:
Clang warns about formatting when we were using `stringPrintf` to print
the result of overflowing an unsigned 64-bit value.

Closes issue #757.