### PR TITLE
Fix shellcheck warnings on docker_build_with_ccache.sh

### DIFF
--- a/build/fbcode_builder/docker_build_with_ccache.sh
+++ b/build/fbcode_builder/docker_build_with_ccache.sh
@@ -66,7 +66,7 @@ if [[ "$build_timeout" != "" ]] ; then
     echo "Build timed out after $build_timeout" 1>&2
     while true; do
       maybe_container=$(
-        egrep '^( ---> Running in [0-9a-f]+|FBCODE_BUILDER_EXIT)$' "$logfile" |
+        grep -E '^( ---> Running in [0-9a-f]+|FBCODE_BUILDER_EXIT)$' "$logfile" |
           tail -n 1 | awk '{print $NF}'
       )
       if [[ "$maybe_container" == "FBCODE_BUILDER_EXIT" ]] ; then
@@ -109,7 +109,7 @@ if [[ "$img" == "" ]] ; then
   # the build command itself, but since our builds aren't **trying** to
   # break cache, we probably won't randomly hit an ID from another build.
   img=$(
-    egrep '^ ---> (Running in [0-9a-f]+|[0-9a-f]+)$' "$logfile" | tac |
+    grep -E  '^ ---> (Running in [0-9a-f]+|[0-9a-f]+)$' "$logfile" | tac |
       sed 's/Running in /container_/;s/ ---> //;' | (
         while read -r x ; do
           # Both docker commands below print an image ID to stdout on


### PR DESCRIPTION
Summary:
- Fix a few shellcheck warnings on `docker_build_with_ccache.sh`.
- This will help when new changes are made to this script as
  shellcheck is run internally.