### PR TITLE
Fix DynamicConverter to work with vector<bool>

### DIFF
--- a/folly/DynamicConverter.h
+++ b/folly/DynamicConverter.h
@@ -368,6 +368,24 @@ struct DynamicConstructor<std::pair<A, B>, void> {
   }
 };
 
+// vector<bool>
+template<>
+struct DynamicConstructor<std::vector<bool>, void>
+{
+    static dynamic construct(const std::vector<bool>& x)
+    {
+        dynamic d = dynamic::array;
+        // Intentionally specifying the type as bool here.
+        // std::vector<bool>'s iterators return a proxy which is a prvalue
+        // and hence cannot bind to an lvalue reference such as auto&
+        for(bool item : x)
+        {
+            d.push_back(toDynamic(item));
+        }
+        return d;
+    }
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // implementation
 

--- a/folly/test/DynamicConverterTest.cpp
+++ b/folly/test/DynamicConverterTest.cpp
@@ -463,3 +463,10 @@ TEST(DynamicConverter, double_destroy) {
   EXPECT_THROW(convertTo<std::vector<B>>(d), B::BException);
   EXPECT_EQ(constructB, destroyB);
 }
+
+TEST(DynamicConverter, simple_vector_bool) {
+  std::vector<bool> bools{true, false};
+  auto d = toDynamic(bools);
+  auto actual = convertTo<decltype(bools)>(d);
+  EXPECT_EQ(bools, actual);
+}


### PR DESCRIPTION
Introduce a specialization for `std::vector<bool>` as the existing
specialization for "other ranges" is not sufficient for binding the
proxy iterator (`bit_const_reference`) to an lvalue when iterating over
the `vector<bool>`.

I do not think you can simply change the type from `const auto&` to `auto&&` when iterating over the container for the "other ranges" specialization.  This is because we cannot bind an rvalue to an lvalue reference (which is the function argument type for our `construct` specializations).

See #752 and https://github.com/facebook/folly/pull/756 for more info.