### PR TITLE
Cut unneeded boost header from AtomicHashMap.h

### DIFF
--- a/folly/AtomicHashMap-inl.h
+++ b/folly/AtomicHashMap-inl.h
@@ -20,6 +20,8 @@
 
 #include <folly/detail/AtomicHashUtils.h>
 
+#include <type_traits>
+
 namespace folly {
 
 // AtomicHashMap constructor -- Atomic wrapper that allows growth

--- a/folly/AtomicHashMap.h
+++ b/folly/AtomicHashMap.h
@@ -82,7 +82,6 @@
 #define FOLLY_ATOMICHASHMAP_H_
 
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/type_traits/is_convertible.hpp>
 
 #include <atomic>
 #include <functional>


### PR DESCRIPTION
Summary:
- AtomicHashMap.h has an unneeded include for
  `<boost/type_traits/is_convertible.h`.
- Remove the include and add `<type_traits>` in `AtomicHashMap-inl.h`
  since it uses `std::is_convertible`.