### PR TITLE
Cut include needed from autotools build days

### DIFF
--- a/folly/experimental/symbolizer/Dwarf.cpp
+++ b/folly/experimental/symbolizer/Dwarf.cpp
@@ -18,13 +18,7 @@
 
 #include <type_traits>
 
-// We can delete this #if check once we completely deprecate and remove
-// the autoconf build.
-#if __has_include(<libdwarf/dwarf.h>)
-#include <libdwarf/dwarf.h>
-#else
 #include <dwarf.h> // @manual
-#endif
 
 namespace folly {
 namespace symbolizer {


### PR DESCRIPTION
Summary:
- When Folly supported autotools builds, a different include for
  `dwarf.h` was required in `folly/experimental/symbolizer/Dwarf.cpp`.
- Since Folly does not support autotools  builds as of `1d58fd57`, cut
  this include and just assume `<dwarf.h>` works.