### PR TITLE
Replace some bool_constant with constexpr bool in FBVector

### DIFF
--- a/folly/FBVector.h
+++ b/folly/FBVector.h
@@ -117,7 +117,7 @@ class fbvector {
     // allocation
     // note that 'allocate' and 'deallocate' are inherited from Allocator
     T* D_allocate(size_type n) {
-      if (usingStdAllocator::value) {
+      if (usingStdAllocator) {
         return static_cast<T*>(checkedMalloc(n * sizeof(T)));
       } else {
         return std::allocator_traits<Allocator>::allocate(*this, n);
@@ -125,7 +125,7 @@ class fbvector {
     }
 
     void D_deallocate(T* p, size_type n) noexcept {
-      if (usingStdAllocator::value) {
+      if (usingStdAllocator) {
         free(p);
       } else {
         std::allocator_traits<Allocator>::deallocate(*this, p, n);
@@ -145,7 +145,7 @@ class fbvector {
         // THIS DISPATCH CODE IS DUPLICATED IN fbvector::D_destroy_range_a.
         // It has been inlined here for speed. It calls the static fbvector
         //  methods to perform the actual destruction.
-        if (usingStdAllocator::value) {
+        if (usingStdAllocator) {
           S_destroy_range(b_, e_);
         } else {
           S_destroy_range_a(*this, b_, e_);
@@ -189,7 +189,7 @@ class fbvector {
 
   static void swap(Impl& a, Impl& b) {
     using std::swap;
-    if (!usingStdAllocator::value) {
+    if (!usingStdAllocator) {
       swap(static_cast<Allocator&>(a), static_cast<Allocator&>(b));
     }
     a.swapData(b);
@@ -213,21 +213,18 @@ class fbvector {
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
  private:
-  typedef bool_constant<
-      is_trivially_copyable<T>::value &&
-      sizeof(T) <= 16 // don't force large structures to be passed by value
-      >
-      should_pass_by_value;
+  static constexpr bool should_pass_by_value = is_trivially_copyable<T>::value
+      && sizeof(T) <= 16; // don't force large structures to be passed by value
   typedef
-      typename std::conditional<should_pass_by_value::value, T, const T&>::type
+      typename std::conditional<should_pass_by_value, T, const T&>::type
           VT;
   typedef
-      typename std::conditional<should_pass_by_value::value, T, T&&>::type MT;
+      typename std::conditional<should_pass_by_value, T, T&&>::type MT;
 
-  typedef bool_constant<std::is_same<Allocator, std::allocator<T>>::value>
-      usingStdAllocator;
+  static constexpr bool usingStdAllocator = std::is_same<Allocator,
+      std::allocator<T>>::value;
   typedef bool_constant<
-      usingStdAllocator::value ||
+      usingStdAllocator ||
       A::propagate_on_container_move_assignment::value>
       moveIsSwap;
 
@@ -257,7 +254,7 @@ class fbvector {
 
   template <typename U, typename... Args>
   void M_construct(U* p, Args&&... args) {
-    if (usingStdAllocator::value) {
+    if (usingStdAllocator) {
       new (p) U(std::forward<Args>(args)...);
     } else {
       std::allocator_traits<Allocator>::construct(
@@ -282,7 +279,7 @@ class fbvector {
       typename U,
       typename Enable = typename std::enable_if<std::is_scalar<U>::value>::type>
   void M_construct(U* p, U arg) {
-    if (usingStdAllocator::value) {
+    if (usingStdAllocator) {
       *p = arg;
     } else {
       std::allocator_traits<Allocator>::construct(impl_, p, arg);
@@ -309,7 +306,7 @@ class fbvector {
       typename Enable =
           typename std::enable_if<!std::is_scalar<U>::value>::type>
   void M_construct(U* p, const U& value) {
-    if (usingStdAllocator::value) {
+    if (usingStdAllocator) {
       new (p) U(value);
     } else {
       std::allocator_traits<Allocator>::construct(impl_, p, value);
@@ -336,7 +333,7 @@ class fbvector {
   // destroy
 
   void M_destroy(T* p) noexcept {
-    if (usingStdAllocator::value) {
+    if (usingStdAllocator) {
       if (!std::is_trivially_destructible<T>::value) {
         p->~T();
       }
@@ -361,7 +358,7 @@ class fbvector {
   // dispatch
   // THIS DISPATCH CODE IS DUPLICATED IN IMPL. SEE IMPL FOR DETAILS.
   void D_destroy_range_a(T* first, T* last) noexcept {
-    if (usingStdAllocator::value) {
+    if (usingStdAllocator) {
       S_destroy_range(first, last);
     } else {
       S_destroy_range_a(impl_, first, last);
@@ -411,7 +408,7 @@ class fbvector {
 
   // dispatch
   void D_uninitialized_fill_n_a(T* dest, size_type sz) {
-    if (usingStdAllocator::value) {
+    if (usingStdAllocator) {
       S_uninitialized_fill_n(dest, sz);
     } else {
       S_uninitialized_fill_n_a(impl_, dest, sz);
@@ -419,7 +416,7 @@ class fbvector {
   }
 
   void D_uninitialized_fill_n_a(T* dest, size_type sz, VT value) {
-    if (usingStdAllocator::value) {
+    if (usingStdAllocator) {
       S_uninitialized_fill_n(dest, sz, value);
     } else {
       S_uninitialized_fill_n_a(impl_, dest, sz, value);
@@ -504,7 +501,7 @@ class fbvector {
   // dispatch
   template <typename It>
   void D_uninitialized_copy_a(T* dest, It first, It last) {
-    if (usingStdAllocator::value) {
+    if (usingStdAllocator) {
       if (folly::is_trivially_copyable<T>::value) {
         S_uninitialized_copy_bits(dest, first, last);
       } else {
@@ -655,12 +652,12 @@ class fbvector {
 
   // dispatch type trait
   typedef bool_constant<
-      folly::IsRelocatable<T>::value && usingStdAllocator::value>
+      folly::IsRelocatable<T>::value && usingStdAllocator>
       relocate_use_memcpy;
 
   typedef bool_constant<
       (std::is_nothrow_move_constructible<T>::value &&
-       usingStdAllocator::value) ||
+       usingStdAllocator) ||
       !std::is_copy_constructible<T>::value>
       relocate_use_move;
 
@@ -689,7 +686,7 @@ class fbvector {
 
   // done
   void relocate_done(T* /*dest*/, T* first, T* last) noexcept {
-    if (folly::IsRelocatable<T>::value && usingStdAllocator::value) {
+    if (folly::IsRelocatable<T>::value && usingStdAllocator) {
       // used memcpy; data has been relocated, do not call destructor
     } else {
       D_destroy_range_a(first, last);
@@ -698,11 +695,11 @@ class fbvector {
 
   // undo
   void relocate_undo(T* dest, T* first, T* last) noexcept {
-    if (folly::IsRelocatable<T>::value && usingStdAllocator::value) {
+    if (folly::IsRelocatable<T>::value && usingStdAllocator) {
       // used memcpy, old data is still valid, nothing to do
     } else if (
         std::is_nothrow_move_constructible<T>::value &&
-        usingStdAllocator::value) {
+        usingStdAllocator) {
       // noexcept move everything back, aka relocate_move
       relocate_move(first, dest, dest + (last - first));
     } else if (!std::is_copy_constructible<T>::value) {
@@ -769,7 +766,7 @@ class fbvector {
       return *this;
     }
 
-    if (!usingStdAllocator::value &&
+    if (!usingStdAllocator &&
         A::propagate_on_container_copy_assignment::value) {
       if (impl_ != other.impl_) {
         // can't use other's different allocator to clean up self
@@ -906,7 +903,7 @@ class fbvector {
 
   // contract dispatch for aliasing under VT optimization
   bool dataIsInternalAndNotVT(const T& t) {
-    if (should_pass_by_value::value) {
+    if (should_pass_by_value) {
       return false;
     }
     return dataIsInternal(t);
@@ -1042,7 +1039,7 @@ class fbvector {
     void* p = impl_.b_;
     // xallocx() will shrink to precisely newCapacityBytes (which was generated
     // by goodMallocSize()) if it successfully shrinks in place.
-    if ((usingJEMalloc() && usingStdAllocator::value) &&
+    if ((usingJEMalloc() && usingStdAllocator) &&
         newCapacityBytes >= folly::jemallocMinInPlaceExpandable &&
         xallocx(p, newCapacityBytes, 0, 0) == newCapacityBytes) {
       impl_.z_ += newCap - oldCap;
@@ -1070,7 +1067,7 @@ class fbvector {
 
  private:
   bool reserve_in_place(size_type n) {
-    if (!usingStdAllocator::value || !usingJEMalloc()) {
+    if (!usingStdAllocator || !usingJEMalloc()) {
       return false;
     }
 
@@ -1179,7 +1176,7 @@ class fbvector {
   }
 
   void swap(fbvector& other) noexcept {
-    if (!usingStdAllocator::value && A::propagate_on_container_swap::value) {
+    if (!usingStdAllocator && A::propagate_on_container_swap::value) {
       swap(impl_, other.impl_);
     } else {
       impl_.swapData(other.impl_);
@@ -1240,7 +1237,7 @@ class fbvector {
       if (last == end()) {
         M_destroy_range_e((iterator)first);
       } else {
-        if (folly::IsRelocatable<T>::value && usingStdAllocator::value) {
+        if (folly::IsRelocatable<T>::value && usingStdAllocator) {
           D_destroy_range_a((iterator)first, (iterator)last);
           if (last - first >= cend() - last) {
             std::memcpy((void*)first, (void*)last, (cend() - last) * sizeof(T));
@@ -1340,7 +1337,7 @@ class fbvector {
       relocate_done(position + n, position, impl_.e_);
       impl_.e_ += n;
     } else {
-      if (folly::IsRelocatable<T>::value && usingStdAllocator::value) {
+      if (folly::IsRelocatable<T>::value && usingStdAllocator) {
         std::memmove((void*)(position + n), (void*)position, tail * sizeof(T));
         impl_.e_ += n;
       } else {
@@ -1628,7 +1625,7 @@ template <class... Args>
 void fbvector<T, Allocator>::emplace_back_aux(Args&&... args) {
   size_type byte_sz =
       folly::goodMallocSize(computePushBackCapacity() * sizeof(T));
-  if (usingStdAllocator::value && usingJEMalloc() &&
+  if (usingStdAllocator && usingJEMalloc() &&
       ((impl_.z_ - impl_.b_) * sizeof(T) >=
        folly::jemallocMinInPlaceExpandable)) {
     // Try to reserve in place.
@@ -1660,7 +1657,7 @@ void fbvector<T, Allocator>::emplace_back_aux(Args&&... args) {
   auto newB = M_allocate(sz);
   auto newE = newB + size();
   try {
-    if (folly::IsRelocatable<T>::value && usingStdAllocator::value) {
+    if (folly::IsRelocatable<T>::value && usingStdAllocator) {
       // For linear memory access, relocate before construction.
       // By the test condition, relocate is noexcept.
       // Note that there is no cleanup to do if M_construct throws - that's


### PR DESCRIPTION
Summary:
- Some constant expressions are wrapped in a type carrying a bool, but
  are only used in value contexts. Remove the type wrapper
  (bool_constant) use and just use `constexpr bool` directly. This makes the
  usages not have to use `::value` everywhere.