### PR TITLE
Add some explicit casts to prevent some compiler warnings

### DIFF
--- a/folly/Format.cpp
+++ b/folly/Format.cpp
@@ -51,7 +51,7 @@ struct format_table_conv_make_item {
     std::size_t index{};
     constexpr explicit make_item(std::size_t index_) : index(index_) {} // gcc49
     constexpr char alpha(std::size_t ord) const {
-      return ord < 10 ? '0' + ord : (Upper ? 'A' : 'a') + (ord - 10);
+      return static_cast<char>(ord < 10 ? '0' + ord : (Upper ? 'A' : 'a') + (ord - 10));
     }
     constexpr char operator()(std::size_t offset) const {
       return alpha(index / constexpr_pow(Base, Size - offset - 1) % Base);
@@ -208,7 +208,7 @@ void FormatValue<double>::formatHelper(
       arg.error("invalid specifier '", arg.presentation, "'");
   }
 
-  int len = builder.position();
+  auto len = builder.position();
   builder.Finalize();
   assert(len > 0);
 

--- a/folly/String.cpp
+++ b/folly/String.cpp
@@ -81,11 +81,11 @@ struct string_table_c_unescape_make_item {
 struct string_table_hex_make_item {
   constexpr unsigned char operator()(std::size_t index) const {
     // clang-format off
-    return
+    return static_cast<unsigned char>(
         index >= '0' && index <= '9' ? index - '0' :
         index >= 'a' && index <= 'f' ? index - 'a' + 10 :
         index >= 'A' && index <= 'F' ? index - 'A' + 10 :
-        16;
+        16);
     // clang-format on
   }
 };

--- a/folly/Utility.h
+++ b/folly/Utility.h
@@ -295,8 +295,11 @@ constexpr auto to_signed(T const& t) -> typename std::make_signed<T>::type {
   // note: static_cast<S>(t) would be more straightforward, but it would also be
   // implementation-defined behavior and that is typically to be avoided; the
   // following code optimized into the same thing, though
+FOLLY_PUSH_WARNING
+FOLLY_MSVC_DISABLE_WARNING(4018)
   return std::numeric_limits<S>::max() < t ? -static_cast<S>(~t) + S{-1}
                                            : static_cast<S>(t);
+FOLLY_POP_WARNING
 }
 
 template <typename T>

--- a/folly/Utility.h
+++ b/folly/Utility.h
@@ -295,11 +295,9 @@ constexpr auto to_signed(T const& t) -> typename std::make_signed<T>::type {
   // note: static_cast<S>(t) would be more straightforward, but it would also be
   // implementation-defined behavior and that is typically to be avoided; the
   // following code optimized into the same thing, though
-FOLLY_PUSH_WARNING
-FOLLY_MSVC_DISABLE_WARNING(4018)
-  return std::numeric_limits<S>::max() < t ? -static_cast<S>(~t) + S{-1}
+  constexpr auto m = static_cast<T>(std::numeric_limits<S>::max());
+  return m < t ? -static_cast<S>(~t) + S{-1}
                                            : static_cast<S>(t);
-FOLLY_POP_WARNING
 }
 
 template <typename T>

--- a/folly/json.cpp
+++ b/folly/json.cpp
@@ -718,7 +718,7 @@ size_t firstEscapableInWord(T s, const serialization_opts& opts) {
           (i == 0 ? uint64_t(-1) << 32 : ~0UL);
       while (bitmap) {
         auto bit = folly::findFirstSet(bitmap);
-        needsEscape |= isChar(offset + bit - 1);
+        needsEscape |= isChar(static_cast<uint8_t>(offset + bit - 1));
         bitmap &= bitmap - 1;
       }
     }


### PR DESCRIPTION
As part of trying to get our internal usage of folly off a fork, we have various compiler warnings set ridiculously high.

This gets rid of a couple of warnings that we hit in folly code.