### PR TITLE
Use std::is_trivially_destructible instead of boost::has_trivial_destructor

### DIFF
--- a/folly/AtomicUnorderedMap.h
+++ b/folly/AtomicUnorderedMap.h
@@ -24,8 +24,6 @@
 #include <system_error>
 #include <type_traits>
 
-#include <boost/type_traits/has_trivial_destructor.hpp>
-
 #include <folly/Conv.h>
 #include <folly/Likely.h>
 #include <folly/Random.h>
@@ -136,8 +134,8 @@ template <
     typename Hash = std::hash<Key>,
     typename KeyEqual = std::equal_to<Key>,
     bool SkipKeyValueDeletion =
-        (boost::has_trivial_destructor<Key>::value &&
-         boost::has_trivial_destructor<Value>::value),
+        (std::is_trivially_destructible<Key>::value &&
+         std::is_trivially_destructible<Value>::value),
     template <typename> class Atom = std::atomic,
     typename IndexType = uint32_t,
     typename Allocator = folly::detail::MMapAlloc>
@@ -478,8 +476,8 @@ template <
     typename Hash = std::hash<Key>,
     typename KeyEqual = std::equal_to<Key>,
     bool SkipKeyValueDeletion =
-        (boost::has_trivial_destructor<Key>::value &&
-         boost::has_trivial_destructor<Value>::value),
+        (std::is_trivially_destructible<Key>::value &&
+         std::is_trivially_destructible<Value>::value),
     template <typename> class Atom = std::atomic,
     typename Allocator = folly::detail::MMapAlloc>
 using AtomicUnorderedInsertMap64 = AtomicUnorderedInsertMap<

--- a/folly/ConcurrentSkipList-inl.h
+++ b/folly/ConcurrentSkipList-inl.h
@@ -29,7 +29,6 @@
 
 #include <boost/noncopyable.hpp>
 #include <boost/random.hpp>
-#include <boost/type_traits.hpp>
 #include <glog/logging.h>
 
 #include <folly/Memory.h>
@@ -81,7 +80,7 @@ class SkipListNode : private boost::noncopyable {
   template <typename NodeAlloc>
   struct DestroyIsNoOp : StrictConjunction<
                              AllocatorHasTrivialDeallocate<NodeAlloc>,
-                             boost::has_trivial_destructor<SkipListNode>> {};
+                             std::is_trivially_destructible<SkipListNode>> {};
 
   // copy the head node to a new head node assuming lock acquired
   SkipListNode* copyHead(SkipListNode* node) {

--- a/folly/test/AtomicUnorderedMapTest.cpp
+++ b/folly/test/AtomicUnorderedMapTest.cpp
@@ -109,8 +109,8 @@ using UIM = AtomicUnorderedInsertMap<
     Value,
     std::hash<Key>,
     std::equal_to<Key>,
-    (boost::has_trivial_destructor<Key>::value &&
-     boost::has_trivial_destructor<Value>::value),
+    (std::is_trivially_destructible<Key>::value &&
+     std::is_trivially_destructible<Value>::value),
     Atom,
     IndexType,
     Allocator>;


### PR DESCRIPTION
Summary:
- Use `std::is_trivially_destructible` instead of
  `boost::has_trivial_destructor` in a few places.