### PR TITLE
Deduction guide for fbvector

### DIFF
--- a/folly/FBVector.h
+++ b/folly/FBVector.h
@@ -1748,4 +1748,11 @@ void attach(fbvector<T, A>& v, T* data, size_t sz, size_t cap) {
   v.impl_.z_ = data + cap;
 }
 
+#if __cpp_deduction_guides >= 201703
+template<class InputIt,
+         class Allocator = std::allocator<typename std::iterator_traits
+         <InputIt>::value_type>>
+fbvector(InputIt, InputIt, Allocator = Allocator())
+  -> fbvector<typename std::iterator_traits<InputIt>::value_type, Allocator>;
+#endif
 } // namespace folly

--- a/folly/test/FBVectorTest.cpp
+++ b/folly/test/FBVectorTest.cpp
@@ -256,3 +256,15 @@ TEST(FBVector, zero_len) {
   fb6 = il;
   fbvector<int> fb7(fb6.begin(), fb6.end());
 }
+
+#if __cpp_deduction_guides >= 201703
+TEST(FBVector, deduction_guides) {
+  fbvector<int> v(3);
+
+  fbvector x(v.begin(), v.end());
+  EXPECT_TRUE((std::is_same_v<fbvector<int>, decltype(x)>));
+
+  fbvector y{v.begin(), v.end()};
+  EXPECT_TRUE((std::is_same_v<fbvector<fbvector<int>::iterator>, decltype(y)>));
+}
+#endif


### PR DESCRIPTION
Summary:
- Add deduction guide for `fbvector` which is only available if the
  feature test macro for deduction guides is available or if we are on
  MSVC.