### PR TITLE
Fix CMakeLists.txt to not exclude everything with 'build' in pathname

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ REMOVE_MATCHES_FROM_LISTS(files hfiles
     "^${FOLLY_DIR}/experimental/hazptr/example/"
     "^${FOLLY_DIR}/experimental/logging/example/"
     "^${FOLLY_DIR}/futures/exercises/"
-    "^${FOLLY_DIR}.*/test/"
+    "^${FOLLY_DIR}/(.*/)?test/"
     "^${FOLLY_DIR}/tools/"
     "Benchmark.cpp$"
     "Test.cpp$"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,14 @@ auto_sources(hfiles "*.h" "RECURSE" "${FOLLY_DIR}")
 # library sources.  Test sources are listed separately below.
 REMOVE_MATCHES_FROM_LISTS(files hfiles
   MATCHES
-    "/build/"
-    "/experimental/exception_tracer/"
-    "/experimental/hazptr/bench/"
-    "/experimental/hazptr/example/"
-    "/experimental/logging/example/"
-    "/futures/exercises/"
-    "/test/"
-    "/tools/"
+    "^${FOLLY_DIR}/build/"
+    "^${FOLLY_DIR}/experimental/exception_tracer/"
+    "^${FOLLY_DIR}/experimental/hazptr/bench/"
+    "^${FOLLY_DIR}/experimental/hazptr/example/"
+    "^${FOLLY_DIR}/experimental/logging/example/"
+    "^${FOLLY_DIR}/futures/exercises/"
+    "^${FOLLY_DIR}.*/test/"
+    "^${FOLLY_DIR}/tools/"
     "Benchmark.cpp$"
     "Test.cpp$"
 )
@@ -142,7 +142,7 @@ list(APPEND hfiles
 if (NOT FOLLY_USE_SYMBOLIZER)
   REMOVE_MATCHES_FROM_LISTS(files hfiles
     MATCHES
-      "/experimental/symbolizer/"
+      "^${FOLLY_DIR}/experimental/symbolizer/"
   )
   list(REMOVE_ITEM files
     ${FOLLY_DIR}/SingletonStackTrace.cpp


### PR DESCRIPTION
The cmake globbing then excluding strategy implies that if the directory
in which we are compiling has a folder named `build` on its path like `/home/alice/project/build/folly/...`, everything breaks.
Note that it is the same for `tools` and `test`, I also fixed the tools one, but the test once has many files.... Using a file list would be the real solution.