### PR TITLE
Reserve the vector to save reallocation cost.

### DIFF
--- a/folly/concurrency/test/ConcurrentHashMapTest.cpp
+++ b/folly/concurrency/test/ConcurrentHashMapTest.cpp
@@ -342,6 +342,7 @@ TEST(ConcurrentHashMap, UpdateStressTest) {
   }
   std::vector<std::thread> threads;
   unsigned int num_threads = 32;
+  threads.reserve(num_threads);
   for (uint32_t t = 0; t < num_threads; t++) {
     threads.push_back(lib::thread([&, t]() {
       int offset = (iters * t / num_threads);
@@ -394,6 +395,7 @@ TEST(ConcurrentHashMap, EraseStressTest) {
   }
   std::vector<std::thread> threads;
   unsigned int num_threads = 32;
+  threads.reserve(num_threads);
   for (uint32_t t = 0; t < num_threads; t++) {
     threads.push_back(lib::thread([&, t]() {
       int offset = (iters * t / num_threads);


### PR DESCRIPTION
Even though this is a test, we are still reallocating a vector (resizing until re-sized/reallocated to 32), which in theory calls for allocation 5 times. But we can save this by just reserving the vector pre-hand (we know the size).