### PR TITLE
Replace boost::is_member_pointer with std::is_member_pointer

### DIFF
--- a/folly/experimental/DynamicParser-inl.h
+++ b/folly/experimental/DynamicParser-inl.h
@@ -24,12 +24,13 @@
  */
 #pragma once
 
-#include <boost/function_types/is_member_pointer.hpp>
 #include <boost/function_types/parameter_types.hpp>
 #include <boost/mpl/equal.hpp>
 #include <boost/mpl/pop_front.hpp>
 #include <boost/mpl/transform.hpp>
 #include <boost/mpl/vector.hpp>
+
+#include <type_traits>
 
 #include <folly/Conv.h>
 
@@ -48,9 +49,7 @@ class IdentifyCallable {
 
  private:
   template <typename Fn>
-  using IsMemFn =
-      typename boost::function_types::template is_member_pointer<decltype(
-          &Fn::operator())>;
+  using IsMemFn = std::is_member_pointer<decltype(&Fn::operator())>;
   template <typename Fn>
   constexpr static typename std::enable_if<IsMemFn<Fn>::value, Kind>::type test(
       IsMemFn<Fn>*) {


### PR DESCRIPTION
Summary::
- Replace a call site in `DynamicParser-inl.h` using `boost::is_member_pointer`
  with the standard library equivalent.