### PR TITLE
Cut disabling uninitialized warnings in folly/experimental/Bits.h

### DIFF
--- a/folly/experimental/Bits.h
+++ b/folly/experimental/Bits.h
@@ -210,12 +210,6 @@ struct Bits {
   }
 };
 
-// gcc 4.8 needs more -Wmaybe-uninitialized tickling, as it propagates the
-// taint upstream from loadRMW
-FOLLY_PUSH_WARNING
-FOLLY_GNU_DISABLE_WARNING("-Wuninitialized")
-FOLLY_GCC_DISABLE_WARNING("-Wmaybe-uninitialized")
-
 template <class T, class Traits>
 inline void Bits<T, Traits>::set(T* p, size_t bit) {
   T& block = p[blockIndex(bit)];
@@ -273,8 +267,6 @@ inline void Bits<T, Traits>::innerSet(
   v |= (value << offset);
   Traits::store(*p, v);
 }
-
-FOLLY_POP_WARNING
 
 template <class T, class Traits>
 inline bool Bits<T, Traits>::test(const T* p, size_t bit) {


### PR DESCRIPTION
Summary:
- `folly/experimental/Bits.h` has a section where we disable two
  uninitialized-flavors of warnings that were needed for GCC 4.8
- Since we do not support GCC 4.8 anymore and GCC 5.1 does not have
  issues with this, do not disable the warnings anymore.