### PR TITLE
Simplify FsUtilTest.cpp

### DIFF
--- a/folly/experimental/io/test/FsUtilTest.cpp
+++ b/folly/experimental/io/test/FsUtilTest.cpp
@@ -23,23 +23,13 @@
 using namespace folly;
 using namespace folly::fs;
 
-namespace {
-// We cannot use EXPECT_EQ(a, b) due to a bug in gtest 1.6.0: gtest wants
-// to print path as a container even though it has operator<< defined,
-// and as path is a container of path, this leads to infinite
-// recursion.
-void expectPathEq(const path& a, const path& b) {
-  EXPECT_TRUE(a == b) << "expected path=" << a << "\nactual path=" << b;
-}
-} // namespace
-
 TEST(Simple, Path) {
   path root("/");
   path abs1("/hello/world");
   path rel1("meow");
   EXPECT_TRUE(starts_with(abs1, root));
   EXPECT_FALSE(starts_with(rel1, root));
-  expectPathEq(path("hello/world"), remove_prefix(abs1, root));
+  EXPECT_EQ(path("hello/world"), remove_prefix(abs1, root));
   EXPECT_THROW({ remove_prefix(rel1, root); }, filesystem_error);
 
   path abs2("/hello");
@@ -52,9 +42,9 @@ TEST(Simple, Path) {
   EXPECT_TRUE(starts_with(abs1, abs4));
   EXPECT_FALSE(starts_with(abs1, abs5));
   EXPECT_FALSE(starts_with(abs1, abs6));
-  expectPathEq(path("world"), remove_prefix(abs1, abs2));
-  expectPathEq(path("world"), remove_prefix(abs1, abs3));
-  expectPathEq(path(), remove_prefix(abs1, abs4));
+  EXPECT_EQ(path("world"), remove_prefix(abs1, abs2));
+  EXPECT_EQ(path("world"), remove_prefix(abs1, abs3));
+  EXPECT_EQ(path(), remove_prefix(abs1, abs4));
   EXPECT_THROW({ remove_prefix(abs1, abs5); }, filesystem_error);
   EXPECT_THROW({ remove_prefix(abs1, abs6); }, filesystem_error);
 }
@@ -65,12 +55,12 @@ TEST(Simple, CanonicalizeParent) {
   path c("/usr/bin/DOES_NOT_EXIST_ASDF");
   path d("/usr/lib/../bin/DOES_NOT_EXIST_ASDF");
 
-  expectPathEq(a, canonical(a));
-  expectPathEq(a, canonical_parent(b));
-  expectPathEq(a, canonical(b));
-  expectPathEq(a, canonical_parent(b));
+  EXPECT_EQ(a, canonical(a));
+  EXPECT_EQ(a, canonical_parent(b));
+  EXPECT_EQ(a, canonical(b));
+  EXPECT_EQ(a, canonical_parent(b));
   EXPECT_THROW({ canonical(c); }, filesystem_error);
   EXPECT_THROW({ canonical(d); }, filesystem_error);
-  expectPathEq(c, canonical_parent(c));
-  expectPathEq(c, canonical_parent(d));
+  EXPECT_EQ(c, canonical_parent(c));
+  EXPECT_EQ(c, canonical_parent(d));
 }


### PR DESCRIPTION
Summary:
This test suite used to wrap equality of two paths by using `EXPECT_TRUE` to
avoid an old bug in GTest 1.6.0. Now that we use GTest 1.8.0, we can
simplify our test.