### PR TITLE
Use feature test macro for deduction guide in Replaceable.h

### DIFF
--- a/folly/Replaceable.h
+++ b/folly/Replaceable.h
@@ -640,8 +640,7 @@ class alignas(T) Replaceable
   aligned_storage_for_t<T> storage_[1];
 };
 
-#if __cplusplus > 201402L
-// C++17 allows us to define a deduction guide:
+#if __cpp_deduction_guides >= 201703 || _MSC_VER
 template <class T>
 Replaceable(T)->Replaceable<T>;
 #endif


### PR DESCRIPTION
Summary:
- Replace a check for deduction guide support to use a feature test macro
  for deduction guides rather than a check using `__cplusplus` directive.
- The existing check using the `__cplusplus` directive is not correct
  for GCC 5.1. With GCC 5.1, `__cplusplus > 201402L` will be true, but the check
  for `#if __cpp_deduction_guides >= 201703` will be false. So, it is
  not valid to just rely on the `__cplusplus` directive to infer
  deduction guide support.
- We extend the check to use the feature test macro except in the case
  of MSVC, which we infer the feature is supported. MSVC does not define
  feature test macros, despite having implemented the feature.