### PR TITLE
Fix pessimizing moves

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -2419,7 +2419,7 @@ inline basic_fbstring<E, T, A, S> operator+(
   basic_fbstring<E, T, A, S> result;
   result.reserve(lhs.size() + rhs.size());
   result.append(lhs).append(rhs);
-  return std::move(result);
+  return result;
 }
 
 // C++11 21.4.8.1/2

--- a/folly/Padded.h
+++ b/folly/Padded.h
@@ -517,7 +517,7 @@ class Adaptor {
   std::pair<Container, size_t> move() {
     std::pair<Container, size_t> p(std::move(c_), lastCount_);
     lastCount_ = Node::kElementCount;
-    return std::move(p);
+    return p;
   }
 
   /**

--- a/folly/fibers/AddTasks-inl.h
+++ b/folly/fibers/AddTasks-inl.h
@@ -125,7 +125,7 @@ addTasks(InputIterator first, InputIterator last) {
 
   iterator.context_->results.reserve(iterator.context_->totalTasks);
 
-  return std::move(iterator);
+  return iterator;
 }
 } // namespace fibers
 } // namespace folly


### PR DESCRIPTION
Summary:
- GCC 9.1 warns when moving a local object in a return statement
  prevents copy elision.
- Remove the explicit `std::move` in those return statements.