### PR TITLE
Avoid C++-only attribute in CPortability.h 

### DIFF
--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -135,11 +135,7 @@
  * Macro for marking functions as having public visibility.
  */
 #if defined(__GNUC__)
-#if __GNUC_PREREQ(4, 9)
-#define FOLLY_EXPORT [[gnu::visibility("default")]]
-#else
 #define FOLLY_EXPORT __attribute__((__visibility__("default")))
-#endif
 #else
 #define FOLLY_EXPORT
 #endif


### PR DESCRIPTION
Summary:
- In defining `FOLLY_EXPORT`, we define it differently based on the GCC
  version. In the case of using GCC or Clang 5+, it will rely on
  `[[gnu::visibility("default")]]` which is a C++-specific attribute.
- Since `CPortability.h` is intended to be made to be included for C
  projects, remove `[[gnu::visibility("default")]]` and always define
  `FOLLY_EXPORT` using `__attribute__` syntax which works in C.