### PR TITLE
Fix shellcheck warnings for bootstrap-osx-homebrew.sh

### DIFF
--- a/folly/build/bootstrap-osx-homebrew.sh
+++ b/folly/build/bootstrap-osx-homebrew.sh
@@ -10,7 +10,7 @@ cd "$BASE_DIR"
 
 # brew install alias
 brew_install() {
-    brew install $@ || brew upgrade $@
+    brew install "$@" || brew upgrade "$@"
 }
 
 # install deps
@@ -19,8 +19,8 @@ install_deps() {
 	dependencies=(autoconf automake libtool pkg-config double-conversion glog gflags boost libevent xz snappy lz4 jemalloc openssl)
 
 	# fetch deps
-	for dependency in ${dependencies[@]}; do
-		brew_install ${dependency}
+	for dependency in "${dependencies[@]}"; do
+		brew_install "${dependency}"
 	done
 }
 


### PR DESCRIPTION
Summary:
- Fix a few shellcheck warnings on `bootstrap-osx-homebrew.sh`.
- This will help when new changes are made to this script as
  shellcheck is run internally.