### PR TITLE
Replace Not with folly::Negation in PolyDetail.h

### DIFF
--- a/folly/Poly.h
+++ b/folly/Poly.h
@@ -422,7 +422,7 @@ constexpr bool poly_empty(Poly<I&> const&) noexcept {
  */
 template <
     class I,
-    std::enable_if_t<detail::Not<std::is_reference<I>>::value, int> = 0>
+    std::enable_if_t<Negation<std::is_reference<I>>::value, int> = 0>
 constexpr Poly<I>&& poly_move(detail::PolyRoot<I>& that) noexcept {
   return static_cast<Poly<I>&&>(static_cast<Poly<I>&>(that));
 }
@@ -430,7 +430,7 @@ constexpr Poly<I>&& poly_move(detail::PolyRoot<I>& that) noexcept {
 /// \overload
 template <
     class I,
-    std::enable_if_t<detail::Not<std::is_const<I>>::value, int> = 0>
+    std::enable_if_t<Negation<std::is_const<I>>::value, int> = 0>
 Poly<I&&> poly_move(detail::PolyRoot<I&> const& that) noexcept {
   return detail::PolyAccess::move(that);
 }

--- a/folly/detail/PolyDetail.h
+++ b/folly/detail/PolyDetail.h
@@ -190,9 +190,6 @@ struct IsInstanceOf : std::false_type {};
 template <class... Ts, template <class...> class U>
 struct IsInstanceOf<U<Ts...>, U> : std::true_type {};
 
-template <class T>
-using Not = Bool<!T::value>;
-
 template <class Then>
 decltype(auto) if_constexpr(std::true_type, Then then) {
   return then(Identity{});
@@ -604,7 +601,7 @@ void* execOnHeap(Op op, Data* from, void* to) {
 template <
     class I,
     class T,
-    std::enable_if_t<Not<std::is_reference<T>>::value, int> = 0>
+    std::enable_if_t<Negation<std::is_reference<T>>::value, int> = 0>
 void* execOnHeap(Op op, Data* from, void* to) {
   switch (op) {
     case Op::eNuke:
@@ -901,7 +898,7 @@ template <
     class T,
     class I,
     class U = std::decay_t<T>,
-    std::enable_if_t<Not<std::is_base_of<PolyBase, U>>::value, int> = 0,
+    std::enable_if_t<Negation<std::is_base_of<PolyBase, U>>::value, int> = 0,
     std::enable_if_t<std::is_constructible<AddCvrefOf<U, I>, T>::value, int> =
         0,
     class = MembersOf<std::decay_t<I>, U>>


### PR DESCRIPTION
Summary:
- Replace `Not` template alias from `PolyDetail.h` with `folly::Negation` from
 `folly/Traits.h` which does the same thing.