### PR TITLE
Fix gcc7 error in ExceptionInfo constructor

### DIFF
--- a/folly/experimental/exception_tracer/ExceptionTracer.h
+++ b/folly/experimental/exception_tracer/ExceptionTracer.h
@@ -28,7 +28,7 @@ namespace folly {
 namespace exception_tracer {
 
 struct ExceptionInfo {
-  const std::type_info* type;
+  const std::type_info* type{nullptr};
   // The values in frames are IP (instruction pointer) addresses.
   // They are only filled if the low-level exception tracer library is
   // linked in or LD_PRELOADed.


### PR DESCRIPTION
When trying to compile `folly/experimental/exception_tracer` with gcc-7.2, I get the following error:

```
ExceptionCounterLib.cpp: In instantiation of '{anonymous}::throwHandler(void*, std::type_info*, void (*)(void*))::<lambda(auto:9&)> [with auto:9 = std::unordered_map<long unsigned int, folly::exception_tracer::ExceptionStats>]':
../../../folly/Synchronized.h:162:20:   required from 'auto folly::SynchronizedBase<Subclass, (folly::detail::MutexLevel)1>::withWLock(Function&&) [with Function = {anonymous}::throwHandler(void*, std::type_info*, void (*)(void*))::<lambda(auto:9&)>; Subclass = folly::Synchronized<std::unordered_map<long unsigned int, folly::exception_tracer::ExceptionStats>, folly::RWSpinLock>]'
ExceptionCounterLib.cpp:132:4:   required from here
ExceptionCounterLib.cpp:127:21: error: uninitialized variable 'info' in 'constexpr' function
       ExceptionInfo info;
                     ^~~~
In file included from ../../../folly/experimental/exception_tracer/ExceptionCounterLib.h:22:0,
                 from ExceptionCounterLib.cpp:16:
../../../folly/experimental/exception_tracer/ExceptionTracer.h:30:8: note: 'struct folly::exception_tracer::ExceptionInfo' has no user-provided default constructor
 struct ExceptionInfo {
        ^~~~~~~~~~~~~
../../../folly/experimental/exception_tracer/ExceptionTracer.h:31:25: note: and the implicitly-defined constructor does not initialize 'const std::type_info* folly::exception_tracer::ExceptionInfo::type'
   const std::type_info* type;
                         ^~~~
```

Fixed by initializing `ExceptionInfo::type`.

Compiling with gcc 7.2 now works.