### PR TITLE
Fix ASan build when folly is embedded as a submodule

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -189,7 +189,7 @@ if (FOLLY_ASAN_ENABLED)
     # sanitizer, but even so, gcc fails to compile them for some reason when
     # sanitization is enabled on the compile line.
     set_source_files_properties(
-      "${CMAKE_SOURCE_DIR}/folly/detail/Sse.cpp"
+      "${PROJECT_SOURCE_DIR}/folly/detail/Sse.cpp"
       PROPERTIES COMPILE_FLAGS -fno-sanitize=address,undefined
     )
   elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES Clang)


### PR DESCRIPTION
When folly is used as a submodule, CMAKE_SOURCE_DIR
will point to the top-level repository, resulting
in set_source_files_properties not taking effect
when compiling with ASan.

Replacing CMAKE_SOURCE_DIR with PROJECT_SOURCE_DIR points
cmake to the intended file.