### PR TITLE
Simplify suppressing self-move warning

### DIFF
--- a/folly/test/ExpectedTest.cpp
+++ b/folly/test/ExpectedTest.cpp
@@ -517,24 +517,15 @@ TEST(Expected, MakeOptional) {
   EXPECT_EQ(**exIntPtr, 3);
 }
 
-#if __CLANG_PREREQ(3, 6)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wself-move"
-#endif
-
 TEST(Expected, SelfAssignment) {
   Expected<std::string, E> a = "42";
   a = static_cast<decltype(a)&>(a); // suppress self-assign warning
   ASSERT_TRUE(a.hasValue() && a.value() == "42");
 
   Expected<std::string, E> b = "23333333";
-  b = std::move(b);
+  b = static_cast<decltype(b)&&>(b); // suppress self-move warning
   ASSERT_TRUE(b.hasValue() && b.value() == "23333333");
 }
-
-#if __CLANG_PREREQ(3, 6)
-#pragma clang diagnostic pop
-#endif
 
 class ContainsExpected {
  public:
@@ -641,13 +632,12 @@ struct NoSelfAssign {
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wself-move"
 #endif
 
 TEST(Expected, NoSelfAssign) {
   folly::Expected<NoSelfAssign, int> e{NoSelfAssign{}};
   e = static_cast<decltype(e)&>(e); // suppress self-assign warning
-  e = std::move(e); // @nolint
+  e = static_cast<decltype(e)&&>(e); // @nolint suppress self-move warning
 }
 
 #ifdef __GNUC__

--- a/folly/test/OptionalTest.cpp
+++ b/folly/test/OptionalTest.cpp
@@ -606,24 +606,15 @@ TEST(Optional, MakeOptional) {
   EXPECT_EQ(**optIntPtr, 3);
 }
 
-#if __CLANG_PREREQ(3, 6)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wself-move"
-#endif
-
 TEST(Optional, SelfAssignment) {
   Optional<int> a = 42;
   a = static_cast<decltype(a)&>(a); // suppress self-assign warning
   ASSERT_TRUE(a.hasValue() && a.value() == 42);
 
   Optional<int> b = 23333333;
-  b = std::move(b);
+  b = static_cast<decltype(b)&&>(b); // suppress self-move warning
   ASSERT_TRUE(b.hasValue() && b.value() == 23333333);
 }
-
-#if __CLANG_PREREQ(3, 6)
-#pragma clang diagnostic pop
-#endif
 
 namespace {
 

--- a/folly/test/small_vector_test.cpp
+++ b/folly/test/small_vector_test.cpp
@@ -1101,7 +1101,7 @@ TEST(small_vector, SelfMoveAssignmentForVectorOfPair) {
   test.emplace_back(13, 2);
   EXPECT_EQ(test.size(), 1);
   EXPECT_EQ(test[0].first, 13);
-  test = static_cast<decltype(test)&&>(test); // trick clang -Wself-move
+  test = static_cast<decltype(test)&&>(test); // suppress self-move warning
   EXPECT_EQ(test.size(), 1);
   EXPECT_EQ(test[0].first, 13);
 }


### PR DESCRIPTION
- A couple of tests pragma push/pop to avoid `-Wself-move` warning in
  code that does a move-assignment with itself.
- Use `static_cast<T&&>` instead of `std::move` which will suppress
  the warning still without the need for pragma push/pop.