### PR TITLE
Cut GCC 5.0 preprocessor guard in Traits.h

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -657,9 +657,7 @@ namespace detail {
 // in order to not prevent all calling code from using it.
 FOLLY_PUSH_WARNING
 FOLLY_GNU_DISABLE_WARNING("-Wsign-compare")
-#if __GNUC_PREREQ(5, 0)
-FOLLY_GNU_DISABLE_WARNING("-Wbool-compare")
-#endif
+FOLLY_GCC_DISABLE_WARNING("-Wbool-compare")
 FOLLY_MSVC_DISABLE_WARNING(4388) // sign-compare
 FOLLY_MSVC_DISABLE_WARNING(4804) // bool-compare
 


### PR DESCRIPTION
Summary:
- Cut `#if __GNUC_PREREQ(5, 0)` preprocessor directive as folly does not
  support any GCC version lower than 5.1.
- Change from `FOLLY_GNU_DISABLE_WARNING` to `FOLLY_GCC_DISABLE_WARNING`
  since Clang does not support `-Wbool-compare` option.