### PR TITLE
Fix msvc ProducerConsumerQueue compilation and update its doc

### DIFF
--- a/folly/ProducerConsumerQueue.h
+++ b/folly/ProducerConsumerQueue.h
@@ -182,7 +182,7 @@ struct ProducerConsumerQueue {
   alignas(hardware_destructive_interference_size)
       std::atomic<unsigned int> writeIndex_;
 
-  char pad1_[hardware_destructive_interference_size - sizeof(writeIndex_)];
+  char pad1_[hardware_destructive_interference_size - sizeof(decltype(writeIndex_))];
 };
 
 } // namespace folly

--- a/folly/docs/ProducerConsumerQueue.md
+++ b/folly/docs/ProducerConsumerQueue.md
@@ -40,7 +40,7 @@ the queue filling  or staying empty for long is unlikely.
 A toy example that doesn't really do anything useful:
 
 ``` Cpp
-    folly::ProducerConsumerQueue<folly::fbstring> queue;
+    folly::ProducerConsumerQueue<folly::fbstring> queue{size};
 
     std::thread reader([&queue] {
       for (;;) {


### PR DESCRIPTION
Compilation of basic sample from doc using VS2017 currently fails with:
```
C2327 'folly::ProducerConsumerQueue<folly::fbstring>::writeIndex_': is not a type name, static, or enumerator
```
Fixed it and updated the docs.