### PR TITLE
Take care of zstd static library on Win32

### DIFF
--- a/CMake/FindZstd.cmake
+++ b/CMake/FindZstd.cmake
@@ -8,8 +8,8 @@
 
 find_path(ZSTD_INCLUDE_DIR NAMES zstd.h)
 
-find_library(ZSTD_LIBRARY_DEBUG NAMES zstdd)
-find_library(ZSTD_LIBRARY_RELEASE NAMES zstd)
+find_library(ZSTD_LIBRARY_DEBUG NAMES zstdd zstd_staticd)
+find_library(ZSTD_LIBRARY_RELEASE NAMES zstd zstd_static)
 
 include(SelectLibraryConfigurations)
 SELECT_LIBRARY_CONFIGURATIONS(ZSTD)


### PR DESCRIPTION
When built as a static library on Win32, `zstd` has an output name like `zstd_static.lib` and `zstd_staticd.lib`:
https://github.com/facebook/zstd/blob/69baaee3e42f90dedea2c946bc19bfeac4e782ee/build/cmake/lib/CMakeLists.txt#L140
So `FindZstd.cmake` should also take this into consideration.