### PR TITLE
[CMake] Closer to compiling with Clang

### DIFF
--- a/CMake/FollyCompilerUnix.cmake
+++ b/CMake/FollyCompilerUnix.cmake
@@ -11,7 +11,7 @@ function(apply_folly_compile_options_to_target THETARGET)
       "FOLLY_XLOG_STRIP_PREFIXES=\"${FOLLY_DIR_PREFIXES}\""
   )
   target_compile_options(${THETARGET}
-    PUBLIC
+    PRIVATE
       -g
       -std=gnu++14
       -finput-charset=UTF-8
@@ -23,6 +23,7 @@ function(apply_folly_compile_options_to_target THETARGET)
       -Wno-error=deprecated-declarations
       -Wno-sign-compare
       -Wno-unused
+      -Wno-inconsistent-missing-override
       -Wunused-label
       -Wunused-result
       -Wnon-virtual-dtor


### PR DESCRIPTION
Summary:
This brings us closer to being able to compile the open
source version of Folly with Clang. There are a few other
open pull requests that need to be addressed to allow us to
compile on Clang without any warnings that aren't already
explicitly disabled. See pull requests `745` and `756`.

@yfeldblum Sorry for the duplicate of https://github.com/facebook/folly/pull/768 -- I had rebased and force-pushed the reverting of the original changeset to then apply the new changeset as requested from the internal code review feedback. The result was that the PR got closed due to showing zero commits on the branch and then it wouldn't reopen despite force pushing to the branch with this changeset.  Apologize for that. 