### PR TITLE
Remove multiple definitions about dynamic::TypeInfo

### DIFF
--- a/folly/dynamic.cpp
+++ b/folly/dynamic.cpp
@@ -26,22 +26,6 @@
 namespace folly {
 
 //////////////////////////////////////////////////////////////////////
-
-#define FOLLY_DYNAMIC_DEF_TYPEINFO(T)                 \
-  constexpr const char* dynamic::TypeInfo<T>::name;   \
-  constexpr dynamic::Type dynamic::TypeInfo<T>::type; \
-  //
-
-FOLLY_DYNAMIC_DEF_TYPEINFO(std::nullptr_t)
-FOLLY_DYNAMIC_DEF_TYPEINFO(bool)
-FOLLY_DYNAMIC_DEF_TYPEINFO(std::string)
-FOLLY_DYNAMIC_DEF_TYPEINFO(dynamic::Array)
-FOLLY_DYNAMIC_DEF_TYPEINFO(double)
-FOLLY_DYNAMIC_DEF_TYPEINFO(int64_t)
-FOLLY_DYNAMIC_DEF_TYPEINFO(dynamic::ObjectImpl)
-
-#undef FOLLY_DYNAMIC_DEF_TYPEINFO
-
 const char* dynamic::typeName() const {
   return typeName(type_);
 }


### PR DESCRIPTION
constexpr static memeber (ODR-used) is implicitly inline.  
Then it does not need to be redeclared in .cpp file.

And the redeclaration of constexpr static members is deprecated since C++17

## References
- [cppreference](https://en.cppreference.com/w/cpp/language/static)

> If a static data member is declared constexpr, it is implicitly inline and does not need to be redeclared at namespace scope. This redeclaration without an initializer (formerly required as shown above) is still permitted, but is deprecated. (since C++ 17)
