### PR TITLE
Add non-const data() method to FBString

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -388,6 +388,10 @@ class fbstring_core {
     return c_str();
   }
 
+  Char* data() {
+    return c_str();
+  }
+
   Char* mutableData() {
     switch (category()) {
       case Category::isSmall:
@@ -486,6 +490,13 @@ class fbstring_core {
  private:
   // Disabled
   fbstring_core& operator=(const fbstring_core& rhs);
+
+  Char* c_str() {
+    Char* ptr = ml_.data_;
+    // With this syntax, GCC and Clang generate a CMOV instead of a branch.
+    ptr = (category() == Category::isSmall) ? small_ : ptr;
+    return ptr;
+  }
 
   void reset() {
     setSmallSize(0);
@@ -1672,6 +1683,10 @@ class basic_fbstring {
 
   const value_type* data() const {
     return c_str();
+  }
+
+  value_type* data() {
+    return store_.data();
   }
 
   allocator_type get_allocator() const {


### PR DESCRIPTION
Summary:
- As of C++17, `std::string` contains a non-const `data()` member function.
  This is useful when working with C APIs that have `char*` output parameters.
- Implements P0272 for `FBString`:
  http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0272r1.html

Example of workaround without this:

```
  fbstring s{};
  some_api(&s.front());
```

- The expression `&s.front()` above causes undefined behavior since the string
  is empty.

- Add non-const public member function `data()` to `fbstring` which
  delegates to `fbstring_core`.