### PR TITLE
Update README to reflect min supported GCC version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Folly is published on Github at https://github.com/facebook/folly
 
 #### Dependencies
 
-folly requires gcc 4.9+ and a version of boost compiled with C++14 support.
+folly requires gcc 5.1+ and a version of boost compiled with C++14 support.
 
 googletest is required to build and run folly's tests.  You can download
 it from https://github.com/google/googletest/archive/release-1.8.0.tar.gz


### PR DESCRIPTION
Summary:
- Folly no longer guarantees support for GCC 4.9.
- It is only tested with GCC 5.1 or later, so update the `README` to
  reflect that.