### PR TITLE
Fix LLVM 7 self-assignment warnings in test code

### DIFF
--- a/folly/experimental/test/StringKeyedTest.cpp
+++ b/folly/experimental/test/StringKeyedTest.cpp
@@ -144,7 +144,7 @@ TEST(StringKeyedUnorderedMapTest, sanity) {
 
   EXPECT_EQ(map.size(), 2);
 
-  map = map;
+  map = static_cast<decltype(map)&>(map); // suppress self-assign warning
 
   EXPECT_EQ(map.find("hello")->second, 1);
   EXPECT_EQ(map.find("lo")->second, 3);
@@ -227,7 +227,7 @@ TEST(StringKeyedSetTest, sanity) {
 
   EXPECT_EQ(set.size(), 2);
 
-  set = set;
+  set = static_cast<decltype(set)&>(set); // suppress self-assign warning
 
   EXPECT_NE(set.find(StringPiece("hello")), set.end());
   EXPECT_NE(set.find("lo"), set.end());
@@ -312,7 +312,7 @@ TEST(StringKeyedUnorderedSetTest, sanity) {
 
   EXPECT_EQ(set.size(), 2);
 
-  set = set;
+  set = static_cast<decltype(set)&>(set); // suppress self-assign warning
 
   EXPECT_NE(set.find("hello"), set.end());
   EXPECT_NE(set.find("lo"), set.end());
@@ -437,7 +437,7 @@ TEST(StringKeyedMapTest, sanity) {
 
   EXPECT_EQ(map.size(), 2);
 
-  map = map;
+  map = static_cast<decltype(map)&>(map); // suppress self-assign warning
 
   EXPECT_EQ(map.find("hello")->second, 1);
   EXPECT_EQ(map.find("lo")->second, 3);

--- a/folly/test/ExpectedTest.cpp
+++ b/folly/test/ExpectedTest.cpp
@@ -524,7 +524,7 @@ TEST(Expected, MakeOptional) {
 
 TEST(Expected, SelfAssignment) {
   Expected<std::string, E> a = "42";
-  a = a;
+  a = static_cast<decltype(a)&>(a); // suppress self-assign warning
   ASSERT_TRUE(a.hasValue() && a.value() == "42");
 
   Expected<std::string, E> b = "23333333";
@@ -646,7 +646,7 @@ struct NoSelfAssign {
 
 TEST(Expected, NoSelfAssign) {
   folly::Expected<NoSelfAssign, int> e{NoSelfAssign{}};
-  e = e; // @nolint
+  e = static_cast<decltype(e)&>(e); // @nolint suppress self-assign warning
   e = std::move(e); // @nolint
 }
 

--- a/folly/test/OptionalTest.cpp
+++ b/folly/test/OptionalTest.cpp
@@ -613,7 +613,7 @@ TEST(Optional, MakeOptional) {
 
 TEST(Optional, SelfAssignment) {
   Optional<int> a = 42;
-  a = a;
+  a = static_cast<decltype(a)&>(a); // suppress self-assign warning
   ASSERT_TRUE(a.hasValue() && a.value() == 42);
 
   Optional<int> b = 23333333;

--- a/folly/test/small_vector_test.cpp
+++ b/folly/test/small_vector_test.cpp
@@ -1111,7 +1111,7 @@ TEST(small_vector, SelfCopyAssignmentForVectorOfPair) {
   test.emplace_back(13, 2);
   EXPECT_EQ(test.size(), 1);
   EXPECT_EQ(test[0].first, 13);
-  test = test;
+  test = static_cast<decltype(test)&>(test); // suppress self-assign warning
   EXPECT_EQ(test.size(), 1);
   EXPECT_EQ(test[0].first, 13);
 }


### PR DESCRIPTION
Summary:
- LLVM 7 emits a warning about self-assignment.
- Silence the warning by using a static_cast. 