### PR TITLE
Implement uniform container erasure for FBVector and small_vector

### DIFF
--- a/folly/FBVector.h
+++ b/folly/FBVector.h
@@ -1751,4 +1751,14 @@ template <
 fbvector(InputIt, InputIt, Allocator = Allocator())
     ->fbvector<typename std::iterator_traits<InputIt>::value_type, Allocator>;
 #endif
+
+template <class T, class A, class U>
+void erase(fbvector<T, A>& v, U value) {
+  v.erase(std::remove(v.begin(), v.end(), value), v.end());
+}
+
+template <class T, class A, class Predicate>
+void erase_if(fbvector<T, A>& v, Predicate predicate) {
+  v.erase(std::remove_if(v.begin(), v.end(), predicate), v.end());
+}
 } // namespace folly

--- a/folly/small_vector.h
+++ b/folly/small_vector.h
@@ -1267,6 +1267,17 @@ void swap(
   a.swap(b);
 }
 
+template <class T, std::size_t MaxInline, class A, class B, class C, class U>
+void erase(small_vector<T, MaxInline, A, B, C>& v, U value) {
+  v.erase(std::remove(v.begin(), v.end(), value), v.end());
+}
+
+template <class T, std::size_t MaxInline, class A, class B, class C,
+         class Predicate>
+void erase_if(small_vector<T, MaxInline, A, B, C>& v, Predicate predicate) {
+  v.erase(std::remove_if(v.begin(), v.end(), predicate), v.end());
+}
+
 //////////////////////////////////////////////////////////////////////
 
 namespace detail {

--- a/folly/test/FBVectorTest.cpp
+++ b/folly/test/FBVectorTest.cpp
@@ -270,3 +270,23 @@ TEST(FBVector, deduction_guides) {
   EXPECT_TRUE((std::is_same_v<fbvector<fbvector<int>::iterator>, decltype(y)>));
 }
 #endif
+
+TEST(FBVector, erase) {
+  fbvector<int> v(3);
+  std::iota(v.begin(), v.end(), 1);
+  v.push_back(2);
+  erase(v, 2);
+  ASSERT_EQ(2u, v.size());
+  EXPECT_EQ(1u, v[0]);
+  EXPECT_EQ(3u, v[1]);
+}
+
+TEST(FBVector, erase_if) {
+  fbvector<int> v(6);
+  std::iota(v.begin(), v.end(), 1);
+  erase_if(v, [](const auto &x) { return x % 2 == 0; });
+  ASSERT_EQ(3u, v.size());
+  EXPECT_EQ(1u, v[0]);
+  EXPECT_EQ(3u, v[1]);
+  EXPECT_EQ(5u, v[2]);
+}

--- a/folly/test/small_vector_test.cpp
+++ b/folly/test/small_vector_test.cpp
@@ -21,6 +21,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -1161,4 +1162,24 @@ TEST(small_vector, SelfCopyAssignmentForVectorOfPair) {
   test = static_cast<decltype(test)&>(test); // suppress self-assign warning
   EXPECT_EQ(test.size(), 1);
   EXPECT_EQ(test[0].first, 13);
+}
+
+TEST(small_vector, erase) {
+  small_vector<int> v(3);
+  std::iota(v.begin(), v.end(), 1);
+  v.push_back(2);
+  erase(v, 2);
+  ASSERT_EQ(2u, v.size());
+  EXPECT_EQ(1u, v[0]);
+  EXPECT_EQ(3u, v[1]);
+}
+
+TEST(small_vector, erase_if) {
+  small_vector<int> v(6);
+  std::iota(v.begin(), v.end(), 1);
+  erase_if(v, [](const auto &x) { return x % 2 == 0; });
+  ASSERT_EQ(3u, v.size());
+  EXPECT_EQ(1u, v[0]);
+  EXPECT_EQ(3u, v[1]);
+  EXPECT_EQ(5u, v[2]);
 }


### PR DESCRIPTION
Summary:
- Implement `erase` and `erase_if` for both `FBVector` and
  `small_vector`.
- This matches the APIs as in the C++20 Library Fundamentals v2.