### PR TITLE
Allow HHWheelTimer to set default-timeout

### DIFF
--- a/folly/io/async/HHWheelTimer.h
+++ b/folly/io/async/HHWheelTimer.h
@@ -196,6 +196,13 @@ class HHWheelTimer : private folly::AsyncTimeout,
   }
 
   /**
+   * Set the default timeout interval for this HHWheelTimer.
+   */
+  void setDefaultTimeout(std::chrono::milliseconds timeout) {
+      defaultTimeout_ = timeout;
+  }
+
+  /**
    * Schedule the specified Callback to be invoked after the
    * specified timeout interval.
    *

--- a/folly/io/async/test/HHWheelTimerTest.cpp
+++ b/folly/io/async/test/HHWheelTimerTest.cpp
@@ -125,6 +125,17 @@ TEST_F(HHWheelTimerTest, TestSchedulingWithinCallback) {
 }
 
 /*
+ * Test changing default-timeout in timer.
+ */
+TEST_F(HHWheelTimerTest, TestSetDefaultTimeout) {
+  HHWheelTimer& t = eventBase.timer();
+
+  t.setDefaultTimeout(milliseconds(1000));
+  // verify: default-time has been modified
+  ASSERT_EQ(t.getDefaultTimeout(), milliseconds(1000));
+}
+
+/*
  * Test cancelling a timeout when it is scheduled to be fired right away.
  */
 


### PR DESCRIPTION
### Motivation
We are using facebook::proxygen to build Http-utility on top of it. One of the main server-connector class [Proxygen::HTTPConnector](https://github.com/facebook/proxygen/blob/master/proxygen/lib/http/HTTPConnector.h#L56) requires `folly::HHWheelTimer` to perform timer stuff inside it.

Now, `folly::HHWheelTimer` is a very large object and we would like to avoid `folly::HHWheelTimer` creation for every new `Proxygen::HTTPConnector` therefore, we are thinking to reuse [EventBase::timer()](https://github.com/facebook/folly/blob/master/folly/io/async/EventBase.h#L527) that creates one timer per EventBase (application creates it 1 per io thread).

But `EventBase::timer()` creates timer with default-time and caller can not modify it. Because of that other dependent component can't use it and proxygen gives below error:
```
F0522 23:50:19.629158  7775 WheelTimerInstance.cpp:71] Check failed: defaultTimeoutMS_.count() >= 0 (-1 vs. 0) 
*** Check failure stack trace: ***
    @     0x7f5e6ce26e6d  (unknown)
    @     0x7f5e6ce28ced  (unknown)
    @     0x7f5e6ce26a5c  (unknown)
    @     0x7f5e6ce2963e  (unknown)
    @     0x7f5e6de8c1ad  proxygen::WheelTimerInstance::scheduleTimeout()
    @     0x7f5e6de7c059  proxygen::HTTPTransaction::HTTPTransaction()
    @     0x7f5e6deacff1  _ZNSt8_Rb_treeIjSt4pairIKjN8proxygen15HTTPTransactionEESt10_Select1stIS4_ESt4lessIjESaIS4_EE17_M_emplace_uniqueIJRKSt21piecewise_construct_tSt5tupleIJRjEESF_IJONS2_18TransportDirectionESG_OmRNS2_11HTTPSessionERNS2_18HTTP2PriorityQueueERNS2_18WheelTimerInstanceERPNS2_16HTTPSessionStatsEObRmSK_RNS2_5http214PriorityUpdateESG_EEEEES0_ISt17_Rb_tree_iteratorIS4_EbEDpOT_
    @     0x7f5e6deaa23a  proxygen::HTTPSession::createTransaction()
    @           0x4f7f93  proxygen::HTTPUpstreamSession::newTransaction()
    @           0x4ad9a4  Sherpa::HttpSession::sendRequest()
    @           0x4aee08  Sherpa::HttpSession::connectSuccess()
    @           0x4f5c69  proxygen::HTTPConnector::connectSuccess()
    @     0x7f5e6d47e414  folly::AsyncSocket::handleConnect()
    @     0x7f5e6d48769d  folly::AsyncSocket::handleWrite()
    @     0x7f5e6d47a05c  folly::AsyncSocket::ioReady()
```

### Modification

- add `setDefaultTimeout()` method into timer so, application can configure it.

### Result

- No functional change but it facilitates application to configure defaultTimeout after `folly::HHWheelTimer` is created.