### PR TITLE
Fix bootstrap-osx-homebrew.sh to work with CMake builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ folly is available as a Formula and releases may be built via `brew install foll
 You may also use `folly/build/bootstrap-osx-homebrew.sh` to build against `master`:
 
 ```
-  cd folly
-  ./build/bootstrap-osx-homebrew.sh
+  ./folly/build/bootstrap-osx-homebrew.sh
 ```
+
+This will create a build directory `_build` in the top-level.
 
 #### OS X (MacPorts)
 
@@ -164,9 +165,8 @@ Install the required packages from MacPorts:
 
 ```
   sudo port install \
-    autoconf \
-    automake \
     boost \
+    cmake \
     gflags \
     git \
     google-glog \
@@ -174,8 +174,9 @@ Install the required packages from MacPorts:
     libtool \
     lz4 \
     lzma \
-    scons \
+    openssl \
     snappy \
+    xz \
     zlib
 ```
 
@@ -193,9 +194,10 @@ Download and install folly with the parameters listed below:
 
 ```
   git clone https://github.com/facebook/folly.git
-  cd folly/folly
-  autoreconf -ivf
-  ./configure CPPFLAGS="-I/opt/local/include" LDFLAGS="-L/opt/local/lib"
+  cd folly
+  mkdir _build
+  cd _build
+  cmake ..
   make
   sudo make install
 ```

--- a/folly/build/bootstrap-osx-homebrew.sh
+++ b/folly/build/bootstrap-osx-homebrew.sh
@@ -5,8 +5,7 @@
 # fail fast
 set -e
 
-BASE_DIR="$(cd "$(dirname -- "$0")"/.. ; pwd)"  # folly/folly
-cd "$BASE_DIR"
+BUILD_DIR=${BUILD_DIR:-_build}
 
 # brew install alias
 brew_install() {
@@ -15,45 +14,52 @@ brew_install() {
 
 # install deps
 install_deps() {
-	# folly deps
-	dependencies=(autoconf automake libtool pkg-config double-conversion glog gflags boost libevent xz snappy lz4 jemalloc openssl)
+    # folly deps
+    dependencies=(
+        boost
+        cmake
+        double-conversion
+        gflags
+        glog
+        jemalloc
+        libevent
+        lz4
+        openssl
+        pkg-config
+        snappy
+        xz
+    )
 
-	# fetch deps
-	for dependency in "${dependencies[@]}"; do
-		brew_install "${dependency}"
-	done
+    # fetch deps
+    for dependency in "${dependencies[@]}"; do
+        brew_install "${dependency}"
+    done
 }
 
-# set env flags
-export_flags() {
-	# fetch opt dirs
-	OPT_GFLAGS=$(brew --prefix gflags)
-	OPT_OPENSSL=$(brew --prefix openssl)
-
-	# export flags
-	export LDFLAGS=-L${OPT_OPENSSL}/lib
-	export OPENSSL_INCLUDES=-I${OPT_OPENSSL}/include
-	export GFLAGS_LIBS=-L${OPT_GFLAGS}/lib
-	export GFLAGS_CFLAGS=-I${OPT_GFLAGS}/include
-}
-
-# now the fun part
 install_deps
-export_flags
-autoreconf -ivf
-./configure --disable-silent-rules --disable-dependency-tracking
+
+# Allows this script to be invoked from anywhere in the source tree but the
+# BUILD_DIR we create will always be in the top level folly directory
+TOP_LEVEL_DIR="$(cd "$(dirname -- "$0")"/../.. ; pwd)"  # folly
+cd "$TOP_LEVEL_DIR"
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+OPENSSL_INCLUDES=$(brew --prefix openssl)/include
+cmake \
+    -DOPENSSL_INCLUDE_DIR="${OPENSSL_INCLUDES}" \
+    "$@" \
+    ..
 
 # fetch googletest, if doesn't exist
-pushd test
 GTEST_VER=1.8.0
 GTEST_DIR=gtest-${GTEST_VER}
 if [ ! -d ${GTEST_DIR} ]; then
-	mkdir ${GTEST_DIR}
+    mkdir ${GTEST_DIR}
     curl -SL \
     	https://github.com/google/googletest/archive/release-${GTEST_VER}.tar.gz | \
     	tar -xvzf - --strip-components=1 -C ${GTEST_DIR}
 fi
-popd
 
 # make, test, install
 make


### PR DESCRIPTION
Summary:
- The `bootstrap-osx-homebrew.sh` script is out of date. It previously
  worked when Folly used Autotools, but was not updated when CMake
  replaced Autotools for the build system.
- Update dependencies to install.
- Do not export environment variables when it is not needed; simply pass the
  defines needed directly to the `cmake` invocation.
- Update `README.md` to specify correct dependencies with CMake build
  for both Homebrew and Macports.

Closes #1038