### PR TITLE
Cut noexcept calculations in dynamic-inl.h

### DIFF
--- a/folly/dynamic-inl.h
+++ b/folly/dynamic-inl.h
@@ -134,17 +134,6 @@ struct FOLLY_EXPORT TypeError : std::runtime_error {
       const std::string& expected,
       dynamic::Type actual1,
       dynamic::Type actual2);
-  // TODO: noexcept calculation required through gcc-v4.9; remove once upgrading
-  // to gcc-v5.
-  TypeError(const TypeError&) noexcept(
-      std::is_nothrow_copy_constructible<std::runtime_error>::value);
-  TypeError& operator=(const TypeError&) noexcept(
-      std::is_nothrow_copy_assignable<std::runtime_error>::value);
-  TypeError(TypeError&&) noexcept(
-      std::is_nothrow_move_constructible<std::runtime_error>::value);
-  TypeError& operator=(TypeError&&) noexcept(
-      std::is_nothrow_move_assignable<std::runtime_error>::value);
-  ~TypeError() override;
 };
 
 //////////////////////////////////////////////////////////////////////

--- a/folly/dynamic.cpp
+++ b/folly/dynamic.cpp
@@ -63,16 +63,6 @@ TypeError::TypeError(
           dynamic::typeName(actual1),
           dynamic::typeName(actual2))) {}
 
-TypeError::TypeError(const TypeError&) noexcept(
-    std::is_nothrow_copy_constructible<std::runtime_error>::value) = default;
-TypeError& TypeError::operator=(const TypeError&) noexcept(
-    std::is_nothrow_copy_assignable<std::runtime_error>::value) = default;
-TypeError::TypeError(TypeError&&) noexcept(
-    std::is_nothrow_move_constructible<std::runtime_error>::value) = default;
-TypeError& TypeError::operator=(TypeError&&) noexcept(
-    std::is_nothrow_move_assignable<std::runtime_error>::value) = default;
-TypeError::~TypeError() = default;
-
 // This is a higher-order preprocessor macro to aid going from runtime
 // types to the compile time type system.
 #define FB_DYNAMIC_APPLY(type, apply) \


### PR DESCRIPTION
Summary:
- GCC 4.9 previously required marking `TypeError` special member
  functions with conditional noexcept.
- GCC 5.1 does not have this issue. So, remove the conditional noexcept
  as they always evalaute to true in the existing code.