### PR TITLE
Add parameter check for callback function of `sweep` and `reverseSweep`

### DIFF
--- a/folly/AtomicLinkedList.h
+++ b/folly/AtomicLinkedList.h
@@ -67,9 +67,10 @@ class AtomicLinkedList {
   template <typename F>
   void sweep(F&& func) {
     list_.sweep([&](Wrapper* wrapperPtr) mutable {
-      std::unique_ptr<Wrapper> wrapper(wrapperPtr);
-
-      func(std::move(wrapper->data));
+      if (nullptr != wrapperPtr) {
+        std::unique_ptr<Wrapper> wrapper(wrapperPtr);
+        func(std::move(wrapper->data));
+      } else /* do nothing */;
     });
   }
 
@@ -89,9 +90,10 @@ class AtomicLinkedList {
   template <typename F>
   void reverseSweep(F&& func) {
     list_.reverseSweep([&](Wrapper* wrapperPtr) mutable {
-      std::unique_ptr<Wrapper> wrapper(wrapperPtr);
-
-      func(std::move(wrapper->data));
+      if (nullptr != wrapperPtr) {
+        std::unique_ptr<Wrapper> wrapper(wrapperPtr);
+        func(std::move(wrapper->data));
+      } else /* do nothing */;
     });
   }
 


### PR DESCRIPTION
Unlike intrusive counterpart, callback function here accepts a copy or a reference of element (rather than pointers). Thus, the parameter check process should be handled by the framework. Otherwise, a segmentation fault might raise.