### PR TITLE
Remove -Wuninitialized for GCC in Expected.h

### DIFF
--- a/folly/Expected.h
+++ b/folly/Expected.h
@@ -52,17 +52,6 @@
 
 #define FOLLY_REQUIRES(...) template <FOLLY_REQUIRES_IMPL(__VA_ARGS__)>
 
-/**
- * gcc-4.7 warns about use of uninitialized memory around the use of storage_
- * even though this is explicitly initialized at each point.
- */
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma GCC diagnostic ignored "-Wpragmas"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif // __GNUC__
-
 namespace folly {
 
 /**
@@ -1405,10 +1394,6 @@ template <class Value, class Error>
 bool operator>(const Value& other, const Expected<Value, Error>&) = delete;
 
 } // namespace folly
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 #undef FOLLY_REQUIRES
 #undef FOLLY_REQUIRES_TRAILING


### PR DESCRIPTION
Summary:
- Old versions of GCC (specifically, GCC 4.7) warn about uninitialized memory
  in `Expected.h`
- Newer versions of GCC do not complain, so remove the pragma push/pop which
  was disabling the warning.