### PR TITLE
Implement erase_if for FBVector

### DIFF
--- a/folly/FBVector.h
+++ b/folly/FBVector.h
@@ -1748,4 +1748,9 @@ void attach(fbvector<T, A>& v, T* data, size_t sz, size_t cap) {
   v.impl_.z_ = data + cap;
 }
 
+template <class T, class A, class Predicate>
+void erase_if(fbvector<T, A>& v, Predicate predicate) {
+  v.erase(std::remove_if(v.begin(), v.end(), predicate), v.end());
+}
+
 } // namespace folly

--- a/folly/test/FBVectorTest.cpp
+++ b/folly/test/FBVectorTest.cpp
@@ -256,3 +256,13 @@ TEST(FBVector, zero_len) {
   fb6 = il;
   fbvector<int> fb7(fb6.begin(), fb6.end());
 }
+
+TEST(FBVector, erase_if) {
+  fbvector<int> v(6);
+  std::iota(v.begin(), v.end(), 1);
+  erase_if(v, [](const auto &x) { return x % 2 == 0; });
+  ASSERT_EQ(3u, v.size());
+  EXPECT_EQ(1u, v[0]);
+  EXPECT_EQ(3u, v[1]);
+  EXPECT_EQ(5u, v[2]);
+}


### PR DESCRIPTION
Summary:
- Implement free function `erase_if(fbvector<T, A>&, Predicate)` which
  matches the C++20 `erase_if` for containers.