### PR TITLE
Remove unused FOLLY_NONNULL macro

### DIFF
--- a/folly/CppAttributes.h
+++ b/folly/CppAttributes.h
@@ -102,10 +102,8 @@
  */
 #if FOLLY_HAS_EXTENSION(nullability)
 #define FOLLY_NULLABLE _Nullable
-#define FOLLY_NONNULL _Nonnull
 #else
 #define FOLLY_NULLABLE
-#define FOLLY_NONNULL
 #endif
 
 /**


### PR DESCRIPTION
Summary:
- In `339c14d3`, `FOLLY_NONNULL` was added to make the internal linter
  not complain about passing around non-null pointers to functions
  instead of using a reference.
- It had one or two usages with `d81cde8f` and `a04d119c`, but it is no
  longer used.
- Since it is no longer used, remove the macro entirely.