### PR TITLE
BugFix: QueuedImmediateExecutor.h is missed in the include header files

### DIFF
--- a/folly/Makefile.am
+++ b/folly/Makefile.am
@@ -110,6 +110,7 @@ nobase_follyinclude_HEADERS = \
 	executors/IOObjectCache.h \
 	executors/IOThreadPoolExecutor.h \
 	executors/NotificationQueueExecutor.h \
+	executors/QueuedImmediateExecutor.h \
 	executors/ScheduledExecutor.h \
 	executors/SequencedExecutor.h \
 	executors/SerialExecutor.h \


### PR DESCRIPTION
As per title.