### PR TITLE
Fix LIBCPP cmake check

### DIFF
--- a/CMake/FollyConfigChecks.cmake
+++ b/CMake/FollyConfigChecks.cmake
@@ -166,7 +166,7 @@ check_cxx_source_compiles("
   #if !_LIBCPP_VERSION
   #error No libc++
   #endif
-  void func() {}"
+  int main() { return 0; }"
   FOLLY_USE_LIBCPP
 )
 


### PR DESCRIPTION
The test was missing a `main` meaning that it would fail even if libc++ was in use, making all the rest fail on macos for example.