### PR TITLE
AtomicSharedPtr-detail.h does not work with libc++

### DIFF
--- a/CMake/FollyConfigChecks.cmake
+++ b/CMake/FollyConfigChecks.cmake
@@ -184,6 +184,15 @@ check_cxx_source_compiles("
   FOLLY_USE_LIBCPP
 )
 
+check_cxx_source_compiles("
+  #include <type_traits>
+  #if !__GLIBCXX__
+  #error No libstdc++
+  #endif
+  int main() { return 0; }"
+  FOLLY_USE_LIBSTDCPP
+)
+
 check_cxx_source_runs("
   #include <string.h>
   #include <errno.h>

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -372,6 +372,12 @@ constexpr auto kIsLibcpp = true;
 constexpr auto kIsLibcpp = false;
 #endif
 
+#if FOLLY_USE_LIBSTDCPP
+constexpr auto kIsLibstdcpp = true;
+#else
+constexpr auto kIsLibstdcpp = false;
+#endif
+
 #if _MSC_VER
 constexpr auto kMscVer = _MSC_VER;
 #else

--- a/folly/concurrency/test/AtomicSharedPtrPerformance.cpp
+++ b/folly/concurrency/test/AtomicSharedPtrPerformance.cpp
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// AtomicSharedPtr-detail.h only works with libstdc++, so skip these tests for
+// other vendors
+#ifdef FOLLY_USE_LIBSTDCPP
+
 #include <folly/concurrency/AtomicSharedPtr.h>
 
 #include <sys/time.h>
@@ -225,3 +230,11 @@ int main(int, char**) {
   runSuite<folly::atomic_shared_ptr<int>>();
   return 0;
 }
+
+#else // #ifdef FOLLY_USE_LIBSTDCPP
+
+int main(int, char**) {
+  return 1;
+}
+
+#endif // #ifdef FOLLY_USE_LIBSTDCPP

--- a/folly/concurrency/test/AtomicSharedPtrTest.cpp
+++ b/folly/concurrency/test/AtomicSharedPtrTest.cpp
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// AtomicSharedPtr-detail.h only works with libstdc++, so skip these tests for
+// other vendors
+#ifdef FOLLY_USE_LIBSTDCPP
+
 #include <atomic>
 #include <memory>
 #include <thread>
@@ -182,3 +187,4 @@ TEST(AtomicSharedPtr, DeterministicTest) {
     DSched::join(t);
   }
 }
+#endif // #ifdef FOLLY_USE_LIBSTDCPP

--- a/folly/concurrency/test/CoreCachedSharedPtrTest.cpp
+++ b/folly/concurrency/test/CoreCachedSharedPtrTest.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// AtomicSharedPtr-detail.h only works with libstdc++, so skip these tests for
+// other vendors
+#ifdef FOLLY_USE_LIBSTDCPP
+
 #include <memory>
 #include <thread>
 #include <vector>
@@ -199,3 +203,5 @@ int main(int argc, char** argv) {
 
   return ret;
 }
+
+#endif // #ifdef FOLLY_USE_LIBSTDCPP


### PR DESCRIPTION
Problem:
- There are several tests enabled which rely on using `shared_ptr_internals` found in `folly/concurrency/detail/AtomicSharedPtr-detail.h` and the implementation only works for libstdc++, not libc++.
- This results in a hard error when compiling with Clang with libc++.

Solution:
- Only run the tests when not using libc++ to prevent users from getting
  a hard error if they are using libc++.

Note:
- A longer-term solution would be to implement the similar `shared_ptr_internals` with the libc++ types.