### PR TITLE
Simplify some macros testing __GNUC__ and __clang__

### DIFF
--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -147,7 +147,7 @@
 // noinline
 #ifdef _MSC_VER
 #define FOLLY_NOINLINE __declspec(noinline)
-#elif defined(__clang__) || defined(__GNUC__)
+#elif defined(__GNUC__)
 #define FOLLY_NOINLINE __attribute__((__noinline__))
 #else
 #define FOLLY_NOINLINE
@@ -156,7 +156,7 @@
 // always inline
 #ifdef _MSC_VER
 #define FOLLY_ALWAYS_INLINE __forceinline
-#elif defined(__clang__) || defined(__GNUC__)
+#elif defined(__GNUC__)
 #define FOLLY_ALWAYS_INLINE inline __attribute__((__always_inline__))
 #else
 #define FOLLY_ALWAYS_INLINE inline
@@ -165,7 +165,7 @@
 // attribute hidden
 #if _MSC_VER
 #define FOLLY_ATTR_VISIBILITY_HIDDEN
-#elif defined(__clang__) || defined(__GNUC__)
+#elif defined(__GNUC__)
 #define FOLLY_ATTR_VISIBILITY_HIDDEN __attribute__((__visibility__("hidden")))
 #else
 #define FOLLY_ATTR_VISIBILITY_HIDDEN

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -68,7 +68,7 @@ constexpr bool kHasUnalignedAccess = false;
 #if !defined FOLLY_NODISCARD
 #if defined(_MSC_VER) && (_MSC_VER >= 1700)
 #define FOLLY_NODISCARD _Check_return_
-#elif defined(__clang__) || defined(__GNUC__)
+#elif defined(__GNUC__)
 #define FOLLY_NODISCARD __attribute__((__warn_unused_result__))
 #else
 #define FOLLY_NODISCARD
@@ -146,7 +146,7 @@ constexpr bool kIsSanitize = false;
 #define FOLLY_PACK_ATTR /**/
 #define FOLLY_PACK_PUSH __pragma(pack(push, 1))
 #define FOLLY_PACK_POP __pragma(pack(pop))
-#elif defined(__clang__) || defined(__GNUC__)
+#elif defined(__GNUC__)
 #define FOLLY_PACK_ATTR __attribute__((__packed__))
 #define FOLLY_PACK_PUSH /**/
 #define FOLLY_PACK_POP /**/
@@ -215,7 +215,7 @@ FOLLY_GCC_DISABLE_NEW_SHADOW_WARNINGS
  */
 #if defined(_MSC_VER)
 #define FOLLY_TLS __declspec(thread)
-#elif defined(__GNUC__) || defined(__clang__)
+#elif defined(__GNUC__)
 #define FOLLY_TLS __thread
 #else
 #error cannot define platform specific thread local storage

--- a/folly/experimental/Instructions.h
+++ b/folly/experimental/Instructions.h
@@ -90,7 +90,7 @@ struct Nehalem : public Default {
 
   static FOLLY_ALWAYS_INLINE uint64_t popcount(uint64_t value) {
 // POPCNT is supported starting with Intel Nehalem, AMD K10.
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__)
     // GCC and Clang won't inline the intrinsics.
     uint64_t result;
     asm("popcntq %1, %0" : "=r"(result) : "r"(value));
@@ -109,7 +109,7 @@ struct Haswell : public Nehalem {
   static FOLLY_ALWAYS_INLINE uint64_t blsr(uint64_t value) {
 // BMI1 is supported starting with Intel Haswell, AMD Piledriver.
 // BLSR combines two instructions into one and reduces register pressure.
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__)
     // GCC and Clang won't inline the intrinsics.
     uint64_t result;
     asm("blsrq %1, %0" : "=r"(result) : "r"(value));
@@ -121,7 +121,7 @@ struct Haswell : public Nehalem {
 
   static FOLLY_ALWAYS_INLINE uint64_t
   bextr(uint64_t value, uint32_t start, uint32_t length) {
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__)
     // GCC and Clang won't inline the intrinsics.
     // Encode parameters in `pattern` where `pattern[0:7]` is `start` and
     // `pattern[8:15]` is `length`.
@@ -137,7 +137,7 @@ struct Haswell : public Nehalem {
   }
 
   static FOLLY_ALWAYS_INLINE uint64_t bzhi(uint64_t value, uint32_t index) {
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__)
     // GCC and Clang won't inline the intrinsics.
     const uint64_t index64 = index;
     uint64_t result;

--- a/folly/experimental/Select64.h
+++ b/folly/experimental/Select64.h
@@ -89,7 +89,7 @@ inline uint64_t select64(uint64_t x, uint64_t k) {
 template <>
 FOLLY_ALWAYS_INLINE uint64_t
 select64<compression::instructions::Haswell>(uint64_t x, uint64_t k) {
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__GNUC__)
   // GCC and Clang won't inline the intrinsics.
   uint64_t result = uint64_t(1) << k;
 

--- a/folly/experimental/pushmi/detail/concept_def.h
+++ b/folly/experimental/pushmi/detail/concept_def.h
@@ -54,7 +54,7 @@
 
 PUSHMI_PP_IGNORE_CXX2A_COMPAT_BEGIN
 
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5)
+#if defined(__GNUC__) && __GNUC__ >= 5
 #define PUSHMI_NOT_ON_WINDOWS 1
 #else
 #define PUSHMI_NOT_ON_WINDOWS 0

--- a/folly/experimental/pushmi/detail/if_constexpr.h
+++ b/folly/experimental/pushmi/detail/if_constexpr.h
@@ -64,7 +64,7 @@
 
 // disable buggy compatibility warning about "requires" and "concept" being
 // C++20 keywords.
-#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5)
+#if defined(__GNUC__) && __GNUC__ >= 5
 #define PUSHMI_PP_IGNORE_SHADOW_BEGIN \
     _Pragma("GCC diagnostic push") \
     _Pragma("GCC diagnostic ignored \"-Wshadow\"") \

--- a/folly/lang/UncaughtExceptions.h
+++ b/folly/lang/UncaughtExceptions.h
@@ -18,8 +18,7 @@
 
 #include <exception>
 
-#if !defined(FOLLY_FORCE_EXCEPTION_COUNT_USE_STD) && \
-    (defined(__GNUG__) || defined(__clang__))
+#if !defined(FOLLY_FORCE_EXCEPTION_COUNT_USE_STD) && defined(__GNUG__)
 #define FOLLY_EXCEPTION_COUNT_USE_CXA_GET_GLOBALS
 namespace __cxxabiv1 {
 // forward declaration (originally defined in unwind-cxx.h from from libstdc++)

--- a/folly/portability/Asm.h
+++ b/folly/portability/Asm.h
@@ -26,7 +26,7 @@
 
 namespace folly {
 inline void asm_volatile_memory() {
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(__GNUC__)
   asm volatile("" : : : "memory");
 #elif defined(_MSC_VER)
   ::_ReadWriteBarrier();


### PR DESCRIPTION
Summary:
- Both GCC and Clang define the macro `__GNUC__`, `__GNUG__` and
  friends. Simplify some macros whose intent is to check "if we are GCC or
  Clang" but do so via checking `__GNUC__` in addition to `__clang__`. It
  is sufficient to just check `__GNUC__`.