### PR TITLE
Add missing gflags #include in tests

### DIFF
--- a/folly/concurrency/test/ConcurrentHashMapTest.cpp
+++ b/folly/concurrency/test/ConcurrentHashMapTest.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 
 #include <folly/hash/Hash.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 #include <folly/test/DeterministicSchedule.h>
 

--- a/folly/concurrency/test/DynamicBoundedQueueTest.cpp
+++ b/folly/concurrency/test/DynamicBoundedQueueTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/concurrency/DynamicBoundedQueue.h>
 #include <folly/MPMCQueue.h>
 #include <folly/ProducerConsumerQueue.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 #include <glog/logging.h>

--- a/folly/concurrency/test/UnboundedQueueTest.cpp
+++ b/folly/concurrency/test/UnboundedQueueTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/concurrency/UnboundedQueue.h>
 #include <folly/MPMCQueue.h>
 #include <folly/ProducerConsumerQueue.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 #include <boost/thread/barrier.hpp>

--- a/folly/experimental/test/BitsTest.cpp
+++ b/folly/experimental/test/BitsTest.cpp
@@ -20,6 +20,7 @@
 
 #include <glog/logging.h>
 
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 using namespace folly;

--- a/folly/gen/test/CombineTest.cpp
+++ b/folly/gen/test/CombineTest.cpp
@@ -21,6 +21,7 @@
 #include <folly/Range.h>
 #include <folly/gen/Base.h>
 #include <folly/gen/Combine.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 using namespace folly::gen;

--- a/folly/gen/test/ParallelMapTest.cpp
+++ b/folly/gen/test/ParallelMapTest.cpp
@@ -21,6 +21,7 @@
 #include <folly/Memory.h>
 #include <folly/gen/Base.h>
 #include <folly/gen/ParallelMap.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 using namespace folly;

--- a/folly/gen/test/ParallelTest.cpp
+++ b/folly/gen/test/ParallelTest.cpp
@@ -23,6 +23,7 @@
 
 #include <folly/gen/Base.h>
 #include <folly/gen/Parallel.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 using namespace folly;

--- a/folly/memory/test/ArenaTest.cpp
+++ b/folly/memory/test/ArenaTest.cpp
@@ -16,6 +16,7 @@
 
 #include <folly/memory/Arena.h>
 #include <folly/Memory.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 #include <set>

--- a/folly/synchronization/test/SmallLocksTest.cpp
+++ b/folly/synchronization/test/SmallLocksTest.cpp
@@ -28,6 +28,7 @@
 
 #include <folly/Random.h>
 #include <folly/portability/Asm.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 #include <folly/portability/PThread.h>
 #include <folly/portability/Unistd.h>

--- a/folly/test/AtomicBitSetTest.cpp
+++ b/folly/test/AtomicBitSetTest.cpp
@@ -16,6 +16,7 @@
 
 #include <folly/AtomicBitSet.h>
 
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 #include <glog/logging.h>

--- a/folly/test/FormatOtherTest.cpp
+++ b/folly/test/FormatOtherTest.cpp
@@ -23,6 +23,7 @@
 #include <folly/Portability.h>
 #include <folly/dynamic.h>
 #include <folly/json.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 #include <folly/small_vector.h>
 

--- a/folly/test/MPMCPipelineTest.cpp
+++ b/folly/test/MPMCPipelineTest.cpp
@@ -22,6 +22,7 @@
 #include <glog/logging.h>
 
 #include <folly/Conv.h>
+#include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
 namespace folly {


### PR DESCRIPTION
Some tests fail to compile because gflags.h is not included:

    .../folly/test/FormatOtherTest.cpp: In function 'int main(int, char**)':
    .../folly/test/FormatOtherTest.cpp:113:3: error: 'gflags' has not been declared
       gflags::ParseCommandLineFlags(&argc, &argv, true);
       ^~~~~~

The tests compile without issue on Travis CI without this patch, but I
don't see how that's possible.

Include gflags.h explicitly to fix the compilation of these tests.