### PR TITLE
Only define future_wait if FOLLY_FUTURE_USING_FIBER is set

### DIFF
--- a/folly/fibers/Semaphore.cpp
+++ b/folly/fibers/Semaphore.cpp
@@ -118,6 +118,7 @@ coro::Task<void> Semaphore::co_wait() {
 
 #endif
 
+#if FOLLY_FUTURE_USING_FIBER
 SemiFuture<Unit> Semaphore::future_wait() {
   auto oldVal = tokens_.load(std::memory_order_acquire);
   do {
@@ -137,6 +138,7 @@ SemiFuture<Unit> Semaphore::future_wait() {
       std::memory_order_acquire));
   return makeSemiFuture();
 }
+#endif
 
 size_t Semaphore::getCapacity() const {
   return capacity_;

--- a/folly/fibers/test/FibersTest.cpp
+++ b/folly/fibers/test/FibersTest.cpp
@@ -1594,11 +1594,15 @@ TEST(FiberManager, semaphore) {
         for (size_t i = 0; i < kTasks; ++i) {
           manager.addTask([&, completionCounter]() {
             for (size_t j = 0; j < kIterations; ++j) {
+#if FOLLY_FUTURE_USING_FIBER
               if (j % 2) {
                 sem.wait();
               } else {
                 sem.future_wait().get();
               }
+#else
+              sem.wait();
+#endif
               ++counter;
               sem.signal();
               --counter;


### PR DESCRIPTION
Summary:
- In `db3f999e816ed1a5994621c0dd4fc5b795ce228a`, `future_wait` was added
  to `folly/fibers/Semaphore.cpp`. In this function, it requires being
  able to call `wait(std::unique_ptr<fibers::Baton>)`. This symbol will
  only be defined if and only if `FOLLY_FUTURE_USING_FIBER` is true. For
  example, this will break Mac OS X and mobile users, i.e. where
  `FOLLY_FUTURE_USING_FIBER` is not set.
- To avoid breaking those users, we only define `future_wait` if
  `FOLLY_FUTURE_USING_FIBER` is set.
- Change the Semaphore test in `folly/fibers/test/FibersTest.cpp` to
  only unconditionally call `wait()` in the loop rather than randomly
  choosing to call `wait` or `future_wait()` for the case where
  `FOLLY_FUTURE_USING_FIBER` is `0`. The code is the same for the case
  where `FOLLY_FUTURE_USING_FIBER` is set.

Closes https://github.com/facebook/folly/issues/1061.