### PR TITLE
Appease gcc-8 warnings

### DIFF
--- a/folly/synchronization/AtomicStruct.h
+++ b/folly/synchronization/AtomicStruct.h
@@ -68,13 +68,13 @@ class AtomicStruct {
     // we expect the compiler to optimize away the memcpy, but without
     // it we would violate strict aliasing rules
     Raw d = 0;
-    memcpy(&d, &v, sizeof(T));
+    memcpy(&d, static_cast<void*>(&v), sizeof(T));
     return d;
   }
 
   static T decode(Raw d) noexcept {
     T v;
-    memcpy(&v, &d, sizeof(T));
+    memcpy(static_cast<void*>(&v), &d, sizeof(T));
     return v;
   }
 

--- a/folly/system/ThreadName.cpp
+++ b/folly/system/ThreadName.cpp
@@ -195,7 +195,7 @@ bool setThreadName(pthread_t pid, StringPiece name) {
   // std::thread::native_handle_type, which means we can do unsafe things to
   // extract it.
   std::thread::id id;
-  std::memcpy(&id, &pid, sizeof(id));
+  std::memcpy(static_cast<void*>(&id), &pid, sizeof(id));
   return setThreadName(id, name);
 #endif
 }


### PR DESCRIPTION
GCC 8 introduces a new -Wclass-memaccess warning. The compiler
rightly complains about memcpy'ing a non-POD datatype even
though we know it's ok. Casting to void* before memcpy silences
the compiler.
#852 is the original report.