### PR TITLE
Cut backport of std::make_unique

### DIFF
--- a/folly/Memory.h
+++ b/folly/Memory.h
@@ -240,41 +240,6 @@ size_t allocationBytesForOverAligned(size_t n) {
 }
 
 /**
- * For exception safety and consistency with make_shared. Erase me when
- * we have std::make_unique().
- *
- * @author Louis Brandy (ldbrandy@fb.com)
- * @author Xu Ning (xning@fb.com)
- */
-
-#if __cplusplus >= 201402L || __cpp_lib_make_unique >= 201304L || \
-    (__ANDROID__ && __cplusplus >= 201300L) || _MSC_VER >= 1900
-
-/* using override */ using std::make_unique;
-
-#else
-
-template <typename T, typename... Args>
-typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type
-make_unique(Args&&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
-// Allows 'make_unique<T[]>(10)'. (N3690 s20.9.1.4 p3-4)
-template <typename T>
-typename std::enable_if<std::is_array<T>::value, std::unique_ptr<T>>::type
-make_unique(const size_t n) {
-  return std::unique_ptr<T>(new typename std::remove_extent<T>::type[n]());
-}
-
-// Disallows 'make_unique<T[10]>()'. (N3690 s20.9.1.4 p5)
-template <typename T, typename... Args>
-typename std::enable_if<std::extent<T>::value != 0, std::unique_ptr<T>>::type
-make_unique(Args&&...) = delete;
-
-#endif
-
-/**
  * static_function_deleter
  *
  * So you can write this:

--- a/folly/compression/Compression.cpp
+++ b/folly/compression/Compression.cpp
@@ -60,6 +60,7 @@
 #include <folly/lang/Bits.h>
 #include <folly/stop_watch.h>
 #include <algorithm>
+#include <memory>
 #include <unordered_set>
 
 using folly::io::compression::detail::dataStartsWithLE;
@@ -1237,13 +1238,13 @@ bool LZMA2StreamCodec::canUncompress(const IOBuf* data, Optional<uint64_t>)
 std::unique_ptr<Codec> LZMA2StreamCodec::createCodec(
     int level,
     CodecType type) {
-  return make_unique<LZMA2StreamCodec>(level, type);
+  return std::make_unique<LZMA2StreamCodec>(level, type);
 }
 
 std::unique_ptr<StreamCodec> LZMA2StreamCodec::createStream(
     int level,
     CodecType type) {
-  return make_unique<LZMA2StreamCodec>(level, type);
+  return std::make_unique<LZMA2StreamCodec>(level, type);
 }
 
 LZMA2StreamCodec::LZMA2StreamCodec(int level, CodecType type)

--- a/folly/executors/GlobalThreadPoolList.cpp
+++ b/folly/executors/GlobalThreadPoolList.cpp
@@ -135,7 +135,7 @@ void GlobalThreadPoolList::registerThreadPoolThread(
     ThreadPoolListHook* threadPoolId,
     std::thread::id threadId) {
   DCHECK(!threadHook_);
-  threadHook_.reset(make_unique<ThreadListHook>(threadPoolId, threadId));
+  threadHook_.reset(std::make_unique<ThreadListHook>(threadPoolId, threadId));
 
   globalListImpl_->registerThreadPoolThread(threadPoolId, threadId);
 }


### PR DESCRIPTION
- Previously, folly supported compilers which did not implement
  `std::make_unique`, so there exists a backport implementation.
- Now that folly only supports C++14-compliant compilers, remove the
  backport.
- Fix call sites which were relying on unqualified `make_unique` being
  found in the folly namespace to explicitly use `std::make_unique`.