### PR TITLE
Prevent bzlib.h from pulling in min and max macros

### DIFF
--- a/folly/compression/Compression.cpp
+++ b/folly/compression/Compression.cpp
@@ -44,6 +44,7 @@
 #endif
 
 #if FOLLY_HAVE_LIBBZ2
+#include <folly/portability/Windows.h>
 #include <bzlib.h>
 #endif
 


### PR DESCRIPTION
This fixes issue #882. Ping @terrelln.