### PR TITLE
Cut remove_cvref_t from pushmi/traits.h

### DIFF
--- a/folly/experimental/pushmi/traits.h
+++ b/folly/experimental/pushmi/traits.h
@@ -75,9 +75,6 @@ PUSHMI_INLINE_VAR constexpr int sum_v = detail::sum_impl<Is...>();
 template <class...>
 struct typelist;
 
-template <class T>
-using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
-
 PUSHMI_CONCEPT_DEF(
   template(class... Args)
   (concept True)(Args...),


### PR DESCRIPTION
Summary:
- Remove `remove_cvref_t` alias template from `pusmhi/traits.h` in favor of
  `folly::remove_cvref_t` from `folly/Traits.h` which is the same
  definition.