### PR TITLE
Fix -Wstring-plus-int in FixedStringTest.cpp 

### DIFF
--- a/folly/test/FixedStringTest.cpp
+++ b/folly/test/FixedStringTest.cpp
@@ -350,8 +350,9 @@ TEST(FixedStringAssignTest, RuntimeAppendString) {
 constexpr folly::FixedString<20> constexpr_append_literal_test() {
   folly::FixedString<20> a{"hello"};
   a.append(1u, ' ');
-  a.append("X world!" + 2u, 5u);
-  a.append("X world!" + 7u);
+  constexpr char s[] = "X world!";
+  a.append(&s[2u], 5u);
+  a.append(&s[7u]);
   return a;
 }
 
@@ -362,8 +363,9 @@ TEST(FixedStringAssignTest, ConstexprAppendLiteral) {
 TEST(FixedStringAssignTest, RuntimeAppendLiteral) {
   folly::FixedString<20> a{"hello"};
   a.append(1u, ' ');
-  a.append("X world!" + 2u, 5u);
-  a.append("X world!" + 7u);
+  constexpr char s[] = "X world!";
+  a.append(&s[2u], 5u);
+  a.append(&s[7u]);
   EXPECT_STREQ("hello world!", a.c_str());
 }
 


### PR DESCRIPTION
Summary:
- Clang 8 warns about appending integers to a string using `operator+`
  without a cast.

```
../folly/test/FixedStringTest.cpp:353:23: warning: adding 'unsigned int' to a string does not append to the string [-Wstring-plus-int]
  a.append("X world!" + 2u, 5u);
           ~~~~~~~~~~~^~~~
../folly/test/FixedStringTest.cpp:353:23: note: use array indexing to silence this warning
  a.append("X world!" + 2u, 5u);
                      ^
           &          [   ]
../folly/test/FixedStringTest.cpp:354:23: warning: adding 'unsigned int' to a string does not append to the string [-Wstring-plus-int]
  a.append("X world!" + 7u);
           ~~~~~~~~~~~^~~~
../folly/test/FixedStringTest.cpp:354:23: note: use array indexing to silence this warning
  a.append("X world!" + 7u);
                      ^
           &          [   ]
../folly/test/FixedStringTest.cpp:365:23: warning: adding 'unsigned int' to a string does not append to the string [-Wstring-plus-int]
  a.append("X world!" + 2u, 5u);
           ~~~~~~~~~~~^~~~
../folly/test/FixedStringTest.cpp:365:23: note: use array indexing to silence this warning
  a.append("X world!" + 2u, 5u);
                      ^
           &          [   ]
../folly/test/FixedStringTest.cpp:366:23: warning: adding 'unsigned int' to a string does not append to the string [-Wstring-plus-int]
  a.append("X world!" + 7u);
           ~~~~~~~~~~~^~~~
../folly/test/FixedStringTest.cpp:366:23: note: use array indexing to silence this warning
  a.append("X world!" + 7u);
                      ^
           &          [   ]
```

- Fix this warning by creating a local char[] and using that to append
  to the fixed string