### PR TITLE
Set CMake policy CMP0075 to respect CMAKE_REQUIRED_LIBRARIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ if (POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif()
 
+# CMP0075 Include file check macros honor CMAKE_REQUIRED_LIBRARIES
+if(POLICY CMP0075)
+  cmake_policy(SET CMP0075 NEW)
+endif()
+
 # includes
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
Summary:
- For CMake 3.12 and above, CMP0075 is available which allows the macro
  `check_include_file`, `check_include_files`, and `check_include_files_cxx`
  to prefer to link the check executable to the libraries listed in the
  `CMAKE_REQUIRED_LIBRARIES` variable.
- For CMake 3.13.4, not having this policy set results in a warning such
  as the one below.

```
CMake Warning (dev) at /usr/local/Cellar/cmake/3.14.0/share/cmake/Modules/CheckIncludeFileCXX.cmake:79 (message):
  Policy CMP0075 is not set: Include file check macros honor
  CMAKE_REQUIRED_LIBRARIES.  Run "cmake --help-policy CMP0075" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  CMAKE_REQUIRED_LIBRARIES is set to:

    Threads::Threads;gflags_shared;/usr/lib/libssl.dylib;/usr/local/Cellar/openssl/1.0.2q/lib/libcrypto.dylib

  For compatibility with CMake 3.11 and below this check is ignoring it.
Call Stack (most recent call first):
  CMake/folly-deps.cmake:144 (CHECK_INCLUDE_FILE_CXX)
  CMakeLists.txt:90 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

- This patch sets the policy to the new behavior which means we will
  honor `CMAKE_REQUIRED_LIBRARIES` in the include file check macros now.
- The warning is now gone for those using CMake 3.13.4 or later.