### PR TITLE
Fix some `CMAKE_REQUIRED_FLAGS` stuff

### DIFF
--- a/CMake/FollyCompilerUnix.cmake
+++ b/CMake/FollyCompilerUnix.cmake
@@ -2,7 +2,7 @@ set(CMAKE_CXX_FLAGS_COMMON "-g -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_COMMON}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_COMMON} -O3")
 
-list(APPEND CMAKE_REQUIRED_FLAGS -std=gnu++14)
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=gnu++14")
 function(apply_folly_compile_options_to_target THETARGET)
   target_compile_definitions(${THETARGET}
     PRIVATE

--- a/CMake/FollyConfigChecks.cmake
+++ b/CMake/FollyConfigChecks.cmake
@@ -19,7 +19,8 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
     -Werror=unknown-warning-option
     COMPILER_HAS_UNKNOWN_WARNING_OPTION)
   if (COMPILER_HAS_UNKNOWN_WARNING_OPTION)
-    list(APPEND CMAKE_REQUIRED_FLAGS -Werror=unknown-warning-option)
+    set(CMAKE_REQUIRED_FLAGS
+      "${CMAKE_REQUIRED_FLAGS} -Werror=unknown-warning-option")
   endif()
 
   CHECK_CXX_COMPILER_FLAG(-Wshadow-local COMPILER_HAS_W_SHADOW_LOCAL)
@@ -61,6 +62,13 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
   endif()
 endif()
 
+set(FOLLY_ORIGINAL_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+string(REGEX REPLACE
+  "-std=(c|gnu)\\+\\+.."
+  ""
+  CMAKE_REQUIRED_FLAGS
+  "${CMAKE_REQUIRED_FLAGS}")
+
 check_symbol_exists(pthread_atfork pthread.h FOLLY_HAVE_PTHREAD_ATFORK)
 
 # Unfortunately check_symbol_exists() does not work for memrchr():
@@ -70,11 +78,14 @@ check_symbol_exists(preadv sys/uio.h FOLLY_HAVE_PREADV)
 check_symbol_exists(pwritev sys/uio.h FOLLY_HAVE_PWRITEV)
 check_symbol_exists(clock_gettime time.h FOLLY_HAVE_CLOCK_GETTIME)
 
+
 check_function_exists(
   cplus_demangle_v3_callback
   FOLLY_HAVE_CPLUS_DEMANGLE_V3_CALLBACK
 )
 check_function_exists(malloc_usable_size FOLLY_HAVE_MALLOC_USABLE_SIZE)
+
+set(CMAKE_REQUIRED_FLAGS "${FOLLY_ORIGINAL_CMAKE_REQUIRED_FLAGS}")
 
 check_cxx_source_compiles("
   #pragma GCC diagnostic error \"-Wattributes\"


### PR DESCRIPTION
This fixes two issues related to CMAKE_REQUIRED_FLAGS

----

CMAKE_REQUIRED_FLAGS, unlike the other CMAKE_REQUIRED_* variables, is a
string, not a list. A list with more than one item in
CMAKE_REQUIRED_FLAGS results in a semicolon showing up in the middle of
the command line for at least check_symbol_exists and check_type_size
calls, prematurely terminating the compilation command and resulting in
potentially incorrect CMake test failures.

For example, CMake fails to determine the size of __int128 on macOS
10.13.3, with Apple Clang 9 (clang-900.0.39.2), even though __int128 is
supported for this platform, as the following C program

    int main() {
        __int128 i;
    }

compiles successfully with the command "clang test.c". CMake fails to
compile a program with __int128 for an entirely different reason:

    Building CXX object CMakeFiles/cmTC_d7e3f.dir/INT128_SIZE.cpp.o
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++  -DGFLAGS_IS_A_DLL=0 -isystem /usr/local/include -I/usr/local/opt/openssl@1.1/include  -fsanitize=address,undefined -std=gnu++14;-Werror=unknown-warning-option   -o CMakeFiles/cmTC_d7e3f.dir/INT128_SIZE.cpp.o -c /Users/awang/code/CRES/scc-analysis/build-debug/CMakeFiles/CheckTypeSize/INT128_SIZE.cpp
    clang: error: no input files
    /bin/sh: -Werror=unknown-warning-option: command not found
    make[1]: *** [CMakeFiles/cmTC_d7e3f.dir/INT128_SIZE.cpp.o] Error 127
    make: *** [cmTC_d7e3f/fast] Error 2

Using set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} <new_flag>")
avoids this problem.

----

CMAKE_REQUIRED_FLAGS is given to both C and C++ compiler invocations.
The C++-specific flag -std=gnu++14 causes compilation to fail on Apple
LLVM 9.1.0 (clang-902.0.39.2) with errors along the lines of:

    Building C object CMakeFiles/cmTC_af532.dir/CheckSymbolExists.c.o
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -DGFLAGS_IS_A_DLL=0 -isystem /usr/local/include -I/usr/local/opt/openssl@1.1/include  -std=gnu++14   -o CMakeFiles/cmTC_af532.dir/CheckSymbolExists.c.o   -c /Users/awang/code/CRES/scc-analysis/build-debug/CMakeFiles/CMakeTmp/CheckSymbolExists.c
    error: invalid argument '-std=gnu++14' not allowed with 'C/ObjC'
    make[1]: *** [CMakeFiles/cmTC_af532.dir/CheckSymbolExists.c.o] Error 1
    make: *** [cmTC_af532/fast] Error 2

The affected functions are:

  - pthread_atfork
  - memrchr
  - preadv
  - pwritev
  - clock_gettime
  - cplus_demangle_v3_callback
  - malloc_usable_size

Of these, only pthread_atfork and clock_gettime were detected as being
absent when they were actually present.

The failure to correctly identify the presence of pthread_atfork, at
least, can cause Folly to fail to build on macOS because Folly requires
pthread_atfork for macOS but thinks it is absent due to the failed test.
