### PR TITLE
CMake: Use correct variable name for 'GFlags_FOUND'

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -23,7 +23,7 @@ list(APPEND FOLLY_INCLUDE_DIRECTORIES ${DOUBLE_CONVERSION_INCLUDE_DIR})
 
 set(FOLLY_HAVE_LIBGFLAGS OFF)
 find_package(GFlags CONFIG QUIET)
-if (gflags_FOUND)
+if (GFlags_FOUND)
   message(STATUS "Found gflags from package config")
   set(FOLLY_HAVE_LIBGFLAGS ON)
   if (TARGET gflags-shared)


### PR DESCRIPTION
When using `find_package(GFlags)` in CONFIG mode, it results in a variable named 'GFlags_FOUND' (note the case) being set if the package is found - see https://cmake.org/cmake/help/latest/command/find_package.html.

However, folly-deps.cmake is incorrectly using the variable 'gflags_FOUND' (lowercase). As a result CONFIG mode always fails.

Fix by using the correct variable name.