### PR TITLE
Cut unneeded overload of computeHelper in F14Table.h

### DIFF
--- a/folly/container/detail/F14Table.h
+++ b/folly/container/detail/F14Table.h
@@ -108,10 +108,6 @@ struct F14TableStats {
     return m->computeStats();
   }
 
-  static F14TableStats computeHelper(...) {
-    return {};
-  }
-
  public:
   template <typename T>
   static F14TableStats compute(T const& m) {


### PR DESCRIPTION
Summary:
- `computeHelper` has two overloads for making sure a type `T` has a
  member function `computeStats`, so that the calls from `compute` are
  SFINAE-friendly.
- However, the `computeHelper(...)` overload is not needed since the trailing return
  type of `computeHelper(T*)` is already a SFINAE-mechanism which achieves
  the same thing of making sure `m->computeStats()` is a well-defined
  call before calling it.