### PR TITLE
Remove redundant static_cast

### DIFF
--- a/folly/lang/Exception.h
+++ b/folly/lang/Exception.h
@@ -32,7 +32,7 @@ template <typename Ex>
 #if (__GNUC__ && !__EXCEPTIONS)
   std::terminate();
 #else
-  throw static_cast<Ex&&>(ex);
+  throw ex;
 #endif
 }
 
@@ -42,7 +42,7 @@ template <typename Ex>
 /// compiled with -fno-exceptions.
 template <typename Ex, typename... Args>
 [[noreturn]] FOLLY_NOINLINE FOLLY_COLD void throw_exception(Args&&... args) {
-  throw_exception(Ex(static_cast<Args&&>(args)...));
+  throw_exception(Ex(args...));
 }
 
 } // namespace folly


### PR DESCRIPTION
Summary: remove redundant `static_cast`.

All failing builds are just the cause of timeout from `tdigest` tests. Seems to be a common theme of exceeding 120 sec timeouts for the open-source Travis runs.