### PR TITLE
Cut FOLLY_USE_CPP14_CONSTEXPR and FOLLY_CPP14_CONSTEXPR

### DIFF
--- a/folly/FixedString.h
+++ b/folly/FixedString.h
@@ -307,7 +307,7 @@ struct Helper {
 #endif
 
 template <class T>
-FOLLY_CPP14_CONSTEXPR void constexpr_swap(T& a, T& b) noexcept(
+constexpr void constexpr_swap(T& a, T& b) noexcept(
     noexcept(a = T(std::move(a)))) {
   T tmp((std::move(a)));
   a = std::move(b);
@@ -336,7 +336,7 @@ struct ReverseIterator {
 
   constexpr ReverseIterator() = default;
   constexpr ReverseIterator(const ReverseIterator&) = default;
-  FOLLY_CPP14_CONSTEXPR ReverseIterator& operator=(const ReverseIterator&) =
+  constexpr ReverseIterator& operator=(const ReverseIterator&) =
       default;
   constexpr explicit ReverseIterator(T* p) noexcept : p_(p) {}
   constexpr /* implicit */ ReverseIterator(const other& that) noexcept
@@ -354,25 +354,25 @@ struct ReverseIterator {
   constexpr reference operator*() const {
     return *(p_ - 1);
   }
-  FOLLY_CPP14_CONSTEXPR ReverseIterator& operator++() noexcept {
+  constexpr ReverseIterator& operator++() noexcept {
     --p_;
     return *this;
   }
-  FOLLY_CPP14_CONSTEXPR ReverseIterator operator++(int) noexcept {
+  constexpr ReverseIterator operator++(int) noexcept {
     auto tmp(*this);
     --p_;
     return tmp;
   }
-  FOLLY_CPP14_CONSTEXPR ReverseIterator& operator--() noexcept {
+  constexpr ReverseIterator& operator--() noexcept {
     ++p_;
     return *this;
   }
-  FOLLY_CPP14_CONSTEXPR ReverseIterator operator--(int) noexcept {
+  constexpr ReverseIterator operator--(int) noexcept {
     auto tmp(*this);
     ++p_;
     return tmp;
   }
-  FOLLY_CPP14_CONSTEXPR ReverseIterator& operator+=(std::ptrdiff_t i) noexcept {
+  constexpr ReverseIterator& operator+=(std::ptrdiff_t i) noexcept {
     p_ -= i;
     return *this;
   }
@@ -386,7 +386,7 @@ struct ReverseIterator {
       std::ptrdiff_t i) noexcept {
     return ReverseIterator{that.p_ - i};
   }
-  FOLLY_CPP14_CONSTEXPR ReverseIterator& operator-=(std::ptrdiff_t i) noexcept {
+  constexpr ReverseIterator& operator-=(std::ptrdiff_t i) noexcept {
     p_ += i;
     return *this;
   }
@@ -728,7 +728,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   constexpr BasicFixedString(std::initializer_list<Char> il) noexcept(false)
       : BasicFixedString{il.begin(), il.size()} {}
 
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& operator=(
+  constexpr BasicFixedString& operator=(
       const BasicFixedString&) noexcept = default;
 
   /** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** **
@@ -745,7 +745,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \return `*this`
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& operator=(
+  constexpr BasicFixedString& operator=(
       const BasicFixedString<Char, M>& that) noexcept(M <= N) {
     detail::fixedstring::checkOverflow(that.size_, N);
     size_ = that.copy(data_, that.size_);
@@ -764,7 +764,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \return `*this`
    */
   template <std::size_t M, class = typename std::enable_if<(M - 1u <= N)>::type>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& operator=(
+  constexpr BasicFixedString& operator=(
       const Char (&that)[M]) noexcept {
     return assign(detail::fixedstring::checkNullTerminated(that), M - 1u);
   }
@@ -778,7 +778,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \throw std::out_of_range when il.size() > N
    * \return `*this`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& operator=(
+  constexpr BasicFixedString& operator=(
       std::initializer_list<Char> il) noexcept(false) {
     detail::fixedstring::checkOverflow(il.size(), N);
     for (std::size_t i = 0u; i < il.size(); ++i) {
@@ -793,7 +793,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * Conversion to folly::Range
    * \return `Range<Char*>{begin(), end()}`
    */
-  FOLLY_CPP14_CONSTEXPR Range<Char*> toRange() noexcept {
+  constexpr Range<Char*> toRange() noexcept {
     return {begin(), end()};
   }
 
@@ -821,7 +821,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   // to compile. But it creates ambiguities when passing a FixedString to an
   // API that has overloads for `const char*` and `folly::Range`, for instance.
   // using ArrayType = Char[N];
-  // FOLLY_CPP14_CONSTEXPR /* implicit */ operator ArrayType&() noexcept {
+  // constexpr /* implicit */ operator ArrayType&() noexcept {
   //   return data_;
   // }
 
@@ -841,7 +841,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \throw std::out_of_range when count > N
    * \return `*this`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& assign(
+  constexpr BasicFixedString& assign(
       std::size_t count,
       Char ch) noexcept(false) {
     detail::fixedstring::checkOverflow(count, N);
@@ -858,7 +858,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to `assign(that, 0, that.size())`
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& assign(
+  constexpr BasicFixedString& assign(
       const BasicFixedString<Char, M>& that) noexcept(M <= N) {
     return *this = that;
   }
@@ -868,7 +868,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   // N is a count of characters. In the latter, it would be a position, which
   // totally changes the meaning of the code.
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& assign(
+  constexpr BasicFixedString& assign(
       const BasicFixedString<Char, M>& that,
       std::size_t pos) noexcept(false) = delete;
 
@@ -890,7 +890,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \return `*this`
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& assign(
+  constexpr BasicFixedString& assign(
       const BasicFixedString<Char, M>& that,
       std::size_t pos,
       std::size_t count) noexcept(false) {
@@ -907,7 +907,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to `assign(that, M - 1)`
    */
   template <std::size_t M, class = typename std::enable_if<(M - 1u <= N)>::type>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& assign(
+  constexpr BasicFixedString& assign(
       const Char (&that)[M]) noexcept {
     return assign(detail::fixedstring::checkNullTerminated(that), M - 1u);
   }
@@ -924,7 +924,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \throw std::out_of_range when count > N
    * \return `*this`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& assign(
+  constexpr BasicFixedString& assign(
       const Char* that,
       std::size_t count) noexcept(false) {
     detail::fixedstring::checkOverflow(count, N);
@@ -939,7 +939,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   /** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** **
    * Swap the contents of this string with `that`.
    */
-  FOLLY_CPP14_CONSTEXPR void swap(BasicFixedString& that) noexcept {
+  constexpr void swap(BasicFixedString& that) noexcept {
     // less-than-or-equal here to copy the null terminator:
     for (std::size_t i = 0u; i <= folly::constexpr_max(size_, that.size_);
          ++i) {
@@ -952,7 +952,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * Return a pointer to a range of `size()+1` characters, the last of which
    * is `Char(0)`.
    */
-  FOLLY_CPP14_CONSTEXPR Char* data() noexcept {
+  constexpr Char* data() noexcept {
     return data_;
   }
 
@@ -973,7 +973,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   /** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** **
    * \return `data()`.
    */
-  FOLLY_CPP14_CONSTEXPR Char* begin() noexcept {
+  constexpr Char* begin() noexcept {
     return data_;
   }
 
@@ -994,7 +994,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   /** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** ** **
    * \return `data() + size()`.
    */
-  FOLLY_CPP14_CONSTEXPR Char* end() noexcept {
+  constexpr Char* end() noexcept {
     return data_ + size_;
   }
 
@@ -1016,7 +1016,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * Returns a reverse iterator to the first character of the reversed string.
    * It corresponds to the last + 1 character of the non-reversed string.
    */
-  FOLLY_CPP14_CONSTEXPR reverse_iterator rbegin() noexcept {
+  constexpr reverse_iterator rbegin() noexcept {
     return reverse_iterator{data_ + size_};
   }
 
@@ -1038,7 +1038,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * Returns a reverse iterator to the last + 1 character of the reversed
    * string. It corresponds to the first character of the non-reversed string.
    */
-  FOLLY_CPP14_CONSTEXPR reverse_iterator rend() noexcept {
+  constexpr reverse_iterator rend() noexcept {
     return reverse_iterator{data_};
   }
 
@@ -1102,7 +1102,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \return `*(data() + i)`
    * \throw std::out_of_range when i > size()
    */
-  FOLLY_CPP14_CONSTEXPR Char& at(std::size_t i) noexcept(false) {
+  constexpr Char& at(std::size_t i) noexcept(false) {
     return i <= size_ ? data_[i]
                       : (throw_exception<std::out_of_range>(
                              "Out of range in BasicFixedString::at"),
@@ -1124,7 +1124,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note `(*this)[size()]` is allowed will return `Char(0)`.
    * \return `*(data() + i)`
    */
-  FOLLY_CPP14_CONSTEXPR Char& operator[](std::size_t i) noexcept {
+  constexpr Char& operator[](std::size_t i) noexcept {
 #ifdef NDEBUG
     return data_[i];
 #else
@@ -1146,7 +1146,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   /**
    * \note Equivalent to `(*this)[0]`
    */
-  FOLLY_CPP14_CONSTEXPR Char& front() noexcept {
+  constexpr Char& front() noexcept {
     return (*this)[0u];
   }
 
@@ -1161,7 +1161,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to `at(size()-1)`
    * \pre `!empty()`
    */
-  FOLLY_CPP14_CONSTEXPR Char& back() noexcept {
+  constexpr Char& back() noexcept {
 #ifdef NDEBUG
     return data_[size_ - 1u];
 #else
@@ -1185,7 +1185,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \post `size() == 0u`
    * \post `at(size()) == Char(0)`
    */
-  FOLLY_CPP14_CONSTEXPR void clear() noexcept {
+  constexpr void clear() noexcept {
     data_[0u] = Char(0);
     size_ = 0u;
   }
@@ -1193,7 +1193,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   /**
    * \note Equivalent to `append(1u, ch)`.
    */
-  FOLLY_CPP14_CONSTEXPR void push_back(Char ch) noexcept(false) {
+  constexpr void push_back(Char ch) noexcept(false) {
     detail::fixedstring::checkOverflow(1u, N - size_);
     data_[size_] = ch;
     data_[++size_] = Char(0);
@@ -1214,7 +1214,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \post The characters in the half-open range `[0,size()-1)` are unmodified.
    * \throw std::out_of_range if empty().
    */
-  FOLLY_CPP14_CONSTEXPR void pop_back() noexcept(false) {
+  constexpr void pop_back() noexcept(false) {
     detail::fixedstring::checkOverflow(1u, size_);
     --size_;
     data_[size_] = Char(0);
@@ -1237,7 +1237,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \post `size() == old_size + count`
    * \throw std::out_of_range if count > N - size().
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& append(
+  constexpr BasicFixedString& append(
       std::size_t count,
       Char ch) noexcept(false) {
     detail::fixedstring::checkOverflow(count, N - size_);
@@ -1253,7 +1253,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to `append(*this, 0, that.size())`.
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& append(
+  constexpr BasicFixedString& append(
       const BasicFixedString<Char, M>& that) noexcept(false) {
     return append(that, 0u, that.size_);
   }
@@ -1262,7 +1262,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   // append("null-terminated", N), where N would be a count instead
   // of a position.
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& append(
+  constexpr BasicFixedString& append(
       const BasicFixedString<Char, M>& that,
       std::size_t pos) noexcept(false) = delete;
 
@@ -1283,7 +1283,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    *        `old_size + count > N`.
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& append(
+  constexpr BasicFixedString& append(
       const BasicFixedString<Char, M>& that,
       std::size_t pos,
       std::size_t count) noexcept(false) {
@@ -1301,7 +1301,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
   /**
    * \note Equivalent to `append(that, strlen(that))`.
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& append(const Char* that) noexcept(
+  constexpr BasicFixedString& append(const Char* that) noexcept(
       false) {
     return append(that, folly::constexpr_strlen(that));
   }
@@ -1315,7 +1315,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \post `at(size()) == Char(0)`
    * \throw std::out_of_range if old_size + count > N.
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& append(
+  constexpr BasicFixedString& append(
       const Char* that,
       std::size_t count) noexcept(false) {
     detail::fixedstring::checkOverflow(count, N - size_);
@@ -1401,7 +1401,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * Appends characters from a null-terminated string literal to this string.
    * \note Equivalent to `append(that)`.
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& operator+=(const Char* that) noexcept(
+  constexpr BasicFixedString& operator+=(const Char* that) noexcept(
       false) {
     return append(that);
   }
@@ -1411,7 +1411,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to `append(that)`.
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& operator+=(
+  constexpr BasicFixedString& operator+=(
       const BasicFixedString<Char, M>& that) noexcept(false) {
     return append(that, 0u, that.size_);
   }
@@ -1420,7 +1420,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * Appends a character to this string.
    * \note Equivalent to `push_back(ch)`.
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& operator+=(Char ch) noexcept(false) {
+  constexpr BasicFixedString& operator+=(Char ch) noexcept(false) {
     push_back(ch);
     return *this;
   }
@@ -1429,7 +1429,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * Appends characters from an `initializer_list` to this string.
    * \note Equivalent to `append(il.begin(), il.size())`.
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& operator+=(
+  constexpr BasicFixedString& operator+=(
       std::initializer_list<Char> il) noexcept(false) {
     return append(il.begin(), il.size());
   }
@@ -1439,7 +1439,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to `clear()`
    * \return *this;
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& erase() noexcept {
+  constexpr BasicFixedString& erase() noexcept {
     clear();
     return *this;
   }
@@ -1454,7 +1454,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \return *this;
    * \throw std::out_of_range when pos > size().
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& erase(
+  constexpr BasicFixedString& erase(
       std::size_t pos,
       std::size_t count = npos) noexcept(false) {
     using A = const Char[1];
@@ -1471,7 +1471,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to `erase(first - data(), 1)`
    * \return A pointer to the first character after the erased character.
    */
-  FOLLY_CPP14_CONSTEXPR Char* erase(const Char* first) noexcept(false) {
+  constexpr Char* erase(const Char* first) noexcept(false) {
     erase(first - data_, 1u);
     return data_ + (first - data_);
   }
@@ -1480,7 +1480,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to `erase(first - data(), last - first)`
    * \return A pointer to the first character after the erased characters.
    */
-  FOLLY_CPP14_CONSTEXPR Char* erase(
+  constexpr Char* erase(
       const Char* first,
       const Char* last) noexcept(false) {
     erase(first - data_, last - first);
@@ -1661,7 +1661,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    *   `replace(first - data(), last - first, that.data(), that.size())`
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       const Char* first,
       const Char* last,
       const BasicFixedString<Char, M>& that) noexcept(false) {
@@ -1677,7 +1677,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    *   that.size() - that_pos)</tt>
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       std::size_t this_pos,
       std::size_t this_count,
       const BasicFixedString<Char, M>& that,
@@ -1694,7 +1694,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    *   `replace(this_pos, this_count, that.data() + that_pos, that_count)`
    */
   template <std::size_t M>
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       std::size_t this_pos,
       std::size_t this_count,
       const BasicFixedString<Char, M>& that,
@@ -1709,7 +1709,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to
    *   `replace(this_pos, this_count, that, strlen(that))`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       std::size_t this_pos,
       std::size_t this_count,
       const Char* that) noexcept(false) {
@@ -1724,7 +1724,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to
    *   `replace(first - data(), last - first, that, strlen(that))`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       const Char* first,
       const Char* last,
       const Char* that) noexcept(false) {
@@ -1749,7 +1749,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    *   - `this_count > size() - this_pos`
    *   - `size() - this_count + that_count > N`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       std::size_t this_pos,
       std::size_t this_count,
       const Char* that,
@@ -1772,7 +1772,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to
    *   `replace(this_pos, this_count, BasicFixedString{that_count, ch})`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       std::size_t this_pos,
       std::size_t this_count,
       std::size_t that_count,
@@ -1786,7 +1786,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to
    *   `replace(first - data(), last - first, BasicFixedString{that_count, ch})`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       const Char* first,
       const Char* last,
       std::size_t that_count,
@@ -1803,7 +1803,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \note Equivalent to
    *   `replace(this_pos, this_count, il.begin(), il.size())`
    */
-  FOLLY_CPP14_CONSTEXPR BasicFixedString& replace(
+  constexpr BasicFixedString& replace(
       const Char* first,
       const Char* last,
       std::initializer_list<Char> il) noexcept(false) {
@@ -2014,7 +2014,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    *   from this string into the buffer pointed to by `dest`.
    * \return The number of characters copied.
    */
-  FOLLY_CPP14_CONSTEXPR std::size_t copy(Char* dest, std::size_t count) const
+  constexpr std::size_t copy(Char* dest, std::size_t count) const
       noexcept {
     return copy(dest, count, 0u);
   }
@@ -2026,7 +2026,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * \return The number of characters copied.
    * \throw std::out_of_range if `pos > size()`
    */
-  FOLLY_CPP14_CONSTEXPR std::size_t
+  constexpr std::size_t
   copy(Char* dest, std::size_t count, std::size_t pos) const noexcept(false) {
     detail::fixedstring::checkOverflow(pos, size_);
     for (std::size_t i = 0u; i < count; ++i) {
@@ -2042,7 +2042,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    * Resizes the current string.
    * \note Equivalent to `resize(count, Char(0))`
    */
-  FOLLY_CPP14_CONSTEXPR void resize(std::size_t count) noexcept(false) {
+  constexpr void resize(std::size_t count) noexcept(false) {
     resize(count, Char(0));
   }
 
@@ -2051,7 +2051,7 @@ class BasicFixedString : private detail::fixedstring::FixedStringBase {
    *   `data()[count]` to `Char(0)`. If `count > old_size`, the characters
    *   in the range [`old_size`,`count`) are set to `ch`.
    */
-  FOLLY_CPP14_CONSTEXPR void resize(std::size_t count, Char ch) noexcept(
+  constexpr void resize(std::size_t count, Char ch) noexcept(
       false) {
     detail::fixedstring::checkOverflow(count, N);
     if (count == size_) {
@@ -2998,7 +2998,7 @@ constexpr BasicFixedString<Char, N - 1u> makeFixedString(
  * Swap function
  */
 template <class Char, std::size_t N>
-FOLLY_CPP14_CONSTEXPR void swap(
+constexpr void swap(
     BasicFixedString<Char, N>& a,
     BasicFixedString<Char, N>& b) noexcept {
   a.swap(b);

--- a/folly/Optional.h
+++ b/folly/Optional.h
@@ -104,7 +104,7 @@ class Optional {
       !std::is_abstract<Value>::value,
       "Optional may not be used with abstract types");
 
-  FOLLY_CPP14_CONSTEXPR Optional() noexcept {}
+  constexpr Optional() noexcept {}
 
   Optional(const Optional& src) noexcept(
       std::is_nothrow_copy_constructible<Value>::value) {
@@ -121,14 +121,14 @@ class Optional {
     }
   }
 
-  FOLLY_CPP14_CONSTEXPR /* implicit */ Optional(const None&) noexcept {}
+  constexpr /* implicit */ Optional(const None&) noexcept {}
 
-  FOLLY_CPP14_CONSTEXPR /* implicit */ Optional(Value&& newValue) noexcept(
+  constexpr /* implicit */ Optional(Value&& newValue) noexcept(
       std::is_nothrow_move_constructible<Value>::value) {
     construct(std::move(newValue));
   }
 
-  FOLLY_CPP14_CONSTEXPR /* implicit */ Optional(const Value& newValue) noexcept(
+  constexpr /* implicit */ Optional(const Value& newValue) noexcept(
       std::is_nothrow_copy_constructible<Value>::value) {
     construct(newValue);
   }
@@ -153,12 +153,12 @@ class Optional {
            Null>::type) noexcept = delete;
 
   template <typename... Args>
-  FOLLY_CPP14_CONSTEXPR explicit Optional(in_place_t, Args&&... args) noexcept(
+  constexpr explicit Optional(in_place_t, Args&&... args) noexcept(
       std::is_nothrow_constructible<Value, Args...>::value)
       : Optional{PrivateConstructor{}, std::forward<Args>(args)...} {}
 
   template <typename U, typename... Args>
-  FOLLY_CPP14_CONSTEXPR explicit Optional(
+  constexpr explicit Optional(
       in_place_t,
       std::initializer_list<U> il,
       Args&&... args) noexcept(std::
@@ -274,22 +274,22 @@ class Optional {
     }
   }
 
-  FOLLY_CPP14_CONSTEXPR const Value& value() const& {
+  constexpr const Value& value() const& {
     require_value();
     return storage_.value;
   }
 
-  FOLLY_CPP14_CONSTEXPR Value& value() & {
+  constexpr Value& value() & {
     require_value();
     return storage_.value;
   }
 
-  FOLLY_CPP14_CONSTEXPR Value&& value() && {
+  constexpr Value&& value() && {
     require_value();
     return std::move(storage_.value);
   }
 
-  FOLLY_CPP14_CONSTEXPR const Value&& value() const&& {
+  constexpr const Value&& value() const&& {
     require_value();
     return std::move(storage_.value);
   }
@@ -302,41 +302,41 @@ class Optional {
   }
   Value* get_pointer() && = delete;
 
-  FOLLY_CPP14_CONSTEXPR bool has_value() const noexcept {
+  constexpr bool has_value() const noexcept {
     return storage_.hasValue;
   }
 
-  FOLLY_CPP14_CONSTEXPR bool hasValue() const noexcept {
+  constexpr bool hasValue() const noexcept {
     return has_value();
   }
 
-  FOLLY_CPP14_CONSTEXPR explicit operator bool() const noexcept {
+  constexpr explicit operator bool() const noexcept {
     return has_value();
   }
 
-  FOLLY_CPP14_CONSTEXPR const Value& operator*() const& {
+  constexpr const Value& operator*() const& {
     return value();
   }
-  FOLLY_CPP14_CONSTEXPR Value& operator*() & {
+  constexpr Value& operator*() & {
     return value();
   }
-  FOLLY_CPP14_CONSTEXPR const Value&& operator*() const&& {
+  constexpr const Value&& operator*() const&& {
     return std::move(value());
   }
-  FOLLY_CPP14_CONSTEXPR Value&& operator*() && {
+  constexpr Value&& operator*() && {
     return std::move(value());
   }
 
-  FOLLY_CPP14_CONSTEXPR const Value* operator->() const {
+  constexpr const Value* operator->() const {
     return &value();
   }
-  FOLLY_CPP14_CONSTEXPR Value* operator->() {
+  constexpr Value* operator->() {
     return &value();
   }
 
   // Return a copy of the value if set, or a given default if not.
   template <class U>
-  FOLLY_CPP14_CONSTEXPR Value value_or(U&& dflt) const& {
+  constexpr Value value_or(U&& dflt) const& {
     if (storage_.hasValue) {
       return storage_.value;
     }
@@ -345,7 +345,7 @@ class Optional {
   }
 
   template <class U>
-  FOLLY_CPP14_CONSTEXPR Value value_or(U&& dflt) && {
+  constexpr Value value_or(U&& dflt) && {
     if (storage_.hasValue) {
       return std::move(storage_.value);
     }
@@ -373,7 +373,7 @@ class Optional {
     explicit PrivateConstructor() = default;
   };
   template <typename... Args>
-  FOLLY_CPP14_CONSTEXPR Optional(PrivateConstructor, Args&&... args) noexcept(
+  constexpr Optional(PrivateConstructor, Args&&... args) noexcept(
       std::is_constructible<Value, Args&&...>::value) {
     construct(std::forward<Args>(args)...);
   }
@@ -493,7 +493,7 @@ constexpr bool operator!=(const U& a, const Optional<V>& b) {
 }
 
 template <class U, class V>
-FOLLY_CPP14_CONSTEXPR bool operator==(
+constexpr bool operator==(
     const Optional<U>& a,
     const Optional<V>& b) {
   if (a.hasValue() != b.hasValue()) {
@@ -511,7 +511,7 @@ constexpr bool operator!=(const Optional<U>& a, const Optional<V>& b) {
 }
 
 template <class U, class V>
-FOLLY_CPP14_CONSTEXPR bool operator<(
+constexpr bool operator<(
     const Optional<U>& a,
     const Optional<V>& b) {
   if (a.hasValue() != b.hasValue()) {

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -440,24 +440,6 @@ constexpr auto kCpplibVer = 0;
 #endif
 } // namespace folly
 
-// Define FOLLY_USE_CPP14_CONSTEXPR to be true if the compiler's C++14
-// constexpr support is "good enough".
-#ifndef FOLLY_USE_CPP14_CONSTEXPR
-#if defined(__clang__)
-#define FOLLY_USE_CPP14_CONSTEXPR __cplusplus >= 201300L
-#elif defined(__GNUC__)
-#define FOLLY_USE_CPP14_CONSTEXPR __cplusplus >= 201304L
-#else
-#define FOLLY_USE_CPP14_CONSTEXPR 0 // MSVC?
-#endif
-#endif
-
-#if FOLLY_USE_CPP14_CONSTEXPR
-#define FOLLY_CPP14_CONSTEXPR constexpr
-#else
-#define FOLLY_CPP14_CONSTEXPR inline
-#endif
-
 //  MSVC does not permit:
 //
 //    extern int const num;
@@ -471,18 +453,8 @@ constexpr auto kCpplibVer = 0;
 //  True as of MSVC 2017.
 #if _MSC_VER
 #define FOLLY_STORAGE_CONSTEXPR
-#define FOLLY_STORAGE_CPP14_CONSTEXPR
-#else
-#if __ICC
-#define FOLLY_STORAGE_CONSTEXPR
 #else
 #define FOLLY_STORAGE_CONSTEXPR constexpr
-#endif
-#if FOLLY_USE_CPP14_CONSTEXPR
-#define FOLLY_STORAGE_CPP14_CONSTEXPR constexpr
-#else
-#define FOLLY_STORAGE_CPP14_CONSTEXPR
-#endif
 #endif
 
 #if __cpp_coroutines >= 201703L && __has_include(<experimental/coroutine>)

--- a/folly/Replaceable.h
+++ b/folly/Replaceable.h
@@ -439,7 +439,7 @@ class alignas(T) Replaceable
   template <
       class... Args,
       std::enable_if_t<std::is_constructible<T, Args&&...>::value, int> = 0>
-  FOLLY_CPP14_CONSTEXPR explicit Replaceable(in_place_t, Args&&... args)
+  constexpr explicit Replaceable(in_place_t, Args&&... args)
       // clang-format off
       noexcept(std::is_nothrow_constructible<T, Args&&...>::value)
       // clang-format on
@@ -453,7 +453,7 @@ class alignas(T) Replaceable
       std::enable_if_t<
           std::is_constructible<T, std::initializer_list<U>, Args&&...>::value,
           int> = 0>
-  FOLLY_CPP14_CONSTEXPR explicit Replaceable(
+  constexpr explicit Replaceable(
       in_place_t,
       std::initializer_list<U> il,
       Args&&... args)
@@ -475,7 +475,7 @@ class alignas(T) Replaceable
               !std::is_same<Replaceable<T>, std::decay_t<U>>::value &&
               std::is_convertible<U&&, T>::value,
           int> = 0>
-  FOLLY_CPP14_CONSTEXPR /* implicit */ Replaceable(U&& other)
+  constexpr /* implicit */ Replaceable(U&& other)
       // clang-format off
       noexcept(std::is_nothrow_constructible<T, U&&>::value)
       // clang-format on
@@ -491,7 +491,7 @@ class alignas(T) Replaceable
               !std::is_same<Replaceable<T>, std::decay_t<U>>::value &&
               !std::is_convertible<U&&, T>::value,
           int> = 0>
-  FOLLY_CPP14_CONSTEXPR explicit Replaceable(U&& other)
+  constexpr explicit Replaceable(U&& other)
       // clang-format off
       noexcept(std::is_nothrow_constructible<T, U&&>::value)
       // clang-format on
@@ -611,7 +611,7 @@ class alignas(T) Replaceable
     return launder(reinterpret_cast<T const*>(storage_));
   }
 
-  FOLLY_CPP14_CONSTEXPR T* operator->() {
+  constexpr T* operator->() {
     return launder(reinterpret_cast<T*>(storage_));
   }
 
@@ -619,11 +619,11 @@ class alignas(T) Replaceable
     return *launder(reinterpret_cast<T const*>(storage_));
   }
 
-  FOLLY_CPP14_CONSTEXPR T& operator*() & {
+  constexpr T& operator*() & {
     return *launder(reinterpret_cast<T*>(storage_));
   }
 
-  FOLLY_CPP14_CONSTEXPR T&& operator*() && {
+  constexpr T&& operator*() && {
     return std::move(*launder(reinterpret_cast<T*>(storage_)));
   }
 

--- a/folly/container/Foreach-inl.h
+++ b/folly/container/Foreach-inl.h
@@ -313,7 +313,7 @@ decltype(auto) fetch_impl(RangeTag, Sequence&& sequence, Index&& index) {
 } // namespace for_each_detail
 
 template <typename Sequence, typename Func>
-FOLLY_CPP14_CONSTEXPR Func for_each(Sequence&& sequence, Func func) {
+constexpr Func for_each(Sequence&& sequence, Func func) {
   namespace fed = for_each_detail;
   using tag = fed::SequenceTag<Sequence>;
   fed::for_each_impl(tag{}, std::forward<Sequence>(sequence), func);
@@ -321,7 +321,7 @@ FOLLY_CPP14_CONSTEXPR Func for_each(Sequence&& sequence, Func func) {
 }
 
 template <typename Sequence, typename Index>
-FOLLY_CPP14_CONSTEXPR decltype(auto) fetch(Sequence&& sequence, Index&& index) {
+constexpr decltype(auto) fetch(Sequence&& sequence, Index&& index) {
   namespace fed = for_each_detail;
   using tag = fed::SequenceTag<Sequence>;
   return for_each_detail::fetch_impl(

--- a/folly/container/Foreach.h
+++ b/folly/container/Foreach.h
@@ -83,7 +83,7 @@ namespace folly {
  *  });
  */
 template <typename Range, typename Func>
-FOLLY_CPP14_CONSTEXPR Func for_each(Range&& range, Func func);
+constexpr Func for_each(Range&& range, Func func);
 
 /**
  * The user should return loop_break and loop_continue if they want to iterate
@@ -119,7 +119,7 @@ constexpr auto loop_continue = for_each_detail::LoopControl::CONTINUE;
  * required element.
  */
 template <typename Sequence, typename Index>
-FOLLY_CPP14_CONSTEXPR decltype(auto) fetch(Sequence&& sequence, Index&& index);
+constexpr decltype(auto) fetch(Sequence&& sequence, Index&& index);
 
 } // namespace folly
 

--- a/folly/lang/PropagateConst.h
+++ b/folly/lang/PropagateConst.h
@@ -64,7 +64,7 @@ class propagate_const {
       std::remove_reference_t<decltype(*std::declval<Pointer&>())>;
 
   constexpr propagate_const() = default;
-  FOLLY_CPP14_CONSTEXPR propagate_const(propagate_const&&) = default;
+  constexpr propagate_const(propagate_const&&) = default;
   propagate_const(propagate_const const&) = delete;
 
   template <
@@ -105,14 +105,14 @@ class propagate_const {
   constexpr propagate_const(OtherPointer&& other)
       : pointer_(static_cast<OtherPointer&&>(other)) {}
 
-  FOLLY_CPP14_CONSTEXPR propagate_const& operator=(propagate_const&&) = default;
+  constexpr propagate_const& operator=(propagate_const&&) = default;
   propagate_const& operator=(propagate_const const&) = delete;
 
   template <
       typename OtherPointer,
       typename =
           std::enable_if_t<std::is_convertible<OtherPointer&&, Pointer>::value>>
-  FOLLY_CPP14_CONSTEXPR propagate_const& operator=(
+  constexpr propagate_const& operator=(
       propagate_const<OtherPointer>&& other) {
     pointer_ = static_cast<OtherPointer&&>(other.pointer_);
   }
@@ -122,19 +122,19 @@ class propagate_const {
       typename = std::enable_if_t<
           !detail::is_decay_propagate_const<OtherPointer>::value &&
           std::is_convertible<OtherPointer&&, Pointer>::value>>
-  FOLLY_CPP14_CONSTEXPR propagate_const& operator=(OtherPointer&& other) {
+  constexpr propagate_const& operator=(OtherPointer&& other) {
     pointer_ = static_cast<OtherPointer&&>(other);
     return *this;
   }
 
-  FOLLY_CPP14_CONSTEXPR void swap(propagate_const& other) noexcept(
+  constexpr void swap(propagate_const& other) noexcept(
       noexcept(detail::propagate_const_adl::adl_swap(
           std::declval<Pointer&>(),
           other.pointer_))) {
     detail::propagate_const_adl::adl_swap(pointer_, other.pointer_);
   }
 
-  FOLLY_CPP14_CONSTEXPR element_type* get() {
+  constexpr element_type* get() {
     return get_(pointer_);
   }
 
@@ -146,7 +146,7 @@ class propagate_const {
     return static_cast<bool>(pointer_);
   }
 
-  FOLLY_CPP14_CONSTEXPR element_type& operator*() {
+  constexpr element_type& operator*() {
     return *get();
   }
 
@@ -154,7 +154,7 @@ class propagate_const {
     return *get();
   }
 
-  FOLLY_CPP14_CONSTEXPR element_type* operator->() {
+  constexpr element_type* operator->() {
     return get();
   }
 
@@ -167,7 +167,7 @@ class propagate_const {
       typename = std::enable_if_t<
           std::is_pointer<OtherPointer>::value ||
           std::is_convertible<OtherPointer, element_type*>::value>>
-  FOLLY_CPP14_CONSTEXPR operator element_type*() {
+  constexpr operator element_type*() {
     return get();
   }
 
@@ -199,7 +199,7 @@ class propagate_const {
 };
 
 template <typename Pointer>
-FOLLY_CPP14_CONSTEXPR void swap(
+constexpr void swap(
     propagate_const<Pointer>& a,
     propagate_const<Pointer>& b) noexcept(noexcept(a.swap(b))) {
   a.swap(b);

--- a/folly/test/FixedStringTest.cpp
+++ b/folly/test/FixedStringTest.cpp
@@ -159,7 +159,6 @@ TEST(FixedStringConcatTest, FromTwoStrings) {
   static_assert(res == "hello world!!!", "");
 }
 
-#if FOLLY_USE_CPP14_CONSTEXPR
 constexpr folly::FixedString<20> constexpr_swap_test() {
   folly::FixedString<10> tmp1{"hello"}, tmp2{"world!"};
   tmp2.swap(tmp1);
@@ -169,7 +168,6 @@ constexpr folly::FixedString<20> constexpr_swap_test() {
 TEST(FixedStringSwapTest, ConstexprSwap) {
   static_assert(constexpr_swap_test() == "world!hello", "");
 }
-#endif
 
 TEST(FixedStringSwapTest, RuntimeSwap) {
   folly::FixedString<10> tmp1{"hello"}, tmp2{"world!"};
@@ -177,7 +175,6 @@ TEST(FixedStringSwapTest, RuntimeSwap) {
   EXPECT_STREQ((tmp1 + tmp2).c_str(), "world!hello");
 }
 
-#if FOLLY_USE_CPP14_CONSTEXPR
 constexpr folly::FixedString<10> constexpr_assign_string_test_1() {
   folly::FixedString<10> tmp1, tmp2{"world!"};
   tmp1 = tmp2;
@@ -205,7 +202,6 @@ TEST(FixedStringAssignTest, ConstexprAssignString) {
   static_assert(constexpr_assign_string_test_3() == "db", "");
   static_assert(constexpr_assign_string_test_4() == "dbye", "");
 }
-#endif
 
 TEST(FixedStringAssignTest, RuntimeAssignString) {
   folly::FixedString<10> tmp1, tmp2{"world!"};
@@ -219,7 +215,6 @@ TEST(FixedStringAssignTest, RuntimeAssignString) {
   EXPECT_STREQ("dby", tmp1.c_str());
 }
 
-#if FOLLY_USE_CPP14_CONSTEXPR
 constexpr folly::FixedString<10> constexpr_assign_literal_test_1() {
   folly::FixedString<10> tmp{"aaaaaaaaaa"};
   tmp = "hello";
@@ -244,7 +239,6 @@ TEST(FixedStringAssignTest, ConstexprAssignLiteral) {
   static_assert(constexpr_assign_literal_test_2() == "hello", "");
   static_assert(constexpr_assign_literal_test_3() == "good", "");
 }
-#endif
 
 TEST(FixedStringAssignTest, RuntimeAssignLiteral) {
   folly::FixedString<10> tmp{"aaaaaaaaaa"};
@@ -333,7 +327,6 @@ TEST(FixedStringCompareTest, CompareStdString) {
   EXPECT_TRUE(tmp2 >= tmp1);
 }
 
-#if FOLLY_USE_CPP14_CONSTEXPR
 constexpr folly::FixedString<20> constexpr_append_string_test() {
   folly::FixedString<20> a{"hello"}, b{"X world!"};
   a.append(1u, ' ');
@@ -345,7 +338,6 @@ constexpr folly::FixedString<20> constexpr_append_string_test() {
 TEST(FixedStringAssignTest, ConstexprAppendString) {
   static_assert(constexpr_append_string_test() == "hello world!", "");
 }
-#endif
 
 TEST(FixedStringAssignTest, RuntimeAppendString) {
   folly::FixedString<20> a{"hello"}, b{"X world!"};
@@ -355,7 +347,6 @@ TEST(FixedStringAssignTest, RuntimeAppendString) {
   EXPECT_STREQ("hello world!", a.c_str());
 }
 
-#if FOLLY_USE_CPP14_CONSTEXPR
 constexpr folly::FixedString<20> constexpr_append_literal_test() {
   folly::FixedString<20> a{"hello"};
   a.append(1u, ' ');
@@ -367,7 +358,6 @@ constexpr folly::FixedString<20> constexpr_append_literal_test() {
 TEST(FixedStringAssignTest, ConstexprAppendLiteral) {
   static_assert(constexpr_append_literal_test() == "hello world!", "");
 }
-#endif
 
 TEST(FixedStringAssignTest, RuntimeAppendLiteral) {
   folly::FixedString<20> a{"hello"};
@@ -393,7 +383,6 @@ TEST(FixedStringCAppendTest, CAppendLiteral) {
   static_assert(tmp3 == "hello world!", "");
 }
 
-#if FOLLY_USE_CPP14_CONSTEXPR
 constexpr folly::FixedString<10> constexpr_replace_string_test() {
   folly::FixedString<10> tmp{"abcdefghij"};
   tmp.replace(1, 5, FS("XX"));
@@ -404,7 +393,6 @@ TEST(FixedStringReplaceTest, ConstexprReplaceString) {
   static_assert(constexpr_replace_string_test().size() == 7u, "");
   static_assert(constexpr_replace_string_test() == "aXXghij", "");
 }
-#endif
 
 TEST(FixedStringReplaceTest, RuntimeReplaceString) {
   folly::FixedString<10> tmp{"abcdefghij"};
@@ -637,7 +625,6 @@ TEST(FixedStringConversionTest, ConversionToStdString) {
   EXPECT_STREQ("another string", str.c_str());
 }
 
-#if FOLLY_USE_CPP14_CONSTEXPR
 constexpr std::size_t countSpacesReverse(folly::FixedString<50> s) {
   std::size_t count = 0u;
   auto i = s.rbegin();
@@ -652,7 +639,6 @@ constexpr std::size_t countSpacesReverse(folly::FixedString<50> s) {
 TEST(FixedStringReverseIteratorTest, Cpp14ConstexprReverseIteration) {
   static_assert(3 == countSpacesReverse("This is a string"), "");
 }
-#endif
 
 TEST(FixedStringReverseIteratorTest, ConstexprReverseIteration) {
   static constexpr auto alpha = FS("abcdefghijklmnopqrstuvwxyz");


### PR DESCRIPTION
Summary:
- `FOLLY_USE_CPP14_CONSTEXPR` macro is not needed as Folly requires a
  recent enough version of MSVC where its constexpr support is "good
  enough". For Clang and GCC, the min compiler versions supported would
  both evaluate the prior implementation of this macro to true in both
  cases. This is potentially slightly behavior changing since
  `FOLLY_USE_CPP14_CONSTEXPR` would be `inline` for ICC and I am not
  sure if its constexpr support is "good enough" for a min version of
  ICC we claim support for.
- Replace `FOLLY_CPP14_CONSTEXPR` with `constexpr` in all call sites and
  remove the `FOLLY_CPP14_CONSTEXPR` macro.
- Simplify how we define `FOLLY_STORAGE_CONSTEXPR` and
  `FOLLY_STORAGE_CPP14_CONSTEXPR` after cutting
  `FOLLY_USE_CPP14_CONSTEXPR`.