### PR TITLE
Detect `std::launder` in libc++ 6 (and Xcode 10)

### DIFF
--- a/folly/lang/Launder.h
+++ b/folly/lang/Launder.h
@@ -26,7 +26,8 @@
  *  * std::launder
  */
 
-#if __cpp_lib_launder >= 201606 || (_MSC_VER && _HAS_LAUNDER)
+#if __cpp_lib_launder >= 201606 || (_MSC_VER && _HAS_LAUNDER) || \
+    _LIBCPP_VERSION >= 6000
 
 namespace folly {
 


### PR DESCRIPTION
Fixes #947.

Summary:
>libc++ 6+ (and Xcode 10's libc++, which seems to be based on it) adds std::launder, but does not define the __cpp_lib_launder feature-test macro. As a result, folly's lang/Launder.h concludes std::launder is missing and defines its own implementation. Since std::launder does actually exist, ADL causes 'ambiguous call' errors whenever a standard library type like std::pair is laundered within the folly namespace. (This breaks compilation of folly's futures, for example, and I believe it will cause compilation issues anywhere else F14Map is used, since it launders std::pair in its F14Policy.)