### PR TITLE
moved FOLLY_HAVE_SENDMMSG to FollyConfigChecks.cmake for issue #1011

### DIFF
--- a/CMake/FollyConfigChecks.cmake
+++ b/CMake/FollyConfigChecks.cmake
@@ -74,6 +74,7 @@ check_symbol_exists(preadv sys/uio.h FOLLY_HAVE_PREADV)
 check_symbol_exists(pwritev sys/uio.h FOLLY_HAVE_PWRITEV)
 check_symbol_exists(clock_gettime time.h FOLLY_HAVE_CLOCK_GETTIME)
 check_symbol_exists(pipe2 unistd.h FOLLY_HAVE_PIPE2)
+check_symbol_exists(sendmmsg sys/socket.h FOLLY_HAVE_SENDMMSG)
 
 check_function_exists(malloc_usable_size FOLLY_HAVE_MALLOC_USABLE_SIZE)
 

--- a/CMake/FollyConfigChecks.cmake
+++ b/CMake/FollyConfigChecks.cmake
@@ -75,6 +75,7 @@ check_symbol_exists(pwritev sys/uio.h FOLLY_HAVE_PWRITEV)
 check_symbol_exists(clock_gettime time.h FOLLY_HAVE_CLOCK_GETTIME)
 check_symbol_exists(pipe2 unistd.h FOLLY_HAVE_PIPE2)
 check_symbol_exists(sendmmsg sys/socket.h FOLLY_HAVE_SENDMMSG)
+check_symbol_exists(recvmmsg sys/socket.h FOLLY_HAVE_RECVMMSG)
 
 check_function_exists(malloc_usable_size FOLLY_HAVE_MALLOC_USABLE_SIZE)
 

--- a/CMake/folly-config.h.cmake
+++ b/CMake/folly-config.h.cmake
@@ -79,3 +79,4 @@
 #cmakedefine FOLLY_ASAN_ENABLED 1
 
 #cmakedefine FOLLY_SUPPORT_SHARED_LIBRARY 1
+#cmakedefine FOLLY_HAVE_SENDMMSG 1

--- a/CMake/folly-config.h.cmake
+++ b/CMake/folly-config.h.cmake
@@ -80,3 +80,4 @@
 
 #cmakedefine FOLLY_SUPPORT_SHARED_LIBRARY 1
 #cmakedefine FOLLY_HAVE_SENDMMSG 1
+#cmakedefine FOLLY_HAVE_RECVMMSG 1

--- a/folly/net/NetOps.h
+++ b/folly/net/NetOps.h
@@ -18,6 +18,7 @@
 
 #include <cstdint>
 
+#include <folly/Portability.h>
 #include <folly/net/NetworkSocket.h>
 #include <folly/portability/IOVec.h>
 #include <folly/portability/SysTypes.h>
@@ -71,7 +72,7 @@
 #define UDP_MAX_SEGMENTS (1 << 6UL)
 #endif
 
-#if (!__linux__) || (defined(__ANDROID__) && (__ANDROID_API__ < 21))
+#if !(FOLLY_HAVE_RECVMMSG || FOLLY_HAVE_SENDMMSG)
 struct mmsghdr {
   struct msghdr msg_hdr;
   unsigned int msg_len;

--- a/folly/net/NetOps.h
+++ b/folly/net/NetOps.h
@@ -76,8 +76,6 @@ struct mmsghdr {
   struct msghdr msg_hdr;
   unsigned int msg_len;
 };
-#else
-#define FOLLY_HAVE_SENDMMSG 1
 #endif
 
 #else


### PR DESCRIPTION
Compile error on Linux 2.6.32-754.6.3.el6.x86_64 /gcc 7.4/NetOps.cpp (issue #1011)