### PR TITLE
Fix warning class-memaccess warning when using gcc 9

### DIFF
--- a/folly/IPAddress.h
+++ b/folly/IPAddress.h
@@ -446,7 +446,7 @@ class IPAddress {
     IPAddressV6 ipV6Addr;
     // default constructor
     IPAddressV46() noexcept {
-      std::memset(this, 0, sizeof(IPAddressV46));
+      std::memset(static_cast<void*>(this), 0, sizeof(IPAddressV46));
     }
     explicit IPAddressV46(const IPAddressV4& addr) noexcept : ipV4Addr(addr) {}
     explicit IPAddressV46(const IPAddressV6& addr) noexcept : ipV6Addr(addr) {}


### PR DESCRIPTION
Hello,

When compiling with gcc (GCC) 9.0.1 20190205 (experimental):

```
In file included from /home/docker/development/opensource-pack-builder/components/folly/BUILD/folly-2019.02.25.00/folly/IPAddress.cpp:16:
/home/docker/development/opensource-pack-builder/components/folly/BUILD/folly-2019.02.25.00/folly/IPAddress.h: In constructor 'folly::IPAddress::IPAddressV46::IPAddressV46()':
/home/docker/development/opensource-pack-builder/components/folly/BUILD/folly-2019.02.25.00/folly/IPAddress.h:449:48: error: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'union folly::IPAddress::IPAddressV46'; use assignment
or value-initialization instead [-Werror=class-memaccess]
  449 |       std::memset(this, 0, sizeof(IPAddressV46));
      |                                                ^
/home/docker/development/opensource-pack-builder/components/folly/BUILD/folly-2019.02.25.00/folly/IPAddress.h:444:17: note: 'union folly::IPAddress::IPAddressV46' declared here
  444 |   typedef union IPAddressV46 {
      |                 ^~~~~~~~~~~~
```

This fix this warning.

Regards,
Stac