### PR TITLE
Missing SequenceExecutor.h

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -101,6 +101,7 @@ nobase_follyinclude_HEADERS = \
 	executors/IOThreadPoolExecutor.h \
 	executors/NotificationQueueExecutor.h \
 	executors/ScheduledExecutor.h \
+	executors/SequencedExecutor.h \
 	executors/SerialExecutor.h \
 	executors/ThreadPoolExecutor.h \
 	executors/ThreadedExecutor.h \


### PR DESCRIPTION
When compiling using autoconf, automake, make and make install, SequenceExecutor.h is not installed automatically.