### PR TITLE
Fix warning 'redundant-move'

### DIFF
--- a/folly/executors/task_queue/LifoSemMPMCQueue.h
+++ b/folly/executors/task_queue/LifoSemMPMCQueue.h
@@ -57,7 +57,7 @@ class LifoSemMPMCQueue : public BlockingQueue<T> {
         return folly::none;
       }
     }
-    return std::move(item);
+    return item;
   }
 
   size_t capacity() {

--- a/folly/executors/task_queue/PriorityLifoSemMPMCQueue.h
+++ b/folly/executors/task_queue/PriorityLifoSemMPMCQueue.h
@@ -89,7 +89,7 @@ class PriorityLifoSemMPMCQueue : public BlockingQueue<T> {
     T item;
     while (true) {
       if (nonBlockingTake(item)) {
-        return std::move(item);
+        return item;
       }
       if (!sem_.try_wait_for(time)) {
         return folly::none;

--- a/folly/experimental/JSONSchema.cpp
+++ b/folly/experimental/JSONSchema.cpp
@@ -1031,7 +1031,7 @@ std::unique_ptr<Validator> makeValidator(const dynamic& schema) {
   SchemaValidatorContext context(schema);
   context.refs["#"] = v.get();
   v->loadSchema(context, schema);
-  return std::move(v);
+  return v;
 }
 
 std::shared_ptr<Validator> makeSchemaValidator() {

--- a/folly/logging/LogConfigParser.cpp
+++ b/folly/logging/LogConfigParser.cpp
@@ -574,7 +574,7 @@ dynamic logConfigToDynamic(const LogHandlerConfig& config) {
   if (config.type.hasValue()) {
     result("type", config.type.value());
   }
-  return std::move(result);
+  return result;
 }
 
 dynamic logConfigToDynamic(const LogCategoryConfig& config) {
@@ -587,7 +587,7 @@ dynamic logConfigToDynamic(const LogCategoryConfig& config) {
     }
     value("handlers", std::move(handlers));
   }
-  return std::move(value);
+  return value;
 }
 
 } // namespace folly


### PR DESCRIPTION
Hello Facebook,

This small PR to fix the redundant std::move usage detected by gcc (GCC) 9.0.1 20190225 (experimental)

```
/folly/BUILD/folly-2019.04.01.00/folly/executors/task_queue/PriorityLifoSemMPMCQueue.h:92:30: error: redundant move in return statement [-Werror=redundant-move]
   92 |         return std::move(item);
      |                              ^
```

Stac