### PR TITLE
Fix Clang 8 -Wdefaulted-function-deleted errors

### DIFF
--- a/folly/io/async/EventBaseThread.h
+++ b/folly/io/async/EventBaseThread.h
@@ -35,6 +35,8 @@ class EventBaseThread {
   explicit EventBaseThread(EventBaseManager* ebm);
   ~EventBaseThread();
 
+  EventBaseThread(EventBaseThread const&) = delete;
+  EventBaseThread& operator=(EventBaseThread const&) = delete;
   EventBaseThread(EventBaseThread&&) noexcept;
   EventBaseThread& operator=(EventBaseThread&&) noexcept;
 
@@ -45,9 +47,6 @@ class EventBaseThread {
   void stop();
 
  private:
-  EventBaseThread(EventBaseThread const&) = default;
-  EventBaseThread& operator=(EventBaseThread const&) = default;
-
   EventBaseManager* ebm_;
   std::unique_ptr<ScopedEventBaseThread> th_;
 };

--- a/folly/test/SingletonTestStructs.h
+++ b/folly/test/SingletonTestStructs.h
@@ -43,7 +43,7 @@ struct Watchdog {
   Watchdog(const Watchdog&) = delete;
   Watchdog& operator=(const Watchdog&) = delete;
   Watchdog(Watchdog&&) noexcept = default;
-  Watchdog& operator=(Watchdog&&) noexcept = default;
+  Watchdog& operator=(Watchdog&&) noexcept = delete;
 };
 
 // Some basic types we use for tracking.


### PR DESCRIPTION
Summary:
- Clang 8 introduces a new compiler option which is turned on by
  default: `-Wdefaulted-function-deleted`.
- This flags some code which has special member functions which we
  declare as defaulted, but are implicitly deleted. As such, it is a bit
  misleading to mark them as defaulted. So, mark them as deleted. We
  could also remove them and they would be implicitly deleted, but then
  the internal linter would not like that we define a user defined type
  but are not explicit about deleting or defaulting all special member
  functions.

Note:
- This fixes some Clang 8 compilation issues, but
  https://github.com/facebook/folly/issues/1081 contains details about the
  remaining issues.