### PR TITLE
Fix macOS 10.14 build: compile hash/detail files with -mpclmul

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,30 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
   )
 endif()
 
+set(PCLMUL_FILES
+  ${FOLLY_DIR}/hash/detail/ChecksumDetail.cpp
+  ${FOLLY_DIR}/hash/detail/Crc32CombineDetail.cpp
+  ${FOLLY_DIR}/hash/detail/Crc32cDetail.cpp
+)
+CHECK_CXX_COMPILER_FLAG(-mpclmul COMPILER_HAS_M_PCLMUL)
+if (COMPILER_HAS_M_PCLMUL)
+  message(
+    STATUS
+    "compiler has flag pclmul, setting compile flag for ${PCLMUL_FILES}"
+  )
+  set_source_files_properties(
+    ${PCLMUL_FILES}
+    PROPERTIES
+    COMPILE_OPTIONS
+    -mpclmul
+  )
+else()
+  message(
+    STATUS
+    "compiler does not have flag pclmul, skipping setting compile flags for ${PCLMUL_FILES}"
+  )
+endif()
+
 add_library(folly_base OBJECT
   ${files} ${hfiles}
   ${CMAKE_CURRENT_BINARY_DIR}/folly/folly-config.h


### PR DESCRIPTION
The macOS 10.14 build is failing in homebrew with some compilation errors in the hash/detail files:

* https://github.com/Homebrew/homebrew-core/pull/37954
* https://jenkins.brew.sh/job/Homebrew%20Core%20Pull%20Requests/39386/version=mojave/testReport/junit/brew-test-bot/mojave/install___build_bottle_folly/
* https://github.com/Homebrew/homebrew-core/pull/35982

~~~
/tmp/folly-20190114-14797-1m0rah5/folly-2019.01.07.00/folly/hash/detail/ChecksumDetail.cpp:181:28:
 error: '__builtin_ia32_pclmulqdq128' needs target feature pclmul
    y0 = _mm_xor_si128(y0, _mm_clmulepi64_si128(x0, multipliers_4, 0x00));
                           ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/10.0.0/include/__wmmintrin_pclmul.h:54:13: note: expanded from macro '_mm_clmulepi64_si128'
  ((__m128i)__builtin_ia32_pclmulqdq128((__v2di)(__m128i)(__X), \
            ^
~~~

I noticed a comment by @passy in https://github.com/facebook/flipper/pull/125 referencing this same error message "needs target feature pclmul", and the comment also said that it "should be easily fixable by ensuring that -mpclmul is added to the CFLAGS". I had trouble identifying the system architecture as he suggested, but figured that we could just check if the compiler supports that flag and add it for those specific source files if so.

This fixes the 10.14 build for me. It would be nice to set up CI to keep this build working, but it's difficult to currently set up CI for 10.14 without your own hardware, since travis and azure pipelines only support up to 10.13.