### PR TITLE
Remove implied POSITION_INDEPENDENT_CODE property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,9 +194,6 @@ add_library(folly_base OBJECT
   ${files} ${hfiles}
   ${CMAKE_CURRENT_BINARY_DIR}/folly/folly-config.h
 )
-if (BUILD_SHARED_LIBS)
-  set_property(TARGET folly_base PROPERTY POSITION_INDEPENDENT_CODE ON)
-endif()
 auto_source_group(folly ${FOLLY_DIR} ${files} ${hfiles})
 apply_folly_compile_options_to_target(folly_base)
 # Add the generated files to the correct source group.


### PR DESCRIPTION
PIC is implied by BUILD_SHARED_LIBS in CMake, so the test is confusing.
Note that if one wants to build static and use it to create a shared library with it, he will need to compile either shared
or static with CMake option -DCMAKE_POSITION_INDEPENDENT_CODE