### PR TITLE
Mark swap(Replaceable) conditionally noexcept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -834,6 +834,7 @@ if (BUILD_TESTS)
         SOURCES ProducerConsumerQueueTest.cpp
       TEST random_test SOURCES RandomTest.cpp
       TEST range_test SOURCES RangeTest.cpp
+      TEST replaceable_test SOURCES ReplaceableTest.cpp
       TEST scope_guard_test SOURCES ScopeGuardTest.cpp
       # Heavily dependent on drand and srand48
       #TEST shared_mutex_test SOURCES SharedMutexTest.cpp

--- a/folly/Replaceable.h
+++ b/folly/Replaceable.h
@@ -595,11 +595,8 @@ class alignas(T) Replaceable
 
   /**
    * `swap` just calls `swap(T&, T&)`.
-   *
-   * Should be `noexcept(std::is_nothrow_swappable<T>::value)` but we don't
-   * depend on C++17 features.
    */
-  void swap(Replaceable& other) {
+  void swap(Replaceable& other) noexcept(IsNothrowSwappable<Replaceable>{}) {
     using std::swap;
     swap(*(*this), *other);
   }

--- a/folly/test/ReplaceableTest.cpp
+++ b/folly/test/ReplaceableTest.cpp
@@ -44,7 +44,9 @@ struct HasRef final {
     ++i1;
   }
 };
-
+void swap(HasRef& lhs, HasRef& rhs) {
+  std::swap(lhs.i1, rhs.i1);
+}
 struct OddA;
 struct OddB {
   OddB() = delete;
@@ -69,6 +71,11 @@ struct OddA {
 };
 struct Indestructible {
   ~Indestructible() = delete;
+};
+
+struct HasInt {
+  HasInt(int v) : value{v} {}
+  int value{};
 };
 } // namespace
 
@@ -288,4 +295,42 @@ TEST(ReplaceableTest, Conversions) {
   Replaceable<OddB> rOddB{in_place, {1, 2, 3}, 4};
   Replaceable<OddA> rOddA{std::move(rOddB)};
   Replaceable<OddB> rOddB2{rOddA};
+}
+
+TEST(ReplaceableTest, swapMemberFunctionIsNoexcept) {
+  int v1{1};
+  int v2{2};
+  auto r1 = Replaceable<HasInt>{v1};
+  auto r2 = Replaceable<HasInt>{v2};
+  EXPECT_TRUE(noexcept(r1.swap(r2)));
+  r1.swap(r2);
+  EXPECT_EQ(v2, r1->value);
+  EXPECT_EQ(v1, r2->value);
+}
+
+TEST(ReplaceableTest, swapMemberFunctionIsNotNoexcept) {
+  int v1{1};
+  int v2{2};
+  auto r1 = Replaceable<HasRef>{v1};
+  auto r2 = Replaceable<HasRef>{v2};
+  EXPECT_FALSE(noexcept(r1.swap(r2)));
+  r1.swap(r2);
+  EXPECT_EQ(v1, r1->i1);
+  EXPECT_EQ(v2, r2->i1);
+}
+
+namespace adl_test {
+  struct UserDefinedSwap {
+    bool calledSwap{};
+  };
+  void swap(UserDefinedSwap& lhs, UserDefinedSwap&) {
+    lhs.calledSwap = true;
+  }
+}
+
+TEST(ReplaceableTest, swapMemberFunctionDelegatesToUserSwap) {
+  auto r1 = Replaceable<adl_test::UserDefinedSwap>{};
+  auto r2 = Replaceable<adl_test::UserDefinedSwap>{};
+  r1.swap(r2);
+  EXPECT_TRUE(r1->calledSwap);
 }


### PR DESCRIPTION
Summary:
- Mark `swap(Replaceable&)` noexcept iff `Replaceable` is
  noexcept-swappable. As the comment aludes to, this is a C++17 feature,
  but we have it backported in `folly/Traits.h`