### PR TITLE
Fix for #819 (lang/Ordering.h is not installed via "make install")

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -342,6 +342,7 @@ nobase_follyinclude_HEADERS = \
 	lang/ColdClass.h \
 	lang/Exception.h \
 	lang/Launder.h \
+	lang/Ordering.h \
 	lang/RValueReferenceWrapper.h \
 	lang/SafeAssert.h \
 	lang/UncaughtExceptions.h \


### PR DESCRIPTION
fixes #819.