### PR TITLE
Reduce size of underlying buffer of AtomicBitSet

### DIFF
--- a/folly/AtomicBitSet.h
+++ b/folly/AtomicBitSet.h
@@ -87,7 +87,7 @@ class AtomicBitSet : private boost::noncopyable {
    * Return the size of the underlying buffer in bytes.
    */
   constexpr size_t underlyingSize() const {
-    return kUnderlyingBufferSize * sizeof(BlockType);
+    return kUnderlyingBufferSize * sizeof(AtomicBlockType);
   }
 
   /**

--- a/folly/AtomicBitSet.h
+++ b/folly/AtomicBitSet.h
@@ -84,6 +84,13 @@ class AtomicBitSet : private boost::noncopyable {
   bool operator[](size_t idx) const;
 
   /**
+   * Return the size of the underlying buffer in bytes.
+   */
+  constexpr size_t underlyingSize() const {
+    return kUnderlyingBufferSize * sizeof(BlockType);
+  }
+
+  /**
    * Return the size of the bitset.
    */
   constexpr size_t size() const {
@@ -116,7 +123,10 @@ class AtomicBitSet : private boost::noncopyable {
   // avoid casts
   static constexpr BlockType kOne = 1;
 
-  std::array<AtomicBlockType, N> data_;
+  static constexpr size_t kUnderlyingBufferSize =
+    N / kBitsPerBlock + (N % kBitsPerBlock ? 1 : 0);
+
+  std::array<AtomicBlockType, kUnderlyingBufferSize> data_;
 };
 
 // value-initialize to zero
@@ -125,14 +135,14 @@ inline AtomicBitSet<N>::AtomicBitSet() : data_() {}
 
 template <size_t N>
 inline bool AtomicBitSet<N>::set(size_t idx, std::memory_order order) {
-  assert(idx < N * kBitsPerBlock);
+  assert(idx < N);
   BlockType mask = kOne << bitOffset(idx);
   return data_[blockIndex(idx)].fetch_or(mask, order) & mask;
 }
 
 template <size_t N>
 inline bool AtomicBitSet<N>::reset(size_t idx, std::memory_order order) {
-  assert(idx < N * kBitsPerBlock);
+  assert(idx < N);
   BlockType mask = kOne << bitOffset(idx);
   return data_[blockIndex(idx)].fetch_and(~mask, order) & mask;
 }
@@ -145,7 +155,7 @@ AtomicBitSet<N>::set(size_t idx, bool value, std::memory_order order) {
 
 template <size_t N>
 inline bool AtomicBitSet<N>::test(size_t idx, std::memory_order order) const {
-  assert(idx < N * kBitsPerBlock);
+  assert(idx < N);
   BlockType mask = kOne << bitOffset(idx);
   return data_[blockIndex(idx)].load(order) & mask;
 }

--- a/folly/test/AtomicBitSetTest.cpp
+++ b/folly/test/AtomicBitSetTest.cpp
@@ -54,6 +54,15 @@ TEST(AtomicBitSet, Simple) {
   }
 }
 
+TEST(AtomicBitSet, Size) {
+    constexpr size_t kSize = 1024;
+    AtomicBitSet<kSize - 1> bs1;
+    AtomicBitSet<kSize> bs2;
+
+    EXPECT_EQ(bs1.size() + 1, bs2.size());
+    EXPECT_EQ(bs1.underlyingSize(), bs2.underlyingSize());
+}
+
 } // namespace test
 } // namespace folly
 


### PR DESCRIPTION
Reduce size of the underlying buffer used by AtomicBitSet. For a bitset of 65536 bits the size of the buffer will be reduced from 512KB to 8KB which is good for the systems with a small stack