### PR TITLE
Compile error on Linux 2.6.32-754.6.3.el6.x86_64 /gcc 7.4/NetOps.cpp

### DIFF
--- a/FollyConfigChecks.cmake
+++ b/FollyConfigChecks.cmake
@@ -1,0 +1,245 @@
+include(CheckCXXSourceCompiles)
+include(CheckCXXSourceRuns)
+include(CheckFunctionExists)
+include(CheckIncludeFileCXX)
+include(CheckSymbolExists)
+include(CheckTypeSize)
+include(CheckCXXCompilerFlag)
+
+CHECK_INCLUDE_FILE_CXX(jemalloc/jemalloc.h FOLLY_USE_JEMALLOC)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+  # clang only rejects unknown warning flags if -Werror=unknown-warning-option
+  # is also specified.
+  CHECK_CXX_COMPILER_FLAG(
+    -Werror=unknown-warning-option
+    COMPILER_HAS_UNKNOWN_WARNING_OPTION)
+  if (COMPILER_HAS_UNKNOWN_WARNING_OPTION)
+    set(CMAKE_REQUIRED_FLAGS
+      "${CMAKE_REQUIRED_FLAGS} -Werror=unknown-warning-option")
+  endif()
+
+  CHECK_CXX_COMPILER_FLAG(-Wshadow-local COMPILER_HAS_W_SHADOW_LOCAL)
+  CHECK_CXX_COMPILER_FLAG(
+    -Wshadow-compatible-local
+    COMPILER_HAS_W_SHADOW_COMPATIBLE_LOCAL)
+  if (COMPILER_HAS_W_SHADOW_LOCAL AND COMPILER_HAS_W_SHADOW_COMPATIBLE_LOCAL)
+    set(FOLLY_HAVE_SHADOW_LOCAL_WARNINGS ON)
+    list(APPEND FOLLY_CXX_FLAGS -Wshadow-compatible-local)
+  endif()
+
+  CHECK_CXX_COMPILER_FLAG(-Wnoexcept-type COMPILER_HAS_W_NOEXCEPT_TYPE)
+  if (COMPILER_HAS_W_NOEXCEPT_TYPE)
+    list(APPEND FOLLY_CXX_FLAGS -Wno-noexcept-type)
+  endif()
+
+  CHECK_CXX_COMPILER_FLAG(
+      -Wnullability-completeness
+      COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
+  if (COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
+    list(APPEND FOLLY_CXX_FLAGS -Wno-nullability-completeness)
+  endif()
+
+  CHECK_CXX_COMPILER_FLAG(
+      -Winconsistent-missing-override
+      COMPILER_HAS_W_INCONSISTENT_MISSING_OVERRIDE)
+  if (COMPILER_HAS_W_INCONSISTENT_MISSING_OVERRIDE)
+    list(APPEND FOLLY_CXX_FLAGS -Wno-inconsistent-missing-override)
+  endif()
+
+  CHECK_CXX_COMPILER_FLAG(-faligned-new COMPILER_HAS_F_ALIGNED_NEW)
+  if (COMPILER_HAS_F_ALIGNED_NEW)
+    list(APPEND FOLLY_CXX_FLAGS -faligned-new)
+  endif()
+
+  CHECK_CXX_COMPILER_FLAG(-fopenmp COMPILER_HAS_F_OPENMP)
+  if (COMPILER_HAS_F_OPENMP)
+      list(APPEND FOLLY_CXX_FLAGS -fopenmp)
+  endif()
+endif()
+
+set(FOLLY_ORIGINAL_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+string(REGEX REPLACE
+  "-std=(c|gnu)\\+\\+.."
+  ""
+  CMAKE_REQUIRED_FLAGS
+  "${CMAKE_REQUIRED_FLAGS}")
+
+check_symbol_exists(pthread_atfork pthread.h FOLLY_HAVE_PTHREAD_ATFORK)
+
+# Unfortunately check_symbol_exists() does not work for memrchr():
+# it fails complaining that there are multiple overloaded versions of memrchr()
+check_function_exists(memrchr FOLLY_HAVE_MEMRCHR)
+check_symbol_exists(preadv sys/uio.h FOLLY_HAVE_PREADV)
+check_symbol_exists(pwritev sys/uio.h FOLLY_HAVE_PWRITEV)
+check_symbol_exists(clock_gettime time.h FOLLY_HAVE_CLOCK_GETTIME)
+check_symbol_exists(pipe2 unistd.h FOLLY_HAVE_PIPE2)
+check_symbol_exists(sendmmsg sys/socket.h FOLLY_HAVE_SENDMMSG)
+
+check_function_exists(malloc_usable_size FOLLY_HAVE_MALLOC_USABLE_SIZE)
+
+set(CMAKE_REQUIRED_FLAGS "${FOLLY_ORIGINAL_CMAKE_REQUIRED_FLAGS}")
+
+check_cxx_source_compiles("
+  #pragma GCC diagnostic error \"-Wattributes\"
+  extern \"C\" void (*test_ifunc(void))() { return 0; }
+  void func() __attribute__((ifunc(\"test_ifunc\")));
+  int main() { return 0; }"
+  FOLLY_HAVE_IFUNC
+)
+check_cxx_source_compiles("
+  #include <type_traits>
+  const bool val = std::is_trivially_copyable<bool>::value;
+  int main() { return 0; }"
+  FOLLY_HAVE_STD__IS_TRIVIALLY_COPYABLE
+)
+check_cxx_source_runs("
+  int main(int, char**) {
+    char buf[64] = {0};
+    unsigned long *ptr = (unsigned long *)(buf + 1);
+    *ptr = 0xdeadbeef;
+    return (*ptr & 0xff) == 0xef ? 0 : 1;
+  }"
+  FOLLY_HAVE_UNALIGNED_ACCESS
+)
+check_cxx_source_compiles("
+  int main(int argc, char** argv) {
+    unsigned size = argc;
+    char data[size];
+    return 0;
+  }"
+  FOLLY_HAVE_VLA
+)
+check_cxx_source_compiles("
+  extern \"C\" void configure_link_extern_weak_test() __attribute__((weak));
+  int main(int argc, char** argv) {
+    return configure_link_extern_weak_test == nullptr;
+  }"
+  FOLLY_HAVE_WEAK_SYMBOLS
+)
+check_cxx_source_runs("
+  #include <dlfcn.h>
+  int main() {
+    void *h = dlopen(\"linux-vdso.so.1\", RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);
+    if (h == nullptr) {
+      return -1;
+    }
+    dlclose(h);
+    return 0;
+  }"
+  FOLLY_HAVE_LINUX_VDSO
+)
+
+check_type_size(__int128 INT128_SIZE LANGUAGE CXX)
+if (NOT INT128_SIZE STREQUAL "")
+  set(FOLLY_HAVE_INT128_T ON)
+  check_cxx_source_compiles("
+    #include <functional>
+    #include <type_traits>
+    #include <utility>
+    static_assert(
+      ::std::is_same<::std::make_signed<unsigned __int128>::type,
+                     __int128>::value,
+      \"signed form of 'unsigned __uint128' must be '__int128'.\");
+    static_assert(
+        sizeof(::std::hash<__int128>{}(0)) > 0, \
+        \"std::hash<__int128> is disabled.\");
+    int main() { return 0; }"
+    HAVE_INT128_TRAITS
+  )
+  if (HAVE_INT128_TRAITS)
+    set(FOLLY_SUPPLY_MISSING_INT128_TRAITS OFF)
+  else()
+    set(FOLLY_SUPPLY_MISSING_INT128_TRAITS ON)
+  endif()
+endif()
+
+check_cxx_source_runs("
+  #include <cstddef>
+  #include <cwchar>
+  int main(int argc, char** argv) {
+    return wcstol(L\"01\", nullptr, 10) == 1 ? 0 : 1;
+  }"
+  FOLLY_HAVE_WCHAR_SUPPORT
+)
+
+check_cxx_source_compiles("
+  #include <ext/random>
+  int main(int argc, char** argv) {
+    __gnu_cxx::sfmt19937 rng;
+    return 0;
+  }"
+  FOLLY_HAVE_EXTRANDOM_SFMT19937
+)
+
+check_cxx_source_compiles("
+  #include <type_traits>
+  #if !_LIBCPP_VERSION
+  #error No libc++
+  #endif
+  int main() { return 0; }"
+  FOLLY_USE_LIBCPP
+)
+
+check_cxx_source_compiles("
+  #include <type_traits>
+  #if !__GLIBCXX__
+  #error No libstdc++
+  #endif
+  int main() { return 0; }"
+  FOLLY_USE_LIBSTDCPP
+)
+
+check_cxx_source_runs("
+  #include <string.h>
+  #include <errno.h>
+  int main(int argc, char** argv) {
+    char buf[1024];
+    buf[0] = 0;
+    int ret = strerror_r(ENOMEM, buf, sizeof(buf));
+    return ret;
+  }"
+  FOLLY_HAVE_XSI_STRERROR_R
+)
+
+check_cxx_source_runs("
+  #include <stdarg.h>
+  #include <stdio.h>
+
+  int call_vsnprintf(const char* fmt, ...) {
+    char buf[256];
+    va_list ap;
+    va_start(ap, fmt);
+    int result = vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    return result;
+  }
+
+  int main(int argc, char** argv) {
+    return call_vsnprintf(\"%\", 1) < 0 ? 0 : 1;
+  }"
+  HAVE_VSNPRINTF_ERRORS
+)
+
+if (FOLLY_HAVE_LIBGFLAGS)
+  # Older releases of gflags used the namespace "gflags"; newer releases
+  # use "google" but also make symbols available in the deprecated "gflags"
+  # namespace too.  The folly code internally uses "gflags" unless we tell it
+  # otherwise.
+  check_cxx_source_compiles("
+    #include <gflags/gflags.h>
+    int main() {
+      gflags::GetArgv();
+      return 0;
+    }
+    "
+    GFLAGS_NAMESPACE_IS_GFLAGS
+  )
+  if (GFLAGS_NAMESPACE_IS_GFLAGS)
+    set(FOLLY_UNUSUAL_GFLAGS_NAMESPACE OFF)
+    set(FOLLY_GFLAGS_NAMESPACE gflags)
+  else()
+    set(FOLLY_UNUSUAL_GFLAGS_NAMESPACE ON)
+    set(FOLLY_GFLAGS_NAMESPACE google)
+  endif()
+endif()

--- a/NetOps.h
+++ b/NetOps.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2013-present Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include <folly/net/NetworkSocket.h>
+#include <folly/portability/IOVec.h>
+#include <folly/portability/SysTypes.h>
+#include <folly/portability/Windows.h>
+
+#ifndef _WIN32
+#include <netdb.h>
+#include <poll.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#ifdef MSG_ERRQUEUE
+#define FOLLY_HAVE_MSG_ERRQUEUE 1
+/* for struct sock_extended_err*/
+#include <linux/errqueue.h>
+#endif
+
+#ifndef SO_EE_ORIGIN_ZEROCOPY
+#define SO_EE_ORIGIN_ZEROCOPY 5
+#endif
+
+#ifndef SO_EE_CODE_ZEROCOPY_COPIED
+#define SO_EE_CODE_ZEROCOPY_COPIED 1
+#endif
+
+#ifndef SO_ZEROCOPY
+#define SO_ZEROCOPY 60
+#endif
+
+#ifndef MSG_ZEROCOPY
+#define MSG_ZEROCOPY 0x4000000
+#endif
+
+#ifndef SOL_UDP
+#define SOL_UDP 17
+#endif
+
+#ifndef ETH_MAX_MTU
+#define ETH_MAX_MTU 0xFFFFU
+#endif
+
+#ifndef UDP_SEGMENT
+#define UDP_SEGMENT 103
+#endif
+
+#ifndef UDP_MAX_SEGMENTS
+#define UDP_MAX_SEGMENTS (1 << 6UL)
+#endif
+
+#if (!__linux__) || (defined(__ANDROID__) && (__ANDROID_API__ < 21))
+struct mmsghdr {
+  struct msghdr msg_hdr;
+  unsigned int msg_len;
+};
+#endif
+
+#else
+#include <WS2tcpip.h> // @manual
+
+using nfds_t = int;
+using sa_family_t = ADDRESS_FAMILY;
+
+// these are not supported
+#define SO_EE_ORIGIN_ZEROCOPY 0
+#define SO_ZEROCOPY 0
+#define MSG_ZEROCOPY 0x0
+#define SOL_UDP 0x0
+#define UDP_SEGMENT 0x0
+
+// We don't actually support either of these flags
+// currently.
+#define MSG_DONTWAIT 0x1000
+#define MSG_EOR 0
+struct msghdr {
+  void* msg_name;
+  socklen_t msg_namelen;
+  struct iovec* msg_iov;
+  size_t msg_iovlen;
+  void* msg_control;
+  size_t msg_controllen;
+  int msg_flags;
+};
+
+struct mmsghdr {
+  struct msghdr msg_hdr;
+  unsigned int msg_len;
+};
+
+struct sockaddr_un {
+  sa_family_t sun_family;
+  char sun_path[108];
+};
+
+#define SHUT_RD SD_RECEIVE
+#define SHUT_WR SD_SEND
+#define SHUT_RDWR SD_BOTH
+
+// These are the same, but PF_LOCAL
+// isn't defined by WinSock.
+#define AF_LOCAL PF_UNIX
+#define PF_LOCAL PF_UNIX
+
+// This isn't defined by Windows, and we need to
+// distinguish it from SO_REUSEADDR
+#define SO_REUSEPORT 0x7001
+
+// Someone thought it would be a good idea
+// to define a field via a macro...
+#undef s_host
+#endif
+
+namespace folly {
+namespace netops {
+// Poll descriptor is intended to be byte-for-byte identical to pollfd,
+// except that it is typed as containing a NetworkSocket for sane interactions.
+struct PollDescriptor {
+  NetworkSocket fd;
+  int16_t events;
+  int16_t revents;
+};
+
+NetworkSocket accept(NetworkSocket s, sockaddr* addr, socklen_t* addrlen);
+int bind(NetworkSocket s, const sockaddr* name, socklen_t namelen);
+int close(NetworkSocket s);
+int connect(NetworkSocket s, const sockaddr* name, socklen_t namelen);
+int getpeername(NetworkSocket s, sockaddr* name, socklen_t* namelen);
+int getsockname(NetworkSocket s, sockaddr* name, socklen_t* namelen);
+int getsockopt(
+    NetworkSocket s,
+    int level,
+    int optname,
+    void* optval,
+    socklen_t* optlen);
+int inet_aton(const char* cp, in_addr* inp);
+int listen(NetworkSocket s, int backlog);
+int poll(PollDescriptor fds[], nfds_t nfds, int timeout);
+ssize_t recv(NetworkSocket s, void* buf, size_t len, int flags);
+ssize_t recvfrom(
+    NetworkSocket s,
+    void* buf,
+    size_t len,
+    int flags,
+    sockaddr* from,
+    socklen_t* fromlen);
+ssize_t recvmsg(NetworkSocket s, msghdr* message, int flags);
+ssize_t send(NetworkSocket s, const void* buf, size_t len, int flags);
+ssize_t sendto(
+    NetworkSocket s,
+    const void* buf,
+    size_t len,
+    int flags,
+    const sockaddr* to,
+    socklen_t tolen);
+ssize_t sendmsg(NetworkSocket socket, const msghdr* message, int flags);
+int sendmmsg(
+    NetworkSocket socket,
+    mmsghdr* msgvec,
+    unsigned int vlen,
+    int flags);
+int setsockopt(
+    NetworkSocket s,
+    int level,
+    int optname,
+    const void* optval,
+    socklen_t optlen);
+int shutdown(NetworkSocket s, int how);
+NetworkSocket socket(int af, int type, int protocol);
+int socketpair(int domain, int type, int protocol, NetworkSocket sv[2]);
+
+// And now we diverge from the Posix way of doing things and just do things
+// our own way.
+int set_socket_non_blocking(NetworkSocket s);
+int set_socket_close_on_exec(NetworkSocket s);
+} // namespace netops
+} // namespace folly

--- a/folly-config.h.cmake
+++ b/folly-config.h.cmake
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#if !defined(FOLLY_MOBILE)
+#if defined(__ANDROID__) || \
+    (defined(__APPLE__) &&  \
+     (TARGET_IPHONE_SIMULATOR || TARGET_OS_SIMULATOR || TARGET_OS_IPHONE))
+#define FOLLY_MOBILE 1
+#else
+#define FOLLY_MOBILE 0
+#endif
+#endif // FOLLY_MOBILE
+
+#cmakedefine FOLLY_HAVE_PTHREAD 1
+#cmakedefine FOLLY_HAVE_PTHREAD_ATFORK 1
+
+#cmakedefine FOLLY_HAVE_LIBGFLAGS 1
+#cmakedefine FOLLY_UNUSUAL_GFLAGS_NAMESPACE 1
+#cmakedefine FOLLY_GFLAGS_NAMESPACE @FOLLY_GFLAGS_NAMESPACE@
+
+#cmakedefine FOLLY_HAVE_LIBGLOG 1
+
+#cmakedefine FOLLY_USE_JEMALLOC 1
+#cmakedefine FOLLY_USE_LIBSTDCPP 1
+
+#if __has_include(<features.h>)
+#include <features.h>
+#endif
+
+#cmakedefine FOLLY_HAVE_MEMRCHR 1
+#cmakedefine FOLLY_HAVE_PREADV 1
+#cmakedefine FOLLY_HAVE_PWRITEV 1
+#cmakedefine FOLLY_HAVE_CLOCK_GETTIME 1
+#cmakedefine FOLLY_HAVE_PIPE2 1
+#cmakedefine FOLLY_HAVE_OPENSSL_ASN1_TIME_DIFF 1
+
+#cmakedefine FOLLY_HAVE_IFUNC 1
+#cmakedefine FOLLY_HAVE_STD__IS_TRIVIALLY_COPYABLE 1
+#cmakedefine FOLLY_HAVE_UNALIGNED_ACCESS 1
+#cmakedefine FOLLY_HAVE_VLA 1
+#cmakedefine FOLLY_HAVE_WEAK_SYMBOLS 1
+#cmakedefine FOLLY_HAVE_LINUX_VDSO 1
+#cmakedefine FOLLY_HAVE_MALLOC_USABLE_SIZE 1
+#cmakedefine FOLLY_HAVE_INT128_T 1
+#cmakedefine FOLLY_SUPPLY_MISSING_INT128_TRAITS 1
+#cmakedefine FOLLY_HAVE_WCHAR_SUPPORT 1
+#cmakedefine FOLLY_HAVE_EXTRANDOM_SFMT19937 1
+#cmakedefine FOLLY_USE_LIBCPP 1
+#cmakedefine FOLLY_HAVE_XSI_STRERROR_R 1
+#cmakedefine HAVE_VSNPRINTF_ERRORS 1
+
+#cmakedefine FOLLY_USE_SYMBOLIZER 1
+#define FOLLY_DEMANGLE_MAX_SYMBOL_SIZE 1024
+
+#cmakedefine FOLLY_HAVE_SHADOW_LOCAL_WARNINGS 1
+
+#cmakedefine FOLLY_HAVE_LIBLZ4 1
+#cmakedefine FOLLY_HAVE_LIBLZMA 1
+#cmakedefine FOLLY_HAVE_LIBSNAPPY 1
+#cmakedefine FOLLY_HAVE_LIBZ 1
+#cmakedefine FOLLY_HAVE_LIBZSTD 1
+#cmakedefine FOLLY_HAVE_LIBBZ2 1
+
+#cmakedefine FOLLY_ASAN_ENABLED 1
+
+#cmakedefine FOLLY_SUPPORT_SHARED_LIBRARY 1
+#cmakedefine FOLLY_HAVE_SENDMMSG 1


### PR DESCRIPTION
Compile error on Linux 2.6.32-754.6.3.el6.x86_64 /gcc 7.4/NetOps.cpp (issue #1011)

added below in NetOps.h

#ifndef FOLLY_HAVE_SENDMMSG
#define FOLLY_HAVE_SENDMMSG 1
#endif