### PR TITLE
Install executor_api.h when generated in OSS build

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -50,8 +50,15 @@ if (PYTHON_EXTENSIONS)
     COMMAND
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
       build_ext -f ${incs} ${libs}
+    BYPRODUCTS ${_cybld}/folly/executor_api.h
     DEPENDS folly_pic
     WORKING_DIRECTORY ${_cybld})
+
+  install(
+    FILES ${_cybld}/folly/executor_api.h
+    DESTINATION ${INCLUDE_INSTALL_DIR}/folly/python
+    COMPONENT dev
+  )
 
   # Install Folly Python Bindings
   install(CODE "


### PR DESCRIPTION
futures.h includes folly/python/executor_api.h, this header needs to be
available to downstream projects (Thrift) which use python/futures.h.

Test Plan:

Build and install OSS target on Ubuntu Bionic and ensure executor_api.h
is installed to /usr/local/include/folly/python/executor_api.h.