### PR TITLE
Correct Ubuntu build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,21 @@ sudo apt-get install \
 
 In the folly directory, run:
 ```
-  mkdir _build && cd _build
+  mkdir _build
   cmake ..
   make -j $(nproc)
   make install
 ```
+
+If you receive an error like:
+
+> CMake Error at cmake_install.cmake:41 (file):
+> file INSTALL cannot copy file
+> "/home/[yourname]/[folly-version]/folly/libfolly.a" to
+> "/usr/local/lib/libfolly.a".
+
+then you [need to use `sudo make install`](https://askubuntu.com/a/954877)
+as the last step instead of just `make install`.
 
 #### OS X (Homebrew)
 

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ sudo apt-get install \
     libdwarf-dev
 ```
 
-In the folly directory, run:
+In the folly directory (e.g. the checkout root or the archive unpack root), run:
 ```
-  mkdir _build
+  mkdir _build && cd _build
   cmake ..
   make -j $(nproc)
   make install # with either sudo or DESTDIR as necessary

--- a/README.md
+++ b/README.md
@@ -144,18 +144,8 @@ In the folly directory, run:
   mkdir _build
   cmake ..
   make -j $(nproc)
-  make install
+  make install # with either sudo or DESTDIR as necessary
 ```
-
-If you receive an error like:
-
-> CMake Error at cmake_install.cmake:41 (file):
-> file INSTALL cannot copy file
-> "/home/[yourname]/[folly-version]/folly/libfolly.a" to
-> "/usr/local/lib/libfolly.a".
-
-then you [need to use `sudo make install`](https://askubuntu.com/a/954877)
-as the last step instead of just `make install`.
 
 #### OS X (Homebrew)
 


### PR DESCRIPTION
Associated issue: #847 

The `cmake` and `make` commands given in the [last section](https://github.com/facebook/folly#ubuntu-1604-lts) of the Ubuntu build instructions all need to be run from inside the `folly` folder rather than the `_build` folder, as indicated by @Orvid in #847. Also, the final step (`make install`) may need to be `sudo make install` to allow access to the `/usr` folder.