### PR TITLE
[Build] Fix master branch broken for Clang

### DIFF
--- a/folly/Subprocess.cpp
+++ b/folly/Subprocess.cpp
@@ -313,8 +313,11 @@ void Subprocess::spawn(
 // With -Wclobbered, gcc complains about vfork potentially cloberring the
 // childDir variable, even though we only use it on the child side of the
 // vfork.
+
 FOLLY_PUSH_WARNING
+#if !defined(__clang__)
 FOLLY_GCC_DISABLE_WARNING("-Wclobbered")
+#endif
 void Subprocess::spawnInternal(
     std::unique_ptr<const char*[]> argv,
     const char* executable,


### PR DESCRIPTION
Summary:
Clang does not support the warning option "-Wclobbered", so we cannot
do a pragma push and pop for this warning. So, we push and pop this
particular warning for GCC only.

As it stands currently, Clang accepts `#pragma GCC` directives. If this
sort of thing comes up more in the future, it may make sense for Folly
to define a macro for easily disabling warnings for either just GCC or
just Clang.

@simpkins @yfeldblum 