### PR TITLE
Fix posix_memalign symbol not found with Android API 16

### DIFF
--- a/folly/Memory.h
+++ b/folly/Memory.h
@@ -39,7 +39,7 @@
 namespace folly {
 
 #if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || \
-    (defined(__ANDROID__) && (__ANDROID_API__ > 15)) ||   \
+    (defined(__ANDROID__) && (__ANDROID_API__ > 16)) ||   \
     (defined(__APPLE__) &&                                \
      (__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_6 ||    \
       __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_3_0))


### PR DESCRIPTION

  According to this https://github.com/android-ndk/ndk/issues/647,
  posix_memalign may not exist on Android API 16.
  From Android NDK r17c, the API exists for Android API 17+.
```
    #if __ANDROID_API__ >= 17
    int posix_memalign(void** __memptr, size_t __alignment, size_t __size) __INTRODUCED_IN(17);
    #endif /* __ANDROID_API__ >= 17 */
```
  Change the code to use posix_memalign only after Android API 17+.
  This would also fix issue for OSS React Native to pack latest folly and building with clang.
  See: https://github.com/facebook/react-native/issues/20302 and https://github.com/facebook/react-native/issues/20342