### PR TITLE
Remove unnecessary typename in F14Table.h

### DIFF
--- a/folly/container/detail/F14Table.h
+++ b/folly/container/detail/F14Table.h
@@ -226,7 +226,7 @@ using VoidDefault =
 
 template <typename Arg, typename Default>
 using Defaulted =
-    typename std::conditional_t<std::is_same<Arg, void>::value, Default, Arg>;
+    std::conditional_t<std::is_same<Arg, void>::value, Default, Arg>;
 
 template <
     typename TableKey,


### PR DESCRIPTION
Summary:
- Remove unneeded typename for a using alias in `F14Table.h`.