### PR TITLE
Cut constexpr function comp objects in ConstexprMath.h

### DIFF
--- a/folly/ConstexprMath.h
+++ b/folly/ConstexprMath.h
@@ -17,49 +17,11 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <type_traits>
 
 namespace folly {
-
-// TODO: Replace with std::equal_to, etc., after upgrading to C++14.
-template <typename T>
-struct constexpr_equal_to {
-  constexpr bool operator()(T const& a, T const& b) const {
-    return a == b;
-  }
-};
-template <typename T>
-struct constexpr_not_equal_to {
-  constexpr bool operator()(T const& a, T const& b) const {
-    return a != b;
-  }
-};
-template <typename T>
-struct constexpr_less {
-  constexpr bool operator()(T const& a, T const& b) const {
-    return a < b;
-  }
-};
-template <typename T>
-struct constexpr_less_equal {
-  constexpr bool operator()(T const& a, T const& b) const {
-    return a <= b;
-  }
-};
-template <typename T>
-struct constexpr_greater {
-  constexpr bool operator()(T const& a, T const& b) const {
-    return a > b;
-  }
-};
-template <typename T>
-struct constexpr_greater_equal {
-  constexpr bool operator()(T const& a, T const& b) const {
-    return a >= b;
-  }
-};
-
 // TLDR: Prefer using operator< for ordering. And when
 // a and b are equivalent objects, we return b to make
 // sorting stable.
@@ -91,7 +53,7 @@ constexpr_clamp(T const& v, T const& lo, T const& hi, Less less) {
 }
 template <typename T>
 constexpr T const& constexpr_clamp(T const& v, T const& lo, T const& hi) {
-  return constexpr_clamp(v, lo, hi, constexpr_less<T>{});
+  return constexpr_clamp(v, lo, hi, std::less<T>{});
 }
 
 namespace detail {


### PR DESCRIPTION
Summary:
- We have several function objects that define constexpr call operators
  for `operator<`, `operator<=`, etc. These were needed prior to
  C++14 in order for them to be `constexpr`, as vendor implementations did not
  mark them `constexpr`.
- Since Folly requires C++14, callers who are relying on these should
  migrate to `std::less<T>`, and other function objects in the standard
  library, which are now marked constexpr.