### PR TITLE
Allow building x86 and arm on msvc

### DIFF
--- a/folly/memory/detail/MallocImpl.h
+++ b/folly/memory/detail/MallocImpl.h
@@ -50,6 +50,18 @@ extern int (
 #ifdef _MSC_VER
 // We emulate weak linkage for MSVC. The symbols we're
 // aliasing to are hiding in MallocImpl.cpp
+#if defined(_M_IX86)
+#pragma comment(linker, "/alternatename:_mallocx=_mallocxWeak")
+#pragma comment(linker, "/alternatename:_rallocx=_rallocxWeak")
+#pragma comment(linker, "/alternatename:_xallocx=_xallocxWeak")
+#pragma comment(linker, "/alternatename:_sallocx=_sallocxWeak")
+#pragma comment(linker, "/alternatename:_dallocx=_dallocxWeak")
+#pragma comment(linker, "/alternatename:_sdallocx=_sdallocxWeak")
+#pragma comment(linker, "/alternatename:_nallocx=_nallocxWeak")
+#pragma comment(linker, "/alternatename:_mallctl=_mallctlWeak")
+#pragma comment(linker, "/alternatename:_mallctlnametomib=_mallctlnametomibWeak")
+#pragma comment(linker, "/alternatename:_mallctlbymib=_mallctlbymibWeak")
+#else
 #pragma comment(linker, "/alternatename:mallocx=mallocxWeak")
 #pragma comment(linker, "/alternatename:rallocx=rallocxWeak")
 #pragma comment(linker, "/alternatename:xallocx=xallocxWeak")
@@ -60,6 +72,7 @@ extern int (
 #pragma comment(linker, "/alternatename:mallctl=mallctlWeak")
 #pragma comment(linker, "/alternatename:mallctlnametomib=mallctlnametomibWeak")
 #pragma comment(linker, "/alternatename:mallctlbymib=mallctlbymibWeak")
+#endif
 #endif
 #endif
 }

--- a/folly/portability/Builtins.h
+++ b/folly/portability/Builtins.h
@@ -52,8 +52,9 @@ FOLLY_ALWAYS_INLINE int __builtin_clzl(unsigned long x) {
 
 #if defined(_M_IX86) || defined(_M_ARM)
 FOLLY_ALWAYS_INLINE int __builtin_clzll(unsigned long long x) {
-  if (x == 0)
+  if (x == 0) {
     return 64;
+  }
   unsigned int msb = (unsigned int)(x >> 32);
   unsigned int lsb = (unsigned int)x;
   return (msb != 0) ? __builtin_clz(msb) : 32 + __builtin_clz(lsb);
@@ -79,10 +80,11 @@ FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
   unsigned long index;
   unsigned int msb = (unsigned int)(x >> 32);
   unsigned int lsb = (unsigned int)x;
-  if (lsb != 0)
+  if (lsb != 0) {
     return (int)(_BitScanForward(&index, lsb) ? index : 64);
-  else
+  } else {
     return (int)(_BitScanForward(&index, msb) ? index + 32 : 64);
+  }
 }
 #else
 FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {


### PR DESCRIPTION
A couple of changes to support building folly in MSVC/win32 for x86 and arm platforms.