### PR TITLE
Use a M:N caches-to-lifetimes in SingletonThreadLocal

### DIFF
--- a/folly/test/SingletonThreadLocalTest.cpp
+++ b/folly/test/SingletonThreadLocalTest.cpp
@@ -32,6 +32,10 @@
 
 using namespace folly;
 
+extern "C" int* check() {
+  return &SingletonThreadLocal<int>::get();
+}
+
 namespace {
 static std::atomic<std::size_t> fooCreatedCount{0};
 static std::atomic<std::size_t> fooDeletedCount{0};


### PR DESCRIPTION
Summary:
[Folly] Use a M:N caches-to-lifetimes in `SingletonThreadLocal`.

Sometimes the compiler will not merge cache and lifetime thread-local variables in expected ways, so be resilient. More details in #1135 and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90562.

At the same time, move the tracking into the wrapper. The lifetime was an intrusively-linked-list node which was clever and which was allocation-free but which increased the TLS requirement per instantiation of `SingletonThreadLocal`. Moving the tracking into the wrapper decreases the TLS requirement, although the tracking now requires heap allocations.

Fixes #1135.

Differential Revision: D15508024

