### PR TITLE
Replace _LIBCPP_VERSION with FOLLY_USE_LIBCPP in some cases

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -2771,7 +2771,7 @@ operator<<(
         typename basic_fbstring<E, T, A, S>::value_type,
         typename basic_fbstring<E, T, A, S>::traits_type>& os,
     const basic_fbstring<E, T, A, S>& str) {
-#if _LIBCPP_VERSION
+#if FOLLY_USE_LIBCPP
   typedef std::basic_ostream<
       typename basic_fbstring<E, T, A, S>::value_type,
       typename basic_fbstring<E, T, A, S>::traits_type>

--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -316,7 +316,7 @@ using aligned_storage_for_t =
     typename std::aligned_storage<sizeof(T), alignof(T)>::type;
 
 // Older versions of libstdc++ do not provide std::is_trivially_copyable
-#if defined(__clang__) && !defined(_LIBCPP_VERSION)
+#if defined(__clang__) && !defined(FOLLY_USE_LIBCPP)
 template <class T>
 struct is_trivially_copyable : bool_constant<__is_trivially_copyable(T)> {};
 #elif defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5

--- a/folly/container/detail/F14Table.h
+++ b/folly/container/detail/F14Table.h
@@ -138,7 +138,7 @@ struct F14LinkCheck<getF14IntrinsicsMode()> {
 bool tlsPendingSafeInserts(std::ptrdiff_t delta = 0);
 std::size_t tlsMinstdRand(std::size_t n);
 
-#if defined(_LIBCPP_VERSION)
+#if FOLLY_USE_LIBCPP
 
 template <typename K, typename V, typename H>
 struct StdNodeReplica {

--- a/folly/test/ExpectedTest.cpp
+++ b/folly/test/ExpectedTest.cpp
@@ -667,7 +667,7 @@ struct WithConstructor {
 };
 
 // libstdc++ with GCC 4.x doesn't have std::is_trivially_copyable
-#if (defined(__clang__) && !defined(_LIBCPP_VERSION)) || \
+#if (defined(__clang__) && !defined(FOLLY_USE_LIBCPP)) || \
     !(defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5)
 TEST(Expected, TriviallyCopyable) {
   // These could all be static_asserts but EXPECT_* give much nicer output on


### PR DESCRIPTION
Problem:
- When using `_LIBCPP_VERSION` without a specific version check, it is
  hard to reason about intent.

Solution:
- To make intent clear at the the point of use, use `FOLLY_USE_LIBCPP`
  when we only care if the user is using `libc++` but we do not care about
  the specific version.
- In the case we check against a particular version, still use
  `_LIBCPP_VERSION`.