### PR TITLE
Fix unused variable error in AsyncUDPSocket

### DIFF
--- a/folly/io/async/AsyncUDPSocket.cpp
+++ b/folly/io/async/AsyncUDPSocket.cpp
@@ -133,6 +133,7 @@ void AsyncUDPSocket::bind(const folly::SocketAddress& address) {
 }
 
 void AsyncUDPSocket::dontFragment(bool df) {
+  (void) df; // to avoid potential unused variable warning
 #ifdef IP_MTU_DISCOVER
   if (address().getFamily() == AF_INET) {
     int v4 = df ? IP_PMTUDISC_DO : IP_PMTUDISC_WANT;


### PR DESCRIPTION
Summary:
Some OSes do not define `IP_MTU_DISCOVER` or `IPV6_MTU_DISCOVER`. As such, this would result in the function argument parameter `df` being unused, which is a warning that is then treated as an error.

Earlier today (2806dda49f25a238852f75a52225ce9ee0cbccc1), this logic was added about setting the DF which broke Mac builds.