### PR TITLE
Fix FBStringTest to work with CMake 3.9 or later

### DIFF
--- a/folly/test/FBStringTest.cpp
+++ b/folly/test/FBStringTest.cpp
@@ -94,7 +94,7 @@ void clause11_21_4_2_b(String& test) {
 template <class String>
 void clause11_21_4_2_c(String& test) {
   // Test move constructor. There is a more specialized test, see
-  // TEST(FBString, testMoveCtor)
+  // testMoveCtor test
   String donor(test);
   String test2(std::move(donor));
   EXPECT_EQ(test2, test);


### PR DESCRIPTION
Summary:
- CMake 3.9 or later has the `GoogleTest` module which allows for the
  ability to automatically add tests to CTest by scanning the source code
  for Google Test Macros. This is used in `CMake/FollyFunctions.cmake`.
  However, this scanning is just exact string search without full context.
  So, this flags a comment in  `FBStringTest.cpp`. As a result, it tries to
  register the comment matching the macro as a new test. Since the comment
  matches an exact test case which has already been defined, this results in
  a hard error as you cannot have two test cases of the same name in the same
  test suite. The error is as follows:

```
  add_test given test NAME "fbstring_test.FBString.testMoveCtor" which
  already exists in this directory.
Call Stack (most recent call first):
  CMake/FollyFunctions.cmake:268 (gtest_add_tests)
  CMakeLists.txt:481 (folly_define_tests)
```

- Fix the comment to keep the same intent but not get treated as a test
  registration.