### PR TITLE
Suppress spurious "may be used uninitialized" warnings from gcc.

### DIFF
--- a/folly/FBVector.h
+++ b/folly/FBVector.h
@@ -161,11 +161,17 @@ class fbvector {
       }
     }
 
+FOLLY_PUSH_WARNING
+// GCC has a tendency to false positives for newCap in this function.
+FOLLY_GCC_DISABLE_WARNING("-Wmaybe-uninitialized")
+
     void set(pointer newB, size_type newSize, size_type newCap) {
       z_ = newB + newCap;
       e_ = newB + newSize;
       b_ = newB;
     }
+
+FOLLY_POP_WARNING
 
     void reset(size_type newCap) {
       destroy();
@@ -1377,6 +1383,10 @@ class fbvector {
   //---------------------------------------------------------------------------
   // interface
 
+FOLLY_PUSH_WARNING
+// GCC has a tendency to false positives for newCap in this function.
+FOLLY_GCC_DISABLE_WARNING("-Wmaybe-uninitialized")
+
   template <
       typename IsInternalFunc,
       typename InsertInternalFunc,
@@ -1453,6 +1463,8 @@ class fbvector {
       return position;
     }
   }
+
+FOLLY_POP_WARNING
 
  public:
   template <class... Args>

--- a/folly/detail/ThreadLocalDetail.h
+++ b/folly/detail/ThreadLocalDetail.h
@@ -30,7 +30,14 @@
 #include <folly/Function.h>
 #include <folly/Portability.h>
 #include <folly/ScopeGuard.h>
+
+FOLLY_PUSH_WARNING
+// GCC has a tendency to false positives in SharedMutex::ReadHolder when
+// compiling onThreadExit.
+FOLLY_GCC_DISABLE_WARNING("-Wmaybe-uninitialized")
 #include <folly/SharedMutex.h>
+FOLLY_POP_WARNING
+
 #include <folly/container/Foreach.h>
 #include <folly/detail/AtFork.h>
 #include <folly/memory/Malloc.h>

--- a/folly/experimental/test/FutureDAGTest.cpp
+++ b/folly/experimental/test/FutureDAGTest.cpp
@@ -29,6 +29,10 @@ struct FutureDAGTest : public testing::Test {
     return handle;
   }
 
+FOLLY_PUSH_WARNING
+// GCC has a tendency to false positives for source_node in this function.
+FOLLY_GCC_DISABLE_WARNING("-Wmaybe-uninitialized")
+
   void reset() {
     Handle source_node;
     std::unordered_set<Handle> memo;
@@ -51,6 +55,8 @@ struct FutureDAGTest : public testing::Test {
     }
     dag->reset();
   }
+
+FOLLY_POP_WARNING
 
   void remove(Handle a) {
     for (auto& node : nodes) {


### PR DESCRIPTION
When I configure like so...

```shell
cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -D BUILD_TESTS=ON -D BUILD_SHARED_LIBS=OFF ..
```

on Linux Mint 18.3, I get several errors about variables that may be used uninitialized when I subsequently try to build. GCC has a bit of a reputation for producing such errors as false positives, which only tend to show up in builds with optimisation, as it is only then that the analysis required to produce such errors is performed.

If this is too much clutter, then I guess we could just add `-Wno-maybe-uninitialized` to `CMAKE_CXX_FLAGS_COMMON` in `CMake/FollyCompilerUnix.cmake`.