### PR TITLE
Use <random> instead of boost/random

### DIFF
--- a/folly/io/test/IOBufTest.cpp
+++ b/folly/io/test/IOBufTest.cpp
@@ -18,8 +18,7 @@
 #include <folly/io/TypedIOBuf.h>
 
 #include <cstddef>
-
-#include <boost/random.hpp>
+#include <random>
 
 #include <folly/Range.h>
 #include <folly/memory/Malloc.h>
@@ -305,18 +304,18 @@ TEST(IOBuf, CreateCombined) {
   testSwap(false);
 }
 
-void fillBuf(uint8_t* buf, uint32_t length, boost::mt19937& gen) {
+void fillBuf(uint8_t* buf, uint32_t length, std::mt19937& gen) {
   for (uint32_t n = 0; n < length; ++n) {
     buf[n] = static_cast<uint8_t>(gen() & 0xff);
   }
 }
 
-void fillBuf(IOBuf* buf, boost::mt19937& gen) {
+void fillBuf(IOBuf* buf, std::mt19937& gen) {
   buf->unshare();
   fillBuf(buf->writableData(), buf->length(), gen);
 }
 
-void checkBuf(const uint8_t* buf, uint32_t length, boost::mt19937& gen) {
+void checkBuf(const uint8_t* buf, uint32_t length, std::mt19937& gen) {
   // Rather than using EXPECT_EQ() to check each character,
   // count the number of differences and the first character that differs.
   // This way on error we'll report just that information, rather than tons of
@@ -347,15 +346,15 @@ void checkBuf(const uint8_t* buf, uint32_t length, boost::mt19937& gen) {
   }
 }
 
-void checkBuf(IOBuf* buf, boost::mt19937& gen) {
+void checkBuf(IOBuf* buf, std::mt19937& gen) {
   checkBuf(buf->data(), buf->length(), gen);
 }
 
-void checkBuf(ByteRange buf, boost::mt19937& gen) {
+void checkBuf(ByteRange buf, std::mt19937& gen) {
   checkBuf(buf.data(), buf.size(), gen);
 }
 
-void checkChain(IOBuf* buf, boost::mt19937& gen) {
+void checkChain(IOBuf* buf, std::mt19937& gen) {
   IOBuf* current = buf;
   do {
     checkBuf(current->data(), current->length(), gen);
@@ -365,7 +364,7 @@ void checkChain(IOBuf* buf, boost::mt19937& gen) {
 
 TEST(IOBuf, Chaining) {
   uint32_t fillSeed = 0x12345678;
-  boost::mt19937 gen(fillSeed);
+  std::mt19937 gen(fillSeed);
 
   // An IOBuf with external storage
   uint32_t headroom = 123;
@@ -654,7 +653,7 @@ void testFreeFn(void* buffer, void* ptr) {
 
 TEST(IOBuf, Reserve) {
   uint32_t fillSeed = 0x23456789;
-  boost::mt19937 gen(fillSeed);
+  std::mt19937 gen(fillSeed);
 
   // Reserve does nothing if empty and doesn't have to grow the buffer
   {
@@ -996,7 +995,7 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST(IOBuf, getIov) {
   uint32_t fillSeed = 0xdeadbeef;
-  boost::mt19937 gen(fillSeed);
+  std::mt19937 gen(fillSeed);
 
   size_t len = 4096;
   size_t count = 32;
@@ -1514,7 +1513,7 @@ TEST(IOBuf, CloneCoalescedChain) {
   auto b = IOBuf::createChain(1000, 100);
   b->advance(10);
   const uint32_t fillSeed = 0x12345678;
-  boost::mt19937 gen(fillSeed);
+  std::mt19937 gen(fillSeed);
   {
     auto c = b.get();
     std::size_t length = c->tailroom();
@@ -1540,7 +1539,7 @@ TEST(IOBuf, CloneCoalescedSingle) {
   b->advance(10);
   b->append(900);
   const uint32_t fillSeed = 0x12345678;
-  boost::mt19937 gen(fillSeed);
+  std::mt19937 gen(fillSeed);
   fillBuf(b.get(), gen);
 
   auto c = b->cloneCoalesced();

--- a/folly/test/FBStringBenchmark.cpp
+++ b/folly/test/FBStringBenchmark.cpp
@@ -22,9 +22,8 @@
 #include <cstdlib>
 #include <fstream>
 #include <list>
+#include <random>
 #include <sstream>
-
-#include <boost/random.hpp>
 
 #include <folly/Benchmark.h>
 #include <folly/Random.h>
@@ -35,12 +34,12 @@ using namespace std;
 using namespace folly;
 
 static const int seed = folly::randomNumberSeed();
-typedef boost::mt19937 RandomT;
+using RandomT = std::mt19937;
 static RandomT rng(seed);
 
 template <class Integral1, class Integral2>
 Integral2 random(Integral1 low, Integral2 up) {
-  boost::uniform_int<> range(low, up);
+  std::uniform_int_distribution<> range(low, up);
   return range(rng);
 }
 

--- a/folly/test/FBStringTest.cpp
+++ b/folly/test/FBStringTest.cpp
@@ -23,10 +23,10 @@
 #include <cstdlib>
 #include <iomanip>
 #include <list>
+#include <random>
 #include <sstream>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/random.hpp>
 
 #include <folly/Conv.h>
 #include <folly/Portability.h>
@@ -42,14 +42,14 @@ using namespace folly;
 namespace {
 
 static const int seed = folly::randomNumberSeed();
-typedef boost::mt19937 RandomT;
+using RandomT = std::mt19937;
 static RandomT rng(seed);
 static const size_t maxString = 100;
 static const bool avoidAliasing = true;
 
 template <class Integral1, class Integral2>
 Integral2 random(Integral1 low, Integral2 up) {
-  boost::uniform_int<> range(low, up);
+  std::uniform_int_distribution<> range(low, up);
   return range(rng);
 }
 

--- a/folly/test/FBVectorTestUtil.cpp
+++ b/folly/test/FBVectorTestUtil.cpp
@@ -19,8 +19,6 @@
 #include <list>
 #include <string>
 
-#include <boost/random/mersenne_twister.hpp>
-
 #include <folly/FBString.h>
 #include <folly/Random.h>
 

--- a/folly/test/FBVectorTestUtil.h
+++ b/folly/test/FBVectorTestUtil.h
@@ -18,9 +18,7 @@
 // Author: andrei.alexandrescu@fb.com
 
 #include <list>
-
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_int.hpp>
+#include <random>
 
 #include <folly/Benchmark.h>
 #include <folly/FBString.h>
@@ -32,12 +30,12 @@ namespace test {
 namespace detail {
 
 auto static const seed = randomNumberSeed();
-typedef boost::random::mt19937 RandomT;
+using RandomT = std::mt19937;
 extern RandomT rng;
 
 template <class Integral1, class Integral2>
 Integral2 random(Integral1 low, Integral2 up) {
-  boost::uniform_int<> range(low, up);
+  std::uniform_int_distribution<> range(low, up);
   return range(rng);
 }
 


### PR DESCRIPTION
Summary:
- Use `std::mt19937` instead of `boost::random::mt19937`.
- Use `std::uniform_int_distribution` instead of `boost::uniform_int`.