### PR TITLE
Replace [[no_discard]] with FOLLY_NODISCARD

### DIFF
--- a/folly/experimental/coro/Baton.h
+++ b/folly/experimental/coro/Baton.h
@@ -18,6 +18,8 @@
 #include <atomic>
 #include <experimental/coroutine>
 
+#include <folly/Portability.h>
+
 namespace folly {
 namespace coro {
 
@@ -78,7 +80,7 @@ class Baton {
   /// the behaviour is as if an inline executor was specified.
   /// i.e. the coroutine will be resumed inside the call to .post() on the
   /// thread that next calls .post().
-  [[nodiscard]] WaitOperation operator co_await() const noexcept;
+  FOLLY_NODISCARD WaitOperation operator co_await() const noexcept;
 
   /// Set the Baton to the signalled state if it is not already signalled.
   ///

--- a/folly/experimental/coro/Mutex.h
+++ b/folly/experimental/coro/Mutex.h
@@ -19,6 +19,8 @@
 #include <experimental/coroutine>
 #include <mutex>
 
+#include <folly/Portability.h>
+
 namespace folly {
 namespace coro {
 
@@ -125,7 +127,7 @@ class Mutex {
   /// If you do not specify an executor by calling .via() then the inline
   /// executor is used and the awaiting coroutine is resumed inline inside the
   /// call to .unlock() by the previous lock holder.
-  [[nodiscard]] ScopedLockOperation co_scoped_lock() noexcept;
+  FOLLY_NODISCARD ScopedLockOperation co_scoped_lock() noexcept;
 
   /// Lock the mutex asynchronously.
   ///
@@ -142,7 +144,7 @@ class Mutex {
   ///
   /// Consider using scopedLockAsync() instead to obtain a std::scoped_lock
   /// that handles releasing the lock at the end of the scope.
-  [[nodiscard]] LockOperation co_lock() noexcept;
+  FOLLY_NODISCARD LockOperation co_lock() noexcept;
 
   /// Unlock the mutex.
   ///

--- a/folly/experimental/coro/SharedMutex.h
+++ b/folly/experimental/coro/SharedMutex.h
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include <folly/Executor.h>
+#include <folly/Portability.h>
 #include <folly/SpinLock.h>
 #include <folly/Synchronized.h>
 #include <folly/experimental/coro/SharedLock.h>
@@ -129,7 +130,7 @@ class SharedMutexFair {
   ///
   /// After this operation completes, the caller is responsible for calling
   /// .unlock() to release the lock.
-  [[nodiscard]] LockOperation<LockAwaiter> co_lock() noexcept;
+  FOLLY_NODISCARD LockOperation<LockAwaiter> co_lock() noexcept;
 
   /// Asynchronously acquire an exclusive lock on the mutex and return an object
   /// that will release the lock when it goes out of scope.
@@ -142,7 +143,7 @@ class SharedMutexFair {
   /// execution without suspending. Otherwise, the coroutine is suspended and
   /// will later be resumed on the specified executor once the lock has been
   /// acquired.
-  [[nodiscard]] LockOperation<ScopedLockAwaiter> co_scoped_lock() noexcept;
+  FOLLY_NODISCARD LockOperation<ScopedLockAwaiter> co_scoped_lock() noexcept;
 
   /// Asynchronously acquire a shared lock on the mutex.
   ///
@@ -160,7 +161,7 @@ class SharedMutexFair {
   ///
   /// After this operation completes, the caller is responsible for calling
   /// .unlock_shared() to release the lock.
-  [[nodiscard]] LockOperation<LockSharedAwaiter> co_lock_shared() noexcept;
+FOLLY_NODISCARD LockOperation<LockSharedAwaiter> co_lock_shared() noexcept;
 
   /// Asynchronously acquire an exclusive lock on the mutex and return an object
   /// that will release the lock when it goes out of scope.
@@ -173,7 +174,7 @@ class SharedMutexFair {
   /// execution without suspending. Otherwise, the coroutine is suspended and
   /// will later be resumed on the specified executor once the lock has been
   /// acquired.
-  [[nodiscard]] LockOperation<ScopedLockSharedAwaiter>
+  FOLLY_NODISCARD LockOperation<ScopedLockSharedAwaiter>
   co_scoped_lock_shared() noexcept;
 
   /// Release the exclusive lock.
@@ -275,7 +276,7 @@ class SharedMutexFair {
    public:
     using LockAwaiter::LockAwaiter;
 
-    [[nodiscard]] std::unique_lock<SharedMutexFair> await_resume() noexcept {
+    FOLLY_NODISCARD std::unique_lock<SharedMutexFair> await_resume() noexcept {
       LockAwaiter::await_resume();
       return std::unique_lock<SharedMutexFair>{*mutex_, std::adopt_lock};
     }
@@ -285,7 +286,7 @@ class SharedMutexFair {
    public:
     using LockSharedAwaiter::LockSharedAwaiter;
 
-    [[nodiscard]] SharedLock<SharedMutexFair> await_resume() noexcept {
+    FOLLY_NODISCARD SharedLock<SharedMutexFair> await_resume() noexcept {
       LockSharedAwaiter::await_resume();
       return SharedLock<SharedMutexFair>{*mutex_, std::adopt_lock};
     }


### PR DESCRIPTION
Summay:
- Some call sites use `[[no_discard]]` which will be ignored by some
  older C++14 compilers, such as GCC 4.9 through GCC 6.X. This can
  result in a warning emitted to the effect of "nodiscard attribute
  directive ignored".
- Change the call sites to use `FOLLY_NODISCARD` which will only expand
  to `[[no_discard]]` if and only if the attribute exists (by detection of
  feature test macro for it).
- This will prevent warnings about ignored attribute directives and
  provide consistency with other call sites using `FOLLY_NODISCARD`.