### PR TITLE
Return reference in FBVector::emplace_back

### DIFF
--- a/folly/FBVector.h
+++ b/folly/FBVector.h
@@ -1136,13 +1136,14 @@ class fbvector {
   // modifiers (common)
  public:
   template <class... Args>
-  void emplace_back(Args&&... args) {
+  reference emplace_back(Args&&... args) {
     if (impl_.e_ != impl_.z_) {
       M_construct(impl_.e_, std::forward<Args>(args)...);
       ++impl_.e_;
     } else {
       emplace_back_aux(std::forward<Args>(args)...);
     }
+    return back();
   }
 
   void push_back(const T& value) {

--- a/folly/test/FBVectorTest.cpp
+++ b/folly/test/FBVectorTest.cpp
@@ -124,8 +124,10 @@ TEST(fbvector, emplace) {
   fbvector<std::string> s(12, "asd");
   EXPECT_EQ(s.size(), 12);
   EXPECT_EQ(s.front(), "asd");
-  s.emplace_back("funk");
+  const auto& emplaced = s.emplace_back("funk");
+  EXPECT_EQ(emplaced, "funk");
   EXPECT_EQ(s.back(), "funk");
+  EXPECT_EQ(std::addressof(emplaced), std::addressof(s.back()));
 }
 
 TEST(fbvector, initializer_lists) {


### PR DESCRIPTION
Summary:
- Since C++17, `vector::emplace_back()` returns a reference to
  the new element inserted.
- Differential Revision: D15007059 added support for these semantics in
  `small_vector`. This adds it for `FBVector` too to be symmetric.