### PR TITLE
SFINAE-friendly to_unsigned

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -860,6 +860,7 @@ if (BUILD_TESTS)
       TEST try_test SOURCES TryTest.cpp
       TEST unit_test SOURCES UnitTest.cpp
       TEST uri_test SOURCES UriTest.cpp
+      TEST utility_test SOURCES UtilityTest.cpp
       TEST varint_test SOURCES VarintTest.cpp
   )
 

--- a/folly/Utility.h
+++ b/folly/Utility.h
@@ -294,10 +294,15 @@ constexpr auto to_signed(T const& t) -> typename std::make_signed<T>::type {
                                            : static_cast<S>(t);
 }
 
-template <typename T>
+template <typename T, typename = std::enable_if_t<std::is_integral<T>::value>>
 constexpr auto to_unsigned(T const& t) -> typename std::make_unsigned<T>::type {
   using U = typename std::make_unsigned<T>::type;
   return static_cast<U>(t);
+}
+
+template <typename T, typename = std::enable_if_t<!std::is_integral<T>::value>>
+constexpr auto to_unsigned(T const& t) {
+  return t;
 }
 
 template <class E>

--- a/folly/stats/Histogram.h
+++ b/folly/stats/Histogram.h
@@ -28,6 +28,7 @@
 
 #include <folly/CPortability.h>
 #include <folly/Traits.h>
+#include <folly/Utility.h>
 #include <folly/stats/detail/Bucket.h>
 
 namespace folly {
@@ -475,17 +476,6 @@ class Histogram {
   };
 
  private:
-  template <typename S, typename = std::enable_if_t<std::is_integral<S>::value>>
-  static constexpr std::make_unsigned_t<S> to_unsigned(S s) {
-    return static_cast<std::make_unsigned_t<S>>(s);
-  }
-  template <
-      typename S,
-      typename = std::enable_if_t<!std::is_integral<S>::value>>
-  static constexpr S to_unsigned(S s) {
-    return s;
-  }
-
   detail::HistogramBuckets<ValueType, Bucket> buckets_;
 };
 

--- a/folly/test/UtilityTest.cpp
+++ b/folly/test/UtilityTest.cpp
@@ -136,3 +136,8 @@ TEST_F(UtilityTest, to_unsigned) {
     EXPECT_EQ(-12, actual);
   }
 }
+
+TEST_F(UtilityTest, to_unsigned_sfinae_friendly) {
+  constexpr auto actual = folly::to_unsigned(double(-12));
+  EXPECT_EQ(-12, actual);
+}


### PR DESCRIPTION
Summary:
- `to_unsigned` is not SFINAE friendly. It only works on types where
  `std::make_unsigned_t` is well-formed, such as integral types
  (non-bool) or enum type. This makes it less useful in generic
  programming contexts.
- Remove `to_unsigned` from `Histogram.h` in favor of the
  SFINAE-friendly `to_unsigned` in `Utility.h`.
- Add `UtilityTest` to be built and run as part of the CMake build.