### PR TITLE
Missing installation of detail/Singleton.h

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -87,6 +87,7 @@ nobase_follyinclude_HEADERS = \
 	detail/PolyDetail.h \
 	detail/RangeCommon.h \
 	detail/RangeSse42.h \
+	detail/Singleton.h \
 	detail/SlowFingerprint.h \
 	detail/SocketFastOpen.h \
 	detail/StaticSingletonManager.h \


### PR DESCRIPTION
Makefile does not install detail/Singleton.h, which is needed by proxygen