### PR TITLE
Suppress class-memaccess warning with gcc 8.2

### DIFF
--- a/folly/container/detail/F14Policy.h
+++ b/folly/container/detail/F14Policy.h
@@ -1148,7 +1148,7 @@ class VectorContainerPolicy : public BasePolicy<
     complainUnlessNothrowMove<lift_unit_t<MappedTypeOrVoid>>();
 
     if (valueIsTriviallyCopyable()) {
-      std::memcpy(dst, src, n * sizeof(Value));
+      std::memcpy(static_cast<void *>(dst), src, n * sizeof(Value));
     } else {
       for (std::size_t i = 0; i < n; ++i, ++src, ++dst) {
         // TODO(T31574848): clean up assume-s used to optimize placement new


### PR DESCRIPTION
The following code won't compile with g++ 8.2 when `-Wall -Werror` is turned on (`-Werror=class-memaccess` implied):

    std::memcpy(dst, src, n * sizeof(Value))

where in `VectorContainerPolicy`'s case, `Value` is typically an `std::pair`, which  indeed has no trivial copy-assignment.