### PR TITLE
Remove disabling -Warray-bounds for GCC in FBString.h

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -78,10 +78,6 @@
 FOLLY_PUSH_WARNING
 // Ignore shadowing warnings within this file, so includers can use -Wshadow.
 FOLLY_GNU_DISABLE_WARNING("-Wshadow")
-// GCC 4.9 has a false positive in setSmallSize (probably
-// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59124), disable
-// compile-time array bound checking.
-FOLLY_GNU_DISABLE_WARNING("-Warray-bounds")
 
 // FBString cannot use throw when replacing std::string, though it may still
 // use folly::throw_exception


### PR DESCRIPTION
Summary:
- Existing code disables `-Warray-bounds` warning for GCC due to a bug in
  GCC 4.9.
- As seen in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59124, the bug
  has been resolved for GCC 5.1.
- Since the bug has been resolved, we no longer need to disable the
  warning.

@yfeldblum I suspect that we have to hold off on this PR until the internal use cases relying on GCC 4.9 upgrade, but I figured it is better to have some of these cleanup opportunities ready for when the time arises.