### PR TITLE
maxReadsPerEvent_ SHOULD BE initialized to 0

### DIFF
--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -343,7 +343,7 @@ void AsyncSocket::init() {
   eventFlags_ = EventHandler::NONE;
   fd_ = -1;
   sendTimeout_ = 0;
-  maxReadsPerEvent_ = 16;
+  maxReadsPerEvent_ = 0;
   connectCallback_ = nullptr;
   errMessageCallback_ = nullptr;
   readCallback_ = nullptr;


### PR DESCRIPTION
AsyncSocket.setMaxReadsPerEvent() says:
> The default is **unlimited**, but callers can use this method to limit the amount of data read from the socket per event loop iteration.