### PR TITLE
Fix usage of target_include_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,9 +206,8 @@ source_group("folly\\build" FILES
 
 target_include_directories(folly_deps
   INTERFACE
-    $<BUILD_INTERFACE:
-      ${CMAKE_CURRENT_SOURCE_DIR}
-      ${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 


### PR DESCRIPTION
See https://gitlab.kitware.com/cmake/cmake/issues/16686

This patch was originally contributed to MacPorts by @mohd-akram in https://github.com/macports/macports-ports/pull/1933.