### PR TITLE
Contains with precomputed hash for F14Map and F14Set

### DIFF
--- a/folly/container/F14Map.h
+++ b/folly/container/F14Map.h
@@ -833,6 +833,18 @@ class F14BasicMap {
     return !table_.find(key).atEnd();
   }
 
+  FOLLY_ALWAYS_INLINE bool contains(
+      F14HashToken const& token,
+      key_type const& key) const {
+    return !table_.find(token, key).atEnd();
+  }
+
+  template <typename K>
+  FOLLY_ALWAYS_INLINE EnableHeterogeneousFind<K, bool> contains(
+      F14HashToken const& token, K const& key) const {
+    return !table_.find(token, key).atEnd();
+  }
+
   std::pair<iterator, iterator> equal_range(key_type const& key) {
     return equal_range(*this, key);
   }

--- a/folly/container/F14Set.h
+++ b/folly/container/F14Set.h
@@ -615,6 +615,18 @@ class F14BasicSet {
     return !table_.find(key).atEnd();
   }
 
+  FOLLY_ALWAYS_INLINE bool contains(
+      F14HashToken const& token,
+      key_type const& key) const {
+    return !table_.find(token, key).atEnd();
+  }
+
+  template <typename K>
+  FOLLY_ALWAYS_INLINE EnableHeterogeneousFind<K, bool> contains(
+      F14HashToken const& token, K const& key) const {
+    return !table_.find(token, key).atEnd();
+  }
+
   std::pair<iterator, iterator> equal_range(key_type const& key) {
     return equal_range(*this, key);
   }

--- a/folly/container/test/F14MapTest.cpp
+++ b/folly/container/test/F14MapTest.cpp
@@ -1315,13 +1315,20 @@ TEST(F14ValueMap, heterogeneousLookup) {
     EXPECT_TRUE(ref.end() == ref.find(buddy));
     EXPECT_EQ(hello, ref.find(hello)->first);
 
+    const auto buddyHashToken = ref.prehash(buddy);
+    const auto helloHashToken = ref.prehash(hello);
+
     // prehash + find
-    EXPECT_TRUE(ref.end() == ref.find(ref.prehash(buddy), buddy));
-    EXPECT_EQ(hello, ref.find(ref.prehash(hello), hello)->first);
+    EXPECT_TRUE(ref.end() == ref.find(buddyHashToken, buddy));
+    EXPECT_EQ(hello, ref.find(helloHashToken, hello)->first);
 
     // contains
     EXPECT_FALSE(ref.contains(buddy));
     EXPECT_TRUE(ref.contains(hello));
+
+    // contains with prehash
+    EXPECT_FALSE(ref.contains(buddyHashToken, buddy));
+    EXPECT_TRUE(ref.contains(helloHashToken, hello));
 
     // equal_range
     EXPECT_TRUE(std::make_pair(ref.end(), ref.end()) == ref.equal_range(buddy));
@@ -1747,6 +1754,26 @@ TEST(F14Map, continuousCapacityBig3) {
 TEST(F14Map, continuousCapacityF12) {
   runContinuousCapacityTest<folly::F14VectorMap<uint16_t, uint16_t>>(
       0xfff0, 0xfffe);
+}
+
+template<template<class...> class TMap>
+void testContainsWithPrecomputedHash()
+{
+  TMap<int, int> m{};
+  const auto key{1};
+  m.insert({key, 1});
+  const auto hashToken = m.prehash(key);
+  EXPECT_TRUE(m.contains(hashToken, key));
+  const auto otherKey{2};
+  const auto hashTokenNotFound = m.prehash(otherKey);
+  EXPECT_FALSE(m.contains(hashTokenNotFound, otherKey));
+}
+
+TEST(F14Map, containsWithPrecomputedHash) {
+  testContainsWithPrecomputedHash<F14ValueMap>();
+  testContainsWithPrecomputedHash<F14VectorMap>();
+  testContainsWithPrecomputedHash<F14NodeMap>();
+  testContainsWithPrecomputedHash<F14FastMap>();
 }
 
 ///////////////////////////////////

--- a/folly/container/test/F14SetTest.cpp
+++ b/folly/container/test/F14SetTest.cpp
@@ -989,13 +989,20 @@ TEST(F14ValueSet, heterogeneous) {
     EXPECT_TRUE(ref.end() == ref.find(buddy));
     EXPECT_EQ(hello, *ref.find(hello));
 
+    const auto buddyHashToken = ref.prehash(buddy);
+    const auto helloHashToken = ref.prehash(hello);
+
     // prehash + find
-    EXPECT_TRUE(ref.end() == ref.find(ref.prehash(buddy), buddy));
-    EXPECT_EQ(hello, *ref.find(ref.prehash(hello), hello));
+    EXPECT_TRUE(ref.end() == ref.find(buddyHashToken, buddy));
+    EXPECT_EQ(hello, *ref.find(helloHashToken, hello));
 
     // contains
     EXPECT_FALSE(ref.contains(buddy));
     EXPECT_TRUE(ref.contains(hello));
+
+    // contains with prehash
+    EXPECT_FALSE(ref.contains(buddyHashToken, buddy));
+    EXPECT_TRUE(ref.contains(helloHashToken, hello));
 
     // equal_range
     EXPECT_TRUE(std::make_pair(ref.end(), ref.end()) == ref.equal_range(buddy));
@@ -1340,6 +1347,26 @@ TEST(F14Set, randomInsertOrder) {
   runRandomInsertOrderTest<F14FastSet<std::string>>([](char x) {
     return std::string{std::size_t{1}, x};
   });
+}
+
+template<template<class...> class TSet>
+void testContainsWithPrecomputedHash()
+{
+  TSet<int> m{};
+  const auto key{1};
+  m.insert(key);
+  const auto hashToken = m.prehash(key);
+  EXPECT_TRUE(m.contains(hashToken, key));
+  const auto otherKey{2};
+  const auto hashTokenNotFound = m.prehash(otherKey);
+  EXPECT_FALSE(m.contains(hashTokenNotFound, otherKey));
+}
+
+TEST(F14Set, containsWithPrecomputedHash) {
+  testContainsWithPrecomputedHash<F14ValueSet>();
+  testContainsWithPrecomputedHash<F14NodeSet>();
+  testContainsWithPrecomputedHash<F14VectorSet>();
+  testContainsWithPrecomputedHash<F14FastSet>();
 }
 
 ///////////////////////////////////


### PR DESCRIPTION
Summary:
- Implement `contains(key_type const& key, F14HashToken const& token)` similar
  to the C++20 `contains(key_type const& key, size_t hash)` interface.

Note:
- This is slightly different than the existing interfaces on F14
  containers, as they usually accept the `F14HashToken` as the first
  function parameter. We chose it as the second parameter to be "closer"
  to the C++20 member functions which take a precomputed hash as the
  second argument.