### PR TITLE
Enable _ENABLE_EXTENDED_ALIGNED_STORAGE to use  an extende alignment

### DIFF
--- a/CMake/FollyCompilerMSVC.cmake
+++ b/CMake/FollyCompilerMSVC.cmake
@@ -268,7 +268,7 @@ function(apply_folly_compile_options_to_target THETARGET)
       _CRT_NONSTDC_NO_WARNINGS # Don't deprecate posix names of functions.
       _CRT_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
       _SCL_SECURE_NO_WARNINGS # Don't deprecate the non _s versions of various standard library functions, because safety is for chumps.
-      
+      _ENABLE_EXTENDED_ALIGNED_STORAGE  #A type with an extended alignment in VS 15.8 or later
       _STL_EXTRA_DISABLED_WARNINGS=4774\ 4987
 
       $<$<BOOL:${MSVC_ENABLE_CPP_LATEST}>:_HAS_AUTO_PTR_ETC=1> # We're building in C++ 17 or greater mode, but certain dependencies (Boost) still have dependencies on unary_function and binary_function, so we have to make sure not to remove them.


### PR DESCRIPTION
Hello, there.

We built folly with upcoming Visual Studio 15.8, which failed with the following message:
error C2338: You've instantiated std::aligned_storage<Len, Align> with an extended alignment (in other words, Align > alignof(max_align_t)). Before VS 2017 15.8, the member type would non-conformingly have an alignment of only alignof(max_align_t). VS 2017 15.8 was fixed to handle this correctly, but the fix inherently changes layout and breaks binary compatibility (only for uses of aligned_storage with extended alignments). Please define either (1) _ENABLE_EXTENDED_ALIGNED_STORAGE to acknowledge that you understand this message and that you actually want a type with an extended alignment, or (2) _DISABLE_EXTENDED_ALIGNED_STORAGE to silence this message and get the old non-conformant behavior.

As you request for previous PR(https://github.com/facebook/folly/pull/879). Yo would prefer **option (2)** to use an extended alignment. I enable the option(_ENABLE_EXTENDED_ALIGNED_STORAGE) for you.

Please help merge this:)

Thanks,
Larry