### PR TITLE
Cut endian members from fbstring_core

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -292,18 +292,6 @@ class fbstring_core_model {
  */
 template <class Char>
 class fbstring_core {
- protected:
-// It's MSVC, so we just have to guess ... and allow an override
-#ifdef _MSC_VER
-#ifdef FOLLY_ENDIAN_BE
-  static constexpr auto kIsLittleEndian = false;
-#else
-  static constexpr auto kIsLittleEndian = true;
-#endif
-#else
-  static constexpr auto kIsLittleEndian =
-      __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__;
-#endif
  public:
   fbstring_core() noexcept {
     reset();


### PR DESCRIPTION
Summary:
- `fbstring_core` defines constants based on the host endianness.
- This is purely duplicated as these constants live in `Portability.h`.
  As such, remove them from `fbstring_core` class.