### PR TITLE
Use _t variants of type traits

### DIFF
--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -1216,8 +1216,8 @@ typename std::enable_if<
     Expected<Tgt, ConversionCode>>::type
 convertTo(const Src& value) noexcept {
   if /* constexpr */ (
-      folly::_t<std::make_unsigned<Tgt>>(std::numeric_limits<Tgt>::max()) <
-      folly::_t<std::make_unsigned<Src>>(std::numeric_limits<Src>::max())) {
+      std::make_unsigned_t<Tgt>(std::numeric_limits<Tgt>::max()) <
+      std::make_unsigned_t<Src>(std::numeric_limits<Src>::max())) {
     if (greater_than<Tgt, std::numeric_limits<Tgt>::max()>(value)) {
       return makeUnexpected(ConversionCode::ARITH_POSITIVE_OVERFLOW);
     }

--- a/folly/ExceptionWrapper-inl.h
+++ b/folly/ExceptionWrapper-inl.h
@@ -343,7 +343,7 @@ inline exception_wrapper::exception_wrapper(
 namespace exception_wrapper_detail {
 template <class Ex>
 Ex&& dont_slice(Ex&& ex) {
-  assert(typeid(ex) == typeid(_t<std::decay<Ex>>) ||
+  assert(typeid(ex) == typeid(std::decay_t<Ex>) ||
        !"Dynamic and static exception types don't match. Exception would "
         "be sliced when storing in exception_wrapper.");
   return std::forward<Ex>(ex);
@@ -479,12 +479,12 @@ template <class Ex>
 
 template <class CatchFn, bool IsConst>
 struct exception_wrapper::ExceptionTypeOf {
-  using type = arg_type<_t<std::decay<CatchFn>>>;
+  using type = arg_type<std::decay_t<CatchFn>>;
   static_assert(
       std::is_reference<type>::value,
       "Always catch exceptions by reference.");
   static_assert(
-      !IsConst || std::is_const<_t<std::remove_reference<type>>>::value,
+      !IsConst || std::is_const<std::remove_reference_t<type>>::value,
       "handle() or with_exception() called on a const exception_wrapper "
       "and asked to catch a non-const exception. Handler will never fire. "
       "Catch exception by const reference to fix this.");
@@ -550,7 +550,7 @@ struct exception_wrapper::HandleStdExceptReduce {
     return
         [th = std::forward<ThrowFn>(th), &ca](auto&& continuation) -> StdEx* {
           if (auto e = const_cast<StdEx*>(th(continuation))) {
-            if (auto e2 = dynamic_cast<_t<std::add_pointer<Ex>>>(e)) {
+            if (auto e2 = dynamic_cast<std::add_pointer_t<Ex>>(e)) {
               ca(*e2);
             } else {
               return e;

--- a/folly/ExceptionWrapper.h
+++ b/folly/ExceptionWrapper.h
@@ -62,7 +62,7 @@ template <template <class> class T, class... As>
 using AllOf = StrictConjunction<T<As>...>;
 
 template <bool If, class T>
-using AddConstIf = _t<std::conditional<If, const T, T>>;
+using AddConstIf = std::conditional_t<If, const T, T>;
 
 template <class Fn, class A>
 FOLLY_ALWAYS_INLINE FOLLY_ATTR_VISIBILITY_HIDDEN auto fold(Fn&&, A&& a) {
@@ -206,12 +206,12 @@ class exception_wrapper final {
   static VTable const uninit_;
 
   template <class Ex>
-  using IsStdException = std::is_base_of<std::exception, _t<std::decay<Ex>>>;
+  using IsStdException = std::is_base_of<std::exception, std::decay_t<Ex>>;
   template <bool B, class T>
   using AddConstIf = exception_wrapper_detail::AddConstIf<B, T>;
   template <class CatchFn>
   using IsCatchAll =
-      std::is_same<arg_type<_t<std::decay<CatchFn>>>, AnyException>;
+      std::is_same<arg_type<std::decay_t<CatchFn>>, AnyException>;
 
   struct Unknown {};
 
@@ -221,7 +221,7 @@ class exception_wrapper final {
   // and runtime_error can be safely stored internally.
   struct Buffer {
     using Storage =
-        _t<std::aligned_storage<2 * sizeof(void*), alignof(std::exception)>>;
+        std::aligned_storage_t<2 * sizeof(void*), alignof(std::exception)>;
     Storage buff_;
 
     Buffer() : buff_{} {}
@@ -239,16 +239,16 @@ class exception_wrapper final {
   struct OnHeapTag {};
 
   template <class T>
-  using PlacementOf = _t<std::conditional<
+  using PlacementOf = std::conditional_t<
       !IsStdException<T>::value,
       ThrownTag,
-      _t<std::conditional<
+      std::conditional_t<
           sizeof(T) <= sizeof(Buffer::Storage) &&
               alignof(T) <= alignof(Buffer::Storage) &&
               noexcept(T(std::declval<T&&>())) &&
               noexcept(T(std::declval<T const&>())),
           InSituTag,
-          OnHeapTag>>>>;
+          OnHeapTag>>;
 
   static std::exception const* as_exception_or_null_(std::exception const& ex);
   static std::exception const* as_exception_or_null_(AnyException);
@@ -429,7 +429,7 @@ class exception_wrapper final {
   //!     converted to an `exception_wrapper`.
   template <
       class Ex,
-      class Ex_ = _t<std::decay<Ex>>,
+      class Ex_ = std::decay_t<Ex>,
       FOLLY_REQUIRES(
           Conjunction<IsStdException<Ex_>, IsRegularExceptionType<Ex_>>::value)>
   /* implicit */ exception_wrapper(Ex&& ex);
@@ -443,7 +443,7 @@ class exception_wrapper final {
   //!     `folly::in_place` as the first parameter.
   template <
       class Ex,
-      class Ex_ = _t<std::decay<Ex>>,
+      class Ex_ = std::decay_t<Ex>,
       FOLLY_REQUIRES(IsRegularExceptionType<Ex_>::value)>
   exception_wrapper(in_place_t, Ex&& ex);
 

--- a/folly/Function.h
+++ b/folly/Function.h
@@ -353,7 +353,7 @@ struct FunctionTraits<ReturnType(Args...)> {
 
   template <typename F>
   using ResultOf =
-      SafeResultOf<CallableResult<_t<std::decay<F>>&, Args...>, ReturnType>;
+      SafeResultOf<CallableResult<std::decay_t<F>&, Args...>, ReturnType>;
 
   template <typename Fun>
   static ReturnType callSmall(Data& p, Args&&... args) {
@@ -390,7 +390,7 @@ struct FunctionTraits<ReturnType(Args...) const> {
 
   template <typename F>
   using ResultOf = SafeResultOf<
-      CallableResult<const _t<std::decay<F>>&, Args...>,
+      CallableResult<const std::decay_t<F>&, Args...>,
       ReturnType>;
 
   template <typename Fun>
@@ -429,7 +429,7 @@ struct FunctionTraits<ReturnType(Args...) noexcept> {
 
   template <typename F>
   using ResultOf =
-      SafeResultOf<CallableResult<_t<std::decay<F>>&, Args...>, ReturnType>;
+      SafeResultOf<CallableResult<std::decay_t<F>&, Args...>, ReturnType>;
 
   template <typename Fun>
   static ReturnType callSmall(Data& p, Args&&... args) noexcept {
@@ -466,7 +466,7 @@ struct FunctionTraits<ReturnType(Args...) const noexcept> {
 
   template <typename F>
   using ResultOf = SafeResultOf<
-      CallableResult<const _t<std::decay<F>>&, Args...>,
+      CallableResult<const std::decay_t<F>&, Args...>,
       ReturnType>;
 
   template <typename Fun>
@@ -920,7 +920,7 @@ class FunctionRef<ReturnType(Args...)> final {
 
   template <typename Fun>
   static ReturnType call(void* object, Args&&... args) {
-    using Pointer = _t<std::add_pointer<Fun>>;
+    using Pointer = std::add_pointer_t<Fun>;
     return static_cast<ReturnType>(invoke(
         static_cast<Fun&&>(*static_cast<Pointer>(object)),
         static_cast<Args&&>(args)...));
@@ -951,7 +951,7 @@ class FunctionRef<ReturnType(Args...)> final {
       typename Fun,
       typename std::enable_if<
           Conjunction<
-              Negation<std::is_same<FunctionRef, _t<std::decay<Fun>>>>,
+              Negation<std::is_same<FunctionRef, std::decay_t<Fun>>>,
               is_invocable_r<ReturnType, Fun&&, Args&&...>>::value,
           int>::type = 0>
   constexpr /* implicit */ FunctionRef(Fun&& fun) noexcept

--- a/folly/Optional.h
+++ b/folly/Optional.h
@@ -355,7 +355,7 @@ class Optional {
 
  private:
   template <class T>
-  friend constexpr Optional<_t<std::decay<T>>> make_optional(T&&);
+  friend constexpr Optional<std::decay_t<T>> make_optional(T&&);
   template <class T, class... Args>
   friend constexpr Optional<T> make_optional(Args&&... args);
   template <class T, class U, class... As>
@@ -456,9 +456,9 @@ void swap(Optional<T>& a, Optional<T>& b) noexcept(noexcept(a.swap(b))) {
 }
 
 template <class T>
-constexpr Optional<_t<std::decay<T>>> make_optional(T&& v) {
+constexpr Optional<std::decay_t<T>> make_optional(T&& v) {
   using PrivateConstructor =
-      typename folly::Optional<_t<std::decay<T>>>::PrivateConstructor;
+      typename folly::Optional<std::decay_t<T>>::PrivateConstructor;
   return {PrivateConstructor{}, std::forward<T>(v)};
 }
 

--- a/folly/Poly-inl.h
+++ b/folly/Poly-inl.h
@@ -52,7 +52,7 @@ inline PolyVal<I>::PolyVal(T&& t) {
       "This Poly<> requires copyability, and the source object is not "
       "copyable");
   // The static and dynamic types should match; otherwise, this will slice.
-  assert(typeid(t) == typeid(_t<std::decay<T>>) ||
+  assert(typeid(t) == typeid(std::decay_t<T>) ||
        !"Dynamic and static exception types don't match. Object would "
         "be sliced when storing in Poly.");
   if (inSitu<U>()) {

--- a/folly/Range.h
+++ b/folly/Range.h
@@ -1265,7 +1265,7 @@ struct ComparableAsStringPiece {
  * operator== through conversion for Range<const char*>
  */
 template <class T, class U>
-_t<std::enable_if<detail::ComparableAsStringPiece<T, U>::value, bool>>
+std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool>
 operator==(const T& lhs, const U& rhs) {
   return StringPiece(lhs) == StringPiece(rhs);
 }
@@ -1274,7 +1274,7 @@ operator==(const T& lhs, const U& rhs) {
  * operator!= through conversion for Range<const char*>
  */
 template <class T, class U>
-_t<std::enable_if<detail::ComparableAsStringPiece<T, U>::value, bool>>
+std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool>
 operator!=(const T& lhs, const U& rhs) {
   return StringPiece(lhs) != StringPiece(rhs);
 }
@@ -1283,7 +1283,7 @@ operator!=(const T& lhs, const U& rhs) {
  * operator< through conversion for Range<const char*>
  */
 template <class T, class U>
-_t<std::enable_if<detail::ComparableAsStringPiece<T, U>::value, bool>>
+std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool>
 operator<(const T& lhs, const U& rhs) {
   return StringPiece(lhs) < StringPiece(rhs);
 }
@@ -1292,7 +1292,7 @@ operator<(const T& lhs, const U& rhs) {
  * operator> through conversion for Range<const char*>
  */
 template <class T, class U>
-_t<std::enable_if<detail::ComparableAsStringPiece<T, U>::value, bool>>
+std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool>
 operator>(const T& lhs, const U& rhs) {
   return StringPiece(lhs) > StringPiece(rhs);
 }
@@ -1301,7 +1301,7 @@ operator>(const T& lhs, const U& rhs) {
  * operator< through conversion for Range<const char*>
  */
 template <class T, class U>
-_t<std::enable_if<detail::ComparableAsStringPiece<T, U>::value, bool>>
+std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool>
 operator<=(const T& lhs, const U& rhs) {
   return StringPiece(lhs) <= StringPiece(rhs);
 }
@@ -1310,7 +1310,7 @@ operator<=(const T& lhs, const U& rhs) {
  * operator> through conversion for Range<const char*>
  */
 template <class T, class U>
-_t<std::enable_if<detail::ComparableAsStringPiece<T, U>::value, bool>>
+std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool>
 operator>=(const T& lhs, const U& rhs) {
   return StringPiece(lhs) >= StringPiece(rhs);
 }

--- a/folly/SingletonThreadLocal.h
+++ b/folly/SingletonThreadLocal.h
@@ -93,10 +93,10 @@ template <
     typename T,
     typename Tag = detail::DefaultTag,
     typename Make = detail::DefaultMake<T>,
-    typename TLTag = _t<std::conditional<
+    typename TLTag = std::conditional_t<
         std::is_same<Tag, detail::DefaultTag>::value,
         void,
-        Tag>>>
+        Tag>>
 class SingletonThreadLocal : private detail::SingletonThreadLocalBase {
  private:
   struct Unique final : UniqueBase {

--- a/folly/experimental/flat_combining/FlatCombining.h
+++ b/folly/experimental/flat_combining/FlatCombining.h
@@ -201,7 +201,7 @@ class FlatCombining {
       static_assert(
           std::is_nothrow_constructible<
               folly::Function<void()>,
-              _t<std::decay<Func>>>::value,
+              std::decay_t<Func>>::value,
           "Try using a smaller function object that can fit in folly::Function "
           "without allocation, or use the custom interface of requestFC() to "
           "manage the requested function's arguments and results explicitly "

--- a/folly/futures/Future-inl.h
+++ b/folly/futures/Future-inl.h
@@ -59,7 +59,7 @@ namespace detail {
 //  may be fulfilled. Assumes the stored functor to be noexcept-destructible.
 template <typename T, typename F>
 class CoreCallbackState {
-  using DF = _t<std::decay<F>>;
+  using DF = std::decay_t<F>;
 
  public:
   CoreCallbackState(Promise<T>&& promise, F&& func) noexcept(

--- a/folly/lang/PropagateConst.h
+++ b/folly/lang/PropagateConst.h
@@ -44,7 +44,7 @@ struct is_propagate_const : std::false_type {};
 template <typename Pointer>
 struct is_propagate_const<propagate_const<Pointer>> : std::true_type {};
 template <typename T>
-using is_decay_propagate_const = is_propagate_const<_t<std::decay<T>>>;
+using is_decay_propagate_const = is_propagate_const<std::decay_t<T>>;
 
 namespace propagate_const_adl {
 using std::swap;
@@ -61,7 +61,7 @@ template <typename Pointer>
 class propagate_const {
  public:
   using element_type =
-      _t<std::remove_reference<decltype(*std::declval<Pointer&>())>>;
+      std::remove_reference_t<decltype(*std::declval<Pointer&>())>;
 
   constexpr propagate_const() = default;
   FOLLY_CPP14_CONSTEXPR propagate_const(propagate_const&&) = default;
@@ -110,8 +110,8 @@ class propagate_const {
 
   template <
       typename OtherPointer,
-      typename = _t<
-          std::enable_if<std::is_convertible<OtherPointer&&, Pointer>::value>>>
+      typename =
+          std::enable_if_t<std::is_convertible<OtherPointer&&, Pointer>::value>>
   FOLLY_CPP14_CONSTEXPR propagate_const& operator=(
       propagate_const<OtherPointer>&& other) {
     pointer_ = static_cast<OtherPointer&&>(other.pointer_);

--- a/folly/lang/test/PropagateConstTest.cpp
+++ b/folly/lang/test/PropagateConstTest.cpp
@@ -31,7 +31,7 @@ template class folly::propagate_const<std::shared_ptr<int>>;
 
 template <typename T>
 static bool is_const(T&&) {
-  return std::is_const<_t<std::remove_reference<T>>>::value;
+  return std::is_const<std::remove_reference_t<T>>::value;
 }
 
 template <typename T>

--- a/folly/stats/Histogram.h
+++ b/folly/stats/Histogram.h
@@ -473,8 +473,8 @@ class Histogram {
 
  private:
   template <typename S, typename = std::enable_if_t<std::is_integral<S>::value>>
-  static constexpr _t<std::make_unsigned<S>> to_unsigned(S s) {
-    return static_cast<_t<std::make_unsigned<S>>>(s);
+  static constexpr std::make_unsigned_t<S> to_unsigned(S s) {
+    return static_cast<std::make_unsigned_t<S>>(s);
   }
   template <
       typename S,

--- a/folly/test/RangeTest.cpp
+++ b/folly/test/RangeTest.cpp
@@ -1107,7 +1107,7 @@ void testRangeFunc(C&& x, size_t n) {
   const auto& cx = x;
   // type, conversion checks
   using R1Iter =
-      _t<std::conditional<_t<std::is_reference<C>>::value, int*, int const*>>;
+      std::conditional_t<_t<std::is_reference<C>>::value, int*, int const*>;
   Range<R1Iter> r1 = range(std::forward<C>(x));
   Range<const int*> r2 = range(std::forward<C>(x));
   Range<const int*> r3 = range(cx);


### PR DESCRIPTION
Summary:
- Instead of wrapping a type trait with `_t` use the standard library's
  `_t` type trait variant. This is safe since Folly requires C++14,
  whereas previously the use of `_t` was supported prior to C++14.