### PR TITLE
Remove MSVC workaround in ApplyTupleTest

### DIFF
--- a/folly/functional/test/ApplyTupleTest.cpp
+++ b/folly/functional/test/ApplyTupleTest.cpp
@@ -23,10 +23,6 @@
 #include <array>
 #include <memory>
 
-// this placates visual studio stupidity - see
-// http://stackoverflow.com/questions/5503901
-namespace {}
-
 namespace {
 
 void func(int a, int b, double c) {


### PR DESCRIPTION
Problem:
- There was a bug in a much older version of MSVC relating to
  accessing functions in an anonymous namespace with the workaround
  being to have an extra anonymous namespace.

Solution:
- Remove the workaround as the MSVC versions that Folly now targets
  (MSVC 2015 and MSVC 2017) should not have this bug.