### PR TITLE
Implement erase_if for F14 containers

### DIFF
--- a/folly/container/F14Map.h
+++ b/folly/container/F14Map.h
@@ -1490,4 +1490,28 @@ void swap(
   lhs.swap(rhs);
 }
 
+template <typename K, typename M, typename H, typename E, typename A,
+          typename Pred>
+void erase_if(F14ValueMap<K, M, H, E, A>& c, Pred pred) {
+  f14::detail::erase_if_impl(c, pred);
+}
+
+template <typename K, typename M, typename H, typename E, typename A,
+          typename Pred>
+void erase_if(F14NodeMap<K, M, H, E, A>& c, Pred pred) {
+  f14::detail::erase_if_impl(c, pred);
+}
+
+template <typename K, typename M, typename H, typename E, typename A,
+          typename Pred>
+void erase_if(F14VectorMap<K, M, H, E, A>& c, Pred pred) {
+  f14::detail::erase_if_impl(c, pred);
+}
+
+template <typename K, typename M, typename H, typename E, typename A,
+          typename Pred>
+void erase_if(F14FastMap<K, M, H, E, A>& c, Pred pred) {
+  f14::detail::erase_if_impl(c, pred);
+}
+
 } // namespace folly

--- a/folly/container/F14Set.h
+++ b/folly/container/F14Set.h
@@ -1225,4 +1225,24 @@ void swap(F14FastSet<K, H, E, A>& lhs, F14FastSet<K, H, E, A>& rhs) noexcept(
     noexcept(lhs.swap(rhs))) {
   lhs.swap(rhs);
 }
+
+template <typename K, typename H, typename E, typename A, typename Pred>
+void erase_if(F14ValueSet<K, H, E, A>& c, Pred pred) {
+  f14::detail::erase_if_impl(c, pred);
+}
+
+template <typename K, typename H, typename E, typename A, typename Pred>
+void erase_if(F14NodeSet<K, H, E, A>& c, Pred pred) {
+  f14::detail::erase_if_impl(c, pred);
+}
+
+template <typename K, typename H, typename E, typename A, typename Pred>
+void erase_if(F14VectorSet<K, H, E, A>& c, Pred pred) {
+  f14::detail::erase_if_impl(c, pred);
+}
+
+template <typename K, typename H, typename E, typename A, typename Pred>
+void erase_if(F14FastSet<K, H, E, A>& c, Pred pred) {
+  f14::detail::erase_if_impl(c, pred);
+}
 } // namespace folly

--- a/folly/container/detail/F14Table.h
+++ b/folly/container/detail/F14Table.h
@@ -187,6 +187,16 @@ struct StdNodeReplica<
 
 #endif
 
+template <class Container, class Predicate>
+void erase_if_impl(Container& c, Predicate& predicate) {
+  for (auto i = c.begin(), last = c.end(); i != last;) {
+    auto prev = i++;
+    if (predicate(*prev)) {
+      c.erase(prev);
+    }
+  }
+}
+
 } // namespace detail
 } // namespace f14
 

--- a/folly/container/test/F14MapTest.cpp
+++ b/folly/container/test/F14MapTest.cpp
@@ -1777,6 +1777,26 @@ TEST(F14Map, containsWithPrecomputedHash) {
   testContainsWithPrecomputedHash<F14FastMap>();
 }
 
+template<template<class...> class TMap>
+void testEraseIf()
+{
+  TMap<int, int> m{{1, 1}, {2, 2}, {3, 3}, {4, 4}};
+  const auto isEvenKey = [](const auto& p) {
+    return p.first % 2 == 0;
+  };
+  erase_if(m, isEvenKey);
+  ASSERT_EQ(2u, m.size());
+  EXPECT_TRUE(m.contains(1));
+  EXPECT_TRUE(m.contains(3));
+}
+
+TEST(F14Map, eraseIf) {
+  testEraseIf<F14ValueMap>();
+  testEraseIf<F14VectorMap>();
+  testEraseIf<F14NodeMap>();
+  testEraseIf<F14FastMap>();
+}
+
 ///////////////////////////////////
 #endif // FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE
 ///////////////////////////////////

--- a/folly/container/test/F14SetTest.cpp
+++ b/folly/container/test/F14SetTest.cpp
@@ -1370,6 +1370,26 @@ TEST(F14Set, containsWithPrecomputedHash) {
   testContainsWithPrecomputedHash<F14FastSet>();
 }
 
+template<template<class...> class TSet>
+void testEraseIf()
+{
+  TSet<int> s{1, 2, 3, 4};
+  const auto isEvenKey = [](const auto& key) {
+    return key % 2 == 0;
+  };
+  erase_if(s, isEvenKey);
+  ASSERT_EQ(2u, s.size());
+  EXPECT_TRUE(s.contains(1));
+  EXPECT_TRUE(s.contains(3));
+}
+
+TEST(F14Set, eraseIf) {
+  testEraseIf<F14ValueSet>();
+  testEraseIf<F14FastSet>();
+  testEraseIf<F14VectorSet>();
+  testEraseIf<F14NodeSet>();
+}
+
 ///////////////////////////////////
 #endif // FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE
 ///////////////////////////////////


### PR DESCRIPTION
Summary:
- For each F14 container, implement `erase_if(F14Container&, Predicate)` similar to C++20 `erase_if(std::unordered_map&, Predicate)`.
- The semantics of `erase_if` are that it erases all elements in the container which satisfy the given predicate.