### PR TITLE
Allow trivially move constructible types to be relocatable

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -453,13 +453,11 @@ struct IsNothrowSwappable
 /* using override */ using traits_detail_IsNothrowSwappable::IsNothrowSwappable;
 
 template <class T>
-struct IsRelocatable : std::conditional<
+struct IsRelocatable : std::conditional_t<
                            traits_detail::has_IsRelocatable<T>::value,
                            traits_detail::has_true_IsRelocatable<T>,
-                           // TODO add this line (and some tests for it) when we
-                           // upgrade to gcc 4.7
-                           // std::is_trivially_move_constructible<T>::value ||
-                           is_trivially_copyable<T>>::type {};
+                           bool_constant<std::is_trivially_move_constructible<T>
+                           ::value || is_trivially_copyable<T>::value>>{};
 
 template <class T>
 struct IsZeroInitializable

--- a/folly/test/TraitsTest.cpp
+++ b/folly/test/TraitsTest.cpp
@@ -21,6 +21,7 @@
 #include <type_traits>
 #include <utility>
 
+#include <folly/Portability.h>
 #include <folly/ScopeGuard.h>
 #include <folly/portability/GTest.h>
 
@@ -96,6 +97,19 @@ TEST(Traits, typedefd) {
 TEST(Traits, unset) {
   EXPECT_TRUE(IsRelocatable<F1>::value);
   EXPECT_TRUE(IsRelocatable<F4>::value);
+}
+
+TEST(Traits, triviallyMoveConstructible) {
+FOLLY_PUSH_WARNING
+FOLLY_CLANG_DISABLE_WARNING("-Wunneeded-member-function")
+  struct TriviallyMoveConstructible {
+    TriviallyMoveConstructible(const TriviallyMoveConstructible&) = delete;
+    TriviallyMoveConstructible& operator=(const TriviallyMoveConstructible&) = delete;
+    TriviallyMoveConstructible(TriviallyMoveConstructible&&) = default;
+    TriviallyMoveConstructible& operator=(TriviallyMoveConstructible&&) = delete;
+  };
+  EXPECT_TRUE(IsRelocatable<TriviallyMoveConstructible>::value);
+FOLLY_POP_WARNING
 }
 
 TEST(Traits, bitAndInit) {


### PR DESCRIPTION
Summary:
- If a type is not marked explicitly with `IsRelocatable`
  as `std::true_type`, we infer its relocability only based on the
  property of whether the type is trivially copyable.
- Extend the default relocability to also be true for trivially move
  constructible types.