### PR TITLE
Remove workaround for lack of std::atomic_init

### DIFF
--- a/folly/synchronization/Tearable.h
+++ b/folly/synchronization/Tearable.h
@@ -53,7 +53,13 @@ class Tearable {
       is_trivially_copyable<T>::value,
       "Tearable types must be trivially copyable.");
 
-  Tearable() = default;
+  Tearable() noexcept
+  {
+      for (std::size_t i = 0; i < kNumDataWords; ++i)
+      {
+          std::atomic_init(&data_[i], RawWord{});
+      }
+  }
 
   Tearable(const T& val) : Tearable() {
     store(val);
@@ -87,15 +93,10 @@ class Tearable {
     // trailing data word in write(), for instance).
     unsigned char data alignas(void*)[sizeof(void*)];
   };
-  // Because std::atomic_init is declared but undefined in libstdc++-v4.9.2:
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=64658.
-  struct AtomicWord : std::atomic<RawWord> {
-    AtomicWord() noexcept : std::atomic<RawWord>{RawWord{}} {}
-  };
   const static std::size_t kNumDataWords =
       (sizeof(T) + sizeof(RawWord) - 1) / sizeof(RawWord);
 
-  AtomicWord data_[kNumDataWords];
+  std::atomic<RawWord> data_[kNumDataWords];
 };
 
 } // namespace folly


### PR DESCRIPTION
Summary:
- Since GCC 5 and later has `std::atomic_init`, remove the workaround
  present in `Tearable.h` to default initialize atomic variables.
- Default initialization of atomics do not work as you would expect. See
  http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0883r0.pdf
  for the explanation why.
- To get around the default initialization issue, we just call
  `std::atomic_init` for each element in the array of atomics.