### PR TITLE
[CMake] Do not assume subdirectory for finding libiberty.h

### DIFF
--- a/CMake/FindLibiberty.cmake
+++ b/CMake/FindLibiberty.cmake
@@ -1,4 +1,4 @@
-find_path(LIBIBERTY_INCLUDE_DIR NAMES libiberty/libiberty.h)
+find_path(LIBIBERTY_INCLUDE_DIR NAMES libiberty.h)
 mark_as_advanced(LIBIBERTY_INCLUDE_DIR)
 
 find_library(LIBIBERTY_LIBRARY NAMES iberty)


### PR DESCRIPTION
Summary:
Do not assume `libiberty.h` is contained within a subdirectory called `libiberty`.

In general, it is probably best not to assume a certain directory structure as it will vary across package manager, OS, etc. While users can certainly set `CMAKE_INCLUDE_PATH` and `CMAKE_LIBRARY_PATH` accordingly to make things work, it's not ideal. It is nicer to just modify the find module scripts to support more users out of the box.