### PR TITLE
Run clang-tidy performance checks

### DIFF
--- a/folly/ExceptionWrapper.cpp
+++ b/folly/ExceptionWrapper.cpp
@@ -49,7 +49,7 @@ exception_wrapper::VTable const exception_wrapper::SharedPtr::ops_{
     get_exception_ptr_};
 
 namespace {
-std::exception const* get_std_exception_(std::exception_ptr eptr) noexcept {
+std::exception const* get_std_exception_(const std::exception_ptr& eptr) noexcept {
   try {
     std::rethrow_exception(eptr);
   } catch (const std::exception& ex) {

--- a/folly/String.cpp
+++ b/folly/String.cpp
@@ -692,7 +692,7 @@ size_t hexDumpLine(const void* ptr, size_t offset, size_t size,
 
 } // namespace detail
 
-std::string stripLeftMargin(std::string s) {
+std::string stripLeftMargin(const std::string& s) {
   std::vector<StringPiece> pieces;
   split("\n", s, pieces);
   auto piecer = range(pieces);

--- a/folly/String.h
+++ b/folly/String.h
@@ -582,7 +582,7 @@ inline StringPiece skipWhitespace(StringPiece sp) {
  *  Purpose: including a multiline string literal in source code, indented to
  *  the level expected from context.
  */
-std::string stripLeftMargin(std::string s);
+std::string stripLeftMargin(const std::string& s);
 
 /**
  * Fast, in-place lowercasing of ASCII alphabetic characters in strings.

--- a/folly/compression/Compression.cpp
+++ b/folly/compression/Compression.cpp
@@ -60,6 +60,7 @@
 #include <folly/stop_watch.h>
 #include <algorithm>
 #include <unordered_set>
+#include <utility>
 
 using folly::io::compression::detail::dataStartsWithLE;
 using folly::io::compression::detail::prefixToStringLE;
@@ -69,7 +70,7 @@ namespace io {
 
 Codec::Codec(
     CodecType type,
-    Optional<int> level,
+    const Optional<int>& level,
     StringPiece name,
     bool counters)
     : type_(type) {
@@ -278,7 +279,7 @@ std::string Codec::doUncompressString(
     const StringPiece data,
     Optional<uint64_t> uncompressedLength) {
   const IOBuf inputBuffer{IOBuf::WRAP_BUFFER, data};
-  auto outputBuffer = doUncompress(&inputBuffer, uncompressedLength);
+  auto outputBuffer = doUncompress(&inputBuffer, std::move(uncompressedLength));
   std::string output;
   output.reserve(outputBuffer->computeChainDataLength());
   for (auto range : *outputBuffer) {
@@ -293,7 +294,7 @@ uint64_t Codec::maxCompressedLength(uint64_t uncompressedLength) const {
 
 Optional<uint64_t> Codec::getUncompressedLength(
     const folly::IOBuf* data,
-    Optional<uint64_t> uncompressedLength) const {
+    const Optional<uint64_t>& uncompressedLength) const {
   auto const compressedLength = data->computeChainDataLength();
   if (compressedLength == 0) {
     if (uncompressedLength.value_or(0) != 0) {

--- a/folly/compression/Compression.h
+++ b/folly/compression/Compression.h
@@ -183,12 +183,12 @@ class Codec {
    */
   folly::Optional<uint64_t> getUncompressedLength(
       const folly::IOBuf* data,
-      folly::Optional<uint64_t> uncompressedLength = folly::none) const;
+      const folly::Optional<uint64_t>& uncompressedLength = folly::none) const;
 
  protected:
   Codec(
       CodecType type,
-      folly::Optional<int> level = folly::none,
+      const folly::Optional<int>& level = folly::none,
       folly::StringPiece name = {},
       bool counters = true);
 

--- a/folly/compression/Counters.cpp
+++ b/folly/compression/Counters.cpp
@@ -27,7 +27,7 @@ namespace folly {
 folly::Function<void(double)> FOLLY_WEAK_SYMBOL makeCompressionCounterHandler(
     folly::io::CodecType,
     folly::StringPiece,
-    folly::Optional<int>,
+    const folly::Optional<int>&,
     CompressionCounterKey,
     CompressionCounterType) {
   return {};

--- a/folly/compression/Counters.h
+++ b/folly/compression/Counters.h
@@ -60,7 +60,7 @@ enum class CompressionCounterType {
 folly::Function<void(double)> makeCompressionCounterHandler(
     folly::io::CodecType codecType,
     folly::StringPiece codecName,
-    folly::Optional<int> level,
+    const folly::Optional<int>& level,
     CompressionCounterKey key,
     CompressionCounterType counterType);
 

--- a/folly/concurrency/test/CacheLocalityTest.cpp
+++ b/folly/concurrency/test/CacheLocalityTest.cpp
@@ -431,7 +431,8 @@ TEST(CoreAllocator, Basic) {
   a->deallocate(res);
 
   std::vector<void*> mems;
-  for (int i = 0; i < 10000; i++) {
+  mems.reserve(10000);
+for (int i = 0; i < 10000; i++) {
     mems.push_back(a->allocate(1));
   }
   for (auto& mem : mems) {

--- a/folly/executors/GlobalThreadPoolList.cpp
+++ b/folly/executors/GlobalThreadPoolList.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <folly/CppAttributes.h>
@@ -123,7 +124,7 @@ GlobalThreadPoolList& GlobalThreadPoolList::instance() {
 void GlobalThreadPoolList::registerThreadPool(
     ThreadPoolListHook* threadPoolId,
     std::string name) {
-  globalListImpl_->registerThreadPool(threadPoolId, name);
+  globalListImpl_->registerThreadPool(threadPoolId, std::move(name));
 }
 
 void GlobalThreadPoolList::unregisterThreadPool(
@@ -152,7 +153,7 @@ void GlobalThreadPoolListImpl::registerThreadPool(
     ThreadPoolListHook* threadPoolId,
     std::string name) {
   PoolInfo info;
-  info.name = name;
+  info.name = std::move(name);
   info.addr = threadPoolId;
   pools_.vector().push_back(info);
 }
@@ -203,7 +204,7 @@ ThreadListHook::~ThreadListHook() {
 }
 
 ThreadPoolListHook::ThreadPoolListHook(std::string name) {
-  GlobalThreadPoolList::instance().registerThreadPool(this, name);
+  GlobalThreadPoolList::instance().registerThreadPool(this, std::move(name));
 }
 
 ThreadPoolListHook::~ThreadPoolListHook() {

--- a/folly/executors/IOThreadPoolExecutor.cpp
+++ b/folly/executors/IOThreadPoolExecutor.cpp
@@ -196,7 +196,7 @@ void IOThreadPoolExecutor::stopThreads(size_t n) {
       ioThread->eventBase->terminateLoopSoon();
     }
   }
-  for (auto thread : stoppedThreads) {
+  for (const auto& thread : stoppedThreads) {
     stoppedThreads_.add(thread);
     threadList_.remove(thread);
   }

--- a/folly/executors/ThreadPoolExecutor.cpp
+++ b/folly/executors/ThreadPoolExecutor.cpp
@@ -178,7 +178,7 @@ ThreadPoolExecutor::PoolStats ThreadPoolExecutor::getPoolStats() {
   RWSpinLock::ReadHolder r{&threadListLock_};
   ThreadPoolExecutor::PoolStats stats;
   stats.threadCount = threadList_.get().size();
-  for (auto thread : threadList_.get()) {
+  for (const auto& thread : threadList_.get()) {
     if (thread->idle) {
       stats.idleThreadCount++;
       const std::chrono::nanoseconds idleTime = now - thread->lastActiveTime;
@@ -232,7 +232,7 @@ size_t ThreadPoolExecutor::StoppedThreadQueue::size() {
   return queue_.size();
 }
 
-void ThreadPoolExecutor::addObserver(std::shared_ptr<Observer> o) {
+void ThreadPoolExecutor::addObserver(const std::shared_ptr<Observer>& o) {
   RWSpinLock::ReadHolder r{&threadListLock_};
   observers_.push_back(o);
   for (auto& thread : threadList_.get()) {
@@ -240,7 +240,7 @@ void ThreadPoolExecutor::addObserver(std::shared_ptr<Observer> o) {
   }
 }
 
-void ThreadPoolExecutor::removeObserver(std::shared_ptr<Observer> o) {
+void ThreadPoolExecutor::removeObserver(const std::shared_ptr<Observer>& o) {
   RWSpinLock::ReadHolder r{&threadListLock_};
   for (auto& thread : threadList_.get()) {
     o->threadNotYetStopped(thread.get());

--- a/folly/executors/ThreadPoolExecutor.h
+++ b/folly/executors/ThreadPoolExecutor.h
@@ -117,8 +117,8 @@ class ThreadPoolExecutor : public virtual folly::Executor {
     virtual ~Observer() = default;
   };
 
-  void addObserver(std::shared_ptr<Observer>);
-  void removeObserver(std::shared_ptr<Observer>);
+  void addObserver(const std::shared_ptr<Observer>&);
+  void removeObserver(const std::shared_ptr<Observer>&);
 
  protected:
   // Prerequisite: threadListLock_ writelocked

--- a/folly/experimental/logging/LogCategoryConfig.cpp
+++ b/folly/experimental/logging/LogCategoryConfig.cpp
@@ -23,7 +23,7 @@ LogCategoryConfig::LogCategoryConfig(LogLevel l, bool inherit)
 LogCategoryConfig::LogCategoryConfig(
     LogLevel l,
     bool inherit,
-    std::vector<std::string> h)
+    const std::vector<std::string>& h)
     : level{l}, inheritParentLevel{inherit}, handlers{h} {}
 
 bool LogCategoryConfig::operator==(const LogCategoryConfig& other) const {

--- a/folly/experimental/logging/LogCategoryConfig.h
+++ b/folly/experimental/logging/LogCategoryConfig.h
@@ -34,7 +34,7 @@ class LogCategoryConfig {
   LogCategoryConfig(
       LogLevel level,
       bool inheritParentLevel,
-      std::vector<std::string> handlers);
+      const std::vector<std::string>& handlers);
 
   bool operator==(const LogCategoryConfig& other) const;
   bool operator!=(const LogCategoryConfig& other) const;

--- a/folly/experimental/logging/StandardLogHandler.cpp
+++ b/folly/experimental/logging/StandardLogHandler.cpp
@@ -19,6 +19,8 @@
 #include <folly/experimental/logging/LogMessage.h>
 #include <folly/experimental/logging/LogWriter.h>
 
+#include <utility>
+
 namespace folly {
 
 StandardLogHandler::StandardLogHandler(
@@ -27,7 +29,7 @@ StandardLogHandler::StandardLogHandler(
     std::shared_ptr<LogWriter> writer)
     : formatter_{std::move(formatter)},
       writer_{std::move(writer)},
-      config_{config} {}
+      config_{std::move(config)} {}
 
 StandardLogHandler::~StandardLogHandler() {}
 

--- a/folly/experimental/test/DynamicParserTest.cpp
+++ b/folly/experimental/test/DynamicParserTest.cpp
@@ -35,7 +35,7 @@ using namespace folly;
 
 // See setAllowNonStringKeyErrors() -- most of the tests below presume that
 // all keys in releaseErrors() are coerced to string.
-void checkMaybeCoercedKeys(bool coerce, dynamic good_k, dynamic missing_k) {
+void checkMaybeCoercedKeys(bool coerce, const dynamic& good_k, const dynamic& missing_k) {
   dynamic d = dynamic::object(good_k, 7);
   DynamicParser p(DynamicParser::OnError::RECORD, &d);
   p.setAllowNonStringKeyErrors(!coerce);
@@ -62,7 +62,7 @@ void checkMaybeCoercedKeys(bool coerce, dynamic good_k, dynamic missing_k) {
   ), errors);
 }
 
-void checkCoercedAndUncoercedKeys(dynamic good_k, dynamic missing_k) {
+void checkCoercedAndUncoercedKeys(const dynamic& good_k, const dynamic& missing_k) {
   checkMaybeCoercedKeys(true, good_k, missing_k);
   checkMaybeCoercedKeys(false, good_k, missing_k);
 }
@@ -222,8 +222,8 @@ template <typename Fn>
 void checkXYKeyErrorsAndParseError(
     const dynamic& d,
     Fn fn,
-    std::string key_re,
-    std::string parse_re) {
+    const std::string& key_re,
+    const std::string& parse_re) {
   DynamicParser p(DynamicParser::OnError::RECORD, &d);
   fn(p);
   auto errors = p.releaseErrors();
@@ -288,7 +288,7 @@ TEST(TestDynamicParser, TestRequiredOptionalParseErrors) {
 template <typename Fn>
 void checkItemParseError(
     // real_k can differ from err_k, which is typically coerced to string
-    dynamic d, Fn fn, dynamic real_k, dynamic err_k, std::string re) {
+    dynamic d, Fn fn, const dynamic& real_k, const dynamic& err_k, const std::string& re) {
   DynamicParser p(DynamicParser::OnError::RECORD, &d);
   fn(p);
   auto errors = p.releaseErrors();

--- a/folly/fibers/test/FibersTest.cpp
+++ b/folly/fibers/test/FibersTest.cpp
@@ -295,7 +295,8 @@ TEST(FiberManager, addTasksNoncopyable) {
     if (!taskAdded) {
       manager.addTask([&]() {
         std::vector<std::function<std::unique_ptr<int>()>> funcs;
-        for (int i = 0; i < 3; ++i) {
+        funcs.reserve(3);
+for (int i = 0; i < 3; ++i) {
           funcs.push_back([i, &pendingFibers]() {
             await([&pendingFibers](Promise<int> promise) {
               pendingFibers.push_back(std::move(promise));
@@ -1612,7 +1613,8 @@ void singleBatchDispatch(ExecutorT& executor, int batchSize, int index) {
       executor, [=](std::vector<int>&& batch) {
         EXPECT_EQ(batchSize, batch.size());
         std::vector<std::string> results;
-        for (auto& it : batch) {
+        results.reserve(batch.size());
+for (auto& it : batch) {
           results.push_back(folly::to<std::string>(it));
         }
         return results;
@@ -1663,7 +1665,8 @@ folly::Future<std::vector<std::string>> doubleBatchInnerDispatch(
         for (auto& unit : batch) {
           numberOfElements += unit.size();
           std::vector<std::string> result;
-          for (auto& element : unit) {
+          result.reserve(unit.size());
+for (auto& element : unit) {
             result.push_back(folly::to<std::string>(element));
           }
           results.push_back(std::move(result));

--- a/folly/futures/test/CollectTest.cpp
+++ b/folly/futures/test/CollectTest.cpp
@@ -36,7 +36,8 @@ TEST(Collect, collectAll) {
     std::vector<Promise<int>> promises(10);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -60,7 +61,8 @@ TEST(Collect, collectAll) {
     std::vector<Promise<int>> promises(4);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -93,7 +95,8 @@ TEST(Collect, collectAll) {
     std::vector<Promise<Unit>> promises(10);
     std::vector<Future<Unit>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -117,7 +120,8 @@ TEST(Collect, collect) {
     std::vector<Promise<int>> promises(10);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -140,7 +144,8 @@ TEST(Collect, collect) {
     std::vector<Promise<int>> promises(10);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -176,7 +181,8 @@ TEST(Collect, collect) {
     std::vector<Promise<Unit>> promises(10);
     std::vector<Future<Unit>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -196,7 +202,8 @@ TEST(Collect, collect) {
     std::vector<Promise<Unit>> promises(10);
     std::vector<Future<Unit>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -232,7 +239,8 @@ TEST(Collect, collect) {
     std::vector<Promise<std::unique_ptr<int>>> promises(10);
     std::vector<Future<std::unique_ptr<int>>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -256,7 +264,8 @@ TEST(Collect, collectNotDefaultConstructible) {
   std::iota(indices.begin(), indices.end(), 0);
   std::shuffle(indices.begin(), indices.end(), rng);
 
-  for (auto& p : promises) {
+  futures.reserve(promises.size());
+for (auto& p : promises) {
     futures.push_back(p.getFuture());
   }
 
@@ -280,7 +289,8 @@ TEST(Collect, collectAny) {
     std::vector<Promise<int>> promises(10);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -309,7 +319,8 @@ TEST(Collect, collectAny) {
     std::vector<Promise<Unit>> promises(10);
     std::vector<Future<Unit>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -331,7 +342,8 @@ TEST(Collect, collectAny) {
     std::vector<Promise<int>> promises(10);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -350,7 +362,8 @@ TEST(Collect, collectAnyWithoutException) {
     std::vector<Promise<int>> promises(10);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -371,7 +384,8 @@ TEST(Collect, collectAnyWithoutException) {
     std::vector<Promise<int>> promises(10);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -395,7 +409,8 @@ TEST(Collect, collectAnyWithoutException) {
     std::vector<Promise<int>> promises(10);
     std::vector<Future<int>> futures;
 
-    for (auto& p : promises) {
+    futures.reserve(promises.size());
+for (auto& p : promises) {
       futures.push_back(p.getFuture());
     }
 
@@ -416,7 +431,8 @@ TEST(Collect, collectAnyWithoutException) {
 TEST(Collect, alreadyCompleted) {
   {
     std::vector<Future<Unit>> fs;
-    for (int i = 0; i < 10; i++) {
+    fs.reserve(10);
+for (int i = 0; i < 10; i++) {
       fs.push_back(makeFuture());
     }
 
@@ -427,7 +443,8 @@ TEST(Collect, alreadyCompleted) {
   }
   {
     std::vector<Future<int>> fs;
-    for (int i = 0; i < 10; i++) {
+    fs.reserve(10);
+for (int i = 0; i < 10; i++) {
       fs.push_back(makeFuture(i));
     }
 
@@ -570,7 +587,8 @@ TEST(Collect, collectN) {
   std::vector<Promise<Unit>> promises(10);
   std::vector<Future<Unit>> futures;
 
-  for (auto& p : promises) {
+  futures.reserve(promises.size());
+for (auto& p : promises) {
     futures.push_back(p.getFuture());
   }
 

--- a/folly/futures/test/ViaTest.cpp
+++ b/folly/futures/test/ViaTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <thread>
+#include <utility>
 
 #include <folly/MPMCQueue.h>
 #include <folly/executors/DrivableExecutor.h>
@@ -27,7 +28,7 @@
 using namespace folly;
 
 struct ManualWaiter : public DrivableExecutor {
-  explicit ManualWaiter(std::shared_ptr<ManualExecutor> ex) : ex(ex) {}
+  explicit ManualWaiter(std::shared_ptr<ManualExecutor> ex) : ex(std::move(ex)) {}
 
   void add(Func f) override {
     ex->add(std::move(f));
@@ -285,7 +286,7 @@ TEST(Via, then2) {
 }
 
 TEST(Via, then2Variadic) {
-  struct Foo { bool a = false; void foo(Try<Unit>) { a = true; } };
+  struct Foo { bool a = false; void foo(const Try<Unit>&) { a = true; } };
   Foo f;
   ManualExecutor x;
   makeFuture().then(&x, &Foo::foo, &f);

--- a/folly/hash/test/ChecksumTest.cpp
+++ b/folly/hash/test/ChecksumTest.cpp
@@ -70,7 +70,7 @@ ExpectedResult expectedResults[] = {
 };
 
 void testCRC32C(
-    std::function<uint32_t(const uint8_t*, size_t, uint32_t)> impl) {
+    const std::function<uint32_t(const uint8_t*, size_t, uint32_t)>& impl) {
   for (auto expected : expectedResults) {
     uint32_t result = impl(buffer + expected.offset, expected.length, ~0U);
     EXPECT_EQ(expected.crc32c, result);
@@ -78,7 +78,7 @@ void testCRC32C(
 }
 
 void testCRC32CContinuation(
-    std::function<uint32_t(const uint8_t*, size_t, uint32_t)> impl) {
+    const std::function<uint32_t(const uint8_t*, size_t, uint32_t)>& impl) {
   for (auto expected : expectedResults) {
     size_t partialLength = expected.length / 2;
     uint32_t partialChecksum = impl(

--- a/folly/io/async/test/AsyncSSLSocketTest.h
+++ b/folly/io/async/test/AsyncSSLSocketTest.h
@@ -807,8 +807,8 @@ class TestSSLAsyncCacheServer : public TestSSLServer {
 void getfds(int fds[2]);
 
 void getctx(
-  std::shared_ptr<folly::SSLContext> clientCtx,
-  std::shared_ptr<folly::SSLContext> serverCtx);
+  const std::shared_ptr<folly::SSLContext>& clientCtx,
+  const std::shared_ptr<folly::SSLContext>& serverCtx);
 
 void sslsocketpair(
   EventBase* eventBase,

--- a/folly/io/async/test/AsyncUDPSocketTest.cpp
+++ b/folly/io/async/test/AsyncUDPSocketTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <thread>
+#include <utility>
 
 #include <folly/Conv.h>
 #include <folly/SocketAddress.h>
@@ -81,7 +82,7 @@ class UDPAcceptor
 class UDPServer {
  public:
   UDPServer(EventBase* evb, folly::SocketAddress addr, int n)
-      : evb_(evb), addr_(addr), evbs_(n) {
+      : evb_(evb), addr_(std::move(addr)), evbs_(n) {
   }
 
   void start() {

--- a/folly/io/async/test/EventBaseTest.cpp
+++ b/folly/io/async/test/EventBaseTest.cpp
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <memory>
 #include <thread>
+#include <utility>
 
 using std::atomic;
 using std::deque;
@@ -1268,7 +1269,7 @@ class CountedLoopCallback : public EventBase::LoopCallback {
                         std::function<void()>())
     : eventBase_(eventBase)
     , count_(count)
-    , action_(action) {}
+    , action_(std::move(action)) {}
 
   void runLoopCallback() noexcept override {
     --count_;

--- a/folly/io/async/test/SSLSessionTest.cpp
+++ b/folly/io/async/test/SSLSessionTest.cpp
@@ -45,8 +45,8 @@ void getfds(int fds[2]) {
 }
 
 void getctx(
-    std::shared_ptr<folly::SSLContext> clientCtx,
-    std::shared_ptr<folly::SSLContext> serverCtx) {
+    const std::shared_ptr<folly::SSLContext>& clientCtx,
+    const std::shared_ptr<folly::SSLContext>& serverCtx) {
   clientCtx->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
 
   serverCtx->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");

--- a/folly/io/async/test/TestSSLServer.cpp
+++ b/folly/io/async/test/TestSSLServer.cpp
@@ -15,6 +15,8 @@
  */
 #include <folly/io/async/test/TestSSLServer.h>
 
+#include <utility>
+
 namespace folly {
 
 const char* kTestCert = "folly/io/async/test/certs/tests-cert.pem";
@@ -53,7 +55,7 @@ TestSSLServer::TestSSLServer(
     SSLServerAcceptCallbackBase* acb,
     std::shared_ptr<SSLContext> ctx,
     bool enableTFO)
-    : ctx_(ctx), acb_(acb) {
+    : ctx_(std::move(ctx)), acb_(acb) {
   init(enableTFO);
 }
 

--- a/folly/portability/Stdlib.cpp
+++ b/folly/portability/Stdlib.cpp
@@ -161,7 +161,7 @@ extern "C" int clearenv() {
     }
   }
 
-  for (auto s : data) {
+  for (const auto& s : data) {
     if (unsetenv(s.c_str()) != 0)
       return -1;
   }

--- a/folly/ssl/OpenSSLCertUtils.cpp
+++ b/folly/ssl/OpenSSLCertUtils.cpp
@@ -241,7 +241,7 @@ std::array<uint8_t, SHA256_DIGEST_LENGTH> OpenSSLCertUtils::getDigestSha256(
   return md;
 }
 
-X509StoreUniquePtr OpenSSLCertUtils::readStoreFromFile(std::string caFile) {
+X509StoreUniquePtr OpenSSLCertUtils::readStoreFromFile(const std::string& caFile) {
   std::string certData;
   if (!folly::readFile(caFile.c_str(), certData)) {
     throw std::runtime_error(

--- a/folly/ssl/OpenSSLCertUtils.h
+++ b/folly/ssl/OpenSSLCertUtils.h
@@ -93,7 +93,7 @@ class OpenSSLCertUtils {
   /**
    * Reads a store from a file (or buffer).  Throws on error.
    */
-  static X509StoreUniquePtr readStoreFromFile(std::string caFile);
+  static X509StoreUniquePtr readStoreFromFile(const std::string& caFile);
   static X509StoreUniquePtr readStoreFromBuffer(ByteRange);
 
  private:

--- a/folly/ssl/detail/OpenSSLThreading.cpp
+++ b/folly/ssl/detail/OpenSSLThreading.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <mutex>
+#include <utility>
 
 #include <folly/Portability.h>
 #include <folly/SharedMutex.h>
@@ -58,7 +59,7 @@ void setLockTypes(std::map<int, LockType> inLockTypes) {
             << "OpenSSL now uses platform native mutexes";
 #endif
 
-  lockTypes() = inLockTypes;
+  lockTypes() = std::move(inLockTypes);
 }
 
 bool isSSLLockDisabled(int lockId) {

--- a/folly/stats/test/TimeSeriesTest.cpp
+++ b/folly/stats/test/TimeSeriesTest.cpp
@@ -813,7 +813,7 @@ TEST(BucketedTimeSeries, reConstructEmptyTimeSeries) {
   auto firstTime = ts.firstTime();
   auto latestTime = ts.latestTime();
   auto duration = ts.duration();
-  auto buckets = ts.buckets();
+  const auto& buckets = ts.buckets();
 
   // Reconstruct the timeseries
   BucketedTimeSeries<int64_t> newTs(firstTime, latestTime, duration, buckets);

--- a/folly/synchronization/test/RWSpinLockTest.cpp
+++ b/folly/synchronization/test/RWSpinLockTest.cpp
@@ -152,7 +152,8 @@ TYPED_TEST(RWSpinLockTest, ConcurrentTests) {
   srand(time(nullptr));
 
   std::vector<std::thread> threads;
-  for (int i = 0; i < FLAGS_num_threads; ++i) {
+  threads.reserve(FLAGS_num_threads);
+for (int i = 0; i < FLAGS_num_threads; ++i) {
     threads.push_back(std::thread(&run<RWSpinLockType>, &l));
   }
 
@@ -220,7 +221,8 @@ TEST(RWSpinLock, concurrent_holder_test) {
   };
 
   std::vector<std::thread> threads;
-  for (int i = 0; i < FLAGS_num_threads; ++i) {
+  threads.reserve(FLAGS_num_threads);
+for (int i = 0; i < FLAGS_num_threads; ++i) {
     threads.push_back(std::thread(go));
   }
 

--- a/folly/synchronization/test/SmallLocksTest.cpp
+++ b/folly/synchronization/test/SmallLocksTest.cpp
@@ -110,7 +110,8 @@ void doPslTest() {
 
   const int nthrs = 17;
   std::vector<std::thread> threads;
-  for (int i = 0; i < nthrs; ++i) {
+  threads.reserve(nthrs);
+for (int i = 0; i < nthrs; ++i) {
     threads.push_back(std::thread(&PslTest<T>::doTest, &testObj));
   }
   for (auto& t : threads) {
@@ -142,7 +143,8 @@ TEST(SmallLocks, SpinLockCorrectness) {
 
   int nthrs = sysconf(_SC_NPROCESSORS_ONLN) * 2;
   std::vector<std::thread> threads;
-  for (int i = 0; i < nthrs; ++i) {
+  threads.reserve(nthrs);
+for (int i = 0; i < nthrs; ++i) {
     threads.push_back(std::thread(splock_test));
   }
   for (auto& t : threads) {

--- a/folly/system/MemoryMapping.cpp
+++ b/folly/system/MemoryMapping.cpp
@@ -224,7 +224,7 @@ off_t memOpChunkSize(off_t length, off_t pageSize) {
  * - success: true + amountSucceeded == bufSize (op success on whole buffer)
  * - failure: false + amountSucceeded == nr bytes on which op succeeded.
  */
-bool memOpInChunks(std::function<int(void*, size_t)> op,
+bool memOpInChunks(const std::function<int(void*, size_t)>& op,
                    void* mem, size_t bufSize, off_t pageSize,
                    size_t& amountSucceeded) {
   // Linux' unmap/mlock/munlock take a kernel semaphore and block other threads

--- a/folly/test/AHMIntStressTest.cpp
+++ b/folly/test/AHMIntStressTest.cpp
@@ -107,7 +107,8 @@ TEST(AHMIntStressTest, Test) {
   SCOPE_EXIT { delete objs; };
 
   std::vector<std::thread> threads;
-  for (int threadId = 0; threadId < 64; ++threadId) {
+  threads.reserve(64);
+for (int threadId = 0; threadId < 64; ++threadId) {
     threads.emplace_back([objs] {
       for (int recycles = 0; recycles < 500; ++recycles) {
         for (int i = 0; i < 10; i++) {

--- a/folly/test/ConcurrentSkipListTest.cpp
+++ b/folly/test/ConcurrentSkipListTest.cpp
@@ -111,7 +111,7 @@ static void sumAllValues(SkipListAccessor skipList, int64_t *sum) {
 }
 
 static void concurrentSkip(const vector<ValueType> *values,
-    SkipListAccessor skipList) {
+    const SkipListAccessor& skipList) {
   int64_t sum = 0;
   SkipListAccessor::Skipper skipper(skipList);
   FOR_EACH(it, *values) {

--- a/folly/test/FBVectorTest.cpp
+++ b/folly/test/FBVectorTest.cpp
@@ -277,7 +277,7 @@ TEST(FBVector, zero_len) {
   fbvector<int> fb3(std::move(fb1));
   fbvector<int> fb4;
   fb4 = std::move(fb2);
-  fbvector<int> fb5 = fb3;
+  const fbvector<int>& fb5 = fb3;
   fbvector<int> fb6;
   fb6 = fb4;
   std::initializer_list<int> il = {};

--- a/folly/test/IndestructibleTest.cpp
+++ b/folly/test/IndestructibleTest.cpp
@@ -33,7 +33,7 @@ namespace {
 struct Magic {
   function<void()> dtor_;
   function<void()> move_;
-  Magic(function<void()> ctor, function<void()> dtor, function<void()> move)
+  Magic(const function<void()>& ctor, function<void()> dtor, function<void()> move)
       : dtor_(std::move(dtor)), move_(std::move(move)) {
     ctor();
   }

--- a/folly/test/RandomTest.cpp
+++ b/folly/test/RandomTest.cpp
@@ -82,7 +82,8 @@ TEST(Random, MultiThreaded) {
   const int n = 100;
   std::vector<uint32_t> seeds(n);
   std::vector<std::thread> threads;
-  for (int i = 0; i < n; ++i) {
+  threads.reserve(n);
+for (int i = 0; i < n; ++i) {
     threads.push_back(std::thread([i, &seeds] {
       seeds[i] = randomNumberSeed();
     }));
@@ -109,7 +110,8 @@ TEST(Random, sanity) {
     std::vector<uint32_t> vals;
     folly::Random::DefaultGenerator rng;
     rng.seed(0xdeadbeef);
-    for (int i = 0; i < kTestSize; ++i) {
+    vals.reserve(kTestSize);
+for (int i = 0; i < kTestSize; ++i) {
       vals.push_back(folly::Random::rand32(rng));
     }
     rng.seed(0xdeadbeef);
@@ -126,7 +128,8 @@ TEST(Random, sanity) {
     std::vector<uint64_t> vals;
     folly::Random::DefaultGenerator rng;
     rng.seed(0xdeadbeef);
-    for (int i = 0; i < kTestSize; ++i) {
+    vals.reserve(kTestSize);
+for (int i = 0; i < kTestSize; ++i) {
       vals.push_back(folly::Random::rand64(rng));
     }
     rng.seed(0xdeadbeef);

--- a/folly/test/SpinLockTest.cpp
+++ b/folly/test/SpinLockTest.cpp
@@ -106,7 +106,8 @@ void correctnessTest() {
   int nthrs = sysconf(_SC_NPROCESSORS_ONLN) * 2;
   std::vector<std::thread> threads;
   LockedVal<LOCK> v;
-  for (int i = 0; i < nthrs; ++i) {
+  threads.reserve(nthrs);
+for (int i = 0; i < nthrs; ++i) {
     threads.push_back(std::thread(spinlockTestThread<LOCK>, &v));
   }
   for (auto& t : threads) {
@@ -120,7 +121,8 @@ void trylockTest() {
   std::vector<std::thread> threads;
   TryLockState<LOCK> state;
   size_t count = 100;
-  for (int i = 0; i < nthrs; ++i) {
+  threads.reserve(nthrs);
+for (int i = 0; i < nthrs; ++i) {
     threads.push_back(std::thread(trylockTestThread<LOCK>, &state, count));
   }
   for (auto& t : threads) {

--- a/folly/test/ThreadCachedIntTest.cpp
+++ b/folly/test/ThreadCachedIntTest.cpp
@@ -222,7 +222,8 @@ TEST(ThreadCachedInt, MultiThreadedCached) {
     std::atomic<bool> run(true);
     std::atomic<int> threadsDone(0);
     std::vector<std::thread> threads;
-    for (int i = 0; i < FLAGS_numThreads; ++i) {
+    threads.reserve(FLAGS_numThreads);
+for (int i = 0; i < FLAGS_numThreads; ++i) {
       threads.push_back(std::thread([&] {
         FOR_EACH_RANGE(k, 0, numPerThread) {
           ++TCInt64;

--- a/folly/test/ThreadLocalTest.cpp
+++ b/folly/test/ThreadLocalTest.cpp
@@ -313,7 +313,8 @@ TEST(ThreadLocalPtr, AccessAllThreadsCounter) {
   std::atomic<bool> run(true);
   std::atomic<int> totalAtomic(0);
   std::vector<std::thread> threads;
-  for (int i = 0; i < kNumThreads; ++i) {
+  threads.reserve(kNumThreads);
+for (int i = 0; i < kNumThreads; ++i) {
     threads.push_back(std::thread([&]() {
       stci.add(1);
       totalAtomic.fetch_add(1);

--- a/folly/test/TryTest.cpp
+++ b/folly/test/TryTest.cpp
@@ -132,7 +132,7 @@ TEST(Try, ValueOverloads) {
 // Make sure we can copy Trys for copyable types
 TEST(Try, copy) {
   Try<int> t;
-  auto t2 = t;
+  const auto& t2 = t;
 }
 
 // But don't choke on move-only types
@@ -243,7 +243,7 @@ TEST(Try, exception) {
 }
 
 template <typename E>
-static E* get_exception(std::exception_ptr eptr) {
+static E* get_exception(const std::exception_ptr& eptr) {
   try {
     std::rethrow_exception(eptr);
   } catch (E& e) {

--- a/folly/test/small_vector_test.cpp
+++ b/folly/test/small_vector_test.cpp
@@ -290,7 +290,8 @@ TEST(small_vector, BasicGuarantee) {
     6,
     [&] (folly::small_vector<Thrower,3>& v) {
       std::vector<Thrower> b;
-      for (int i = 0; i < 6; ++i) {
+      b.reserve(6);
+for (int i = 0; i < 6; ++i) {
         b.emplace_back();
       }
 


### PR DESCRIPTION
Runs the several clang-tidy `performance-*` checks on the entire codebase and applies the auto fix-its