### PR TITLE
Fix deduction guide macro guard for Replaceable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -834,6 +834,7 @@ if (BUILD_TESTS)
         SOURCES ProducerConsumerQueueTest.cpp
       TEST random_test SOURCES RandomTest.cpp
       TEST range_test SOURCES RangeTest.cpp
+      TEST replaceable_test SOURCES ReplaceableTest.cpp
       TEST scope_guard_test SOURCES ScopeGuardTest.cpp
       # Heavily dependent on drand and srand48
       #TEST shared_mutex_test SOURCES SharedMutexTest.cpp

--- a/folly/Replaceable.h
+++ b/folly/Replaceable.h
@@ -640,7 +640,7 @@ class alignas(T) Replaceable
   aligned_storage_for_t<T> storage_[1];
 };
 
-#if __cpp_deduction_guides >= 201703 || _MSC_VER
+#if __cpp_deduction_guides >= 201703
 template <class T>
 Replaceable(T)->Replaceable<T>;
 #endif

--- a/folly/test/ReplaceableTest.cpp
+++ b/folly/test/ReplaceableTest.cpp
@@ -289,3 +289,11 @@ TEST(ReplaceableTest, Conversions) {
   Replaceable<OddA> rOddA{std::move(rOddB)};
   Replaceable<OddB> rOddB2{rOddA};
 }
+
+#if __cpp_deduction_guides >= 201703
+TEST(ReplaceableTest, DeductionGuide) {
+  Basic b{};
+  Replaceable r{b};
+  EXPECT_TRUE((std::is_same_v<Replaceable<Basic>, decltype(r)>));
+}
+#endif


### PR DESCRIPTION
Summary:
- `Replaceable` defines a deduction guide if the feature test macro for
  it is met, or if we are on MSVC. However, the MSVC version that folly
  supports also defines the feature test macro for deduction guides. As
  such, remove the extra check for MSVC.
- Add `ReplaceableTest` to the  cmake build.
- Add test for deduction guide.