### PR TITLE
Add assert in Range::size()

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -421,12 +421,7 @@ class Range {
   }
 
   constexpr size_type size() const {
-    // It would be nice to assert(b_ <= e_) here.  This can be achieved even
-    // in a C++11 compatible constexpr function:
-    // http://ericniebler.com/2014/09/27/assert-and-constexpr-in-cxx11/
-    // Unfortunately current gcc versions have a bug causing it to reject
-    // this check in a constexpr function:
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71448
+    assert(b_ <= e_);
     return size_type(e_ - b_);
   }
   constexpr size_type walk_size() const {


### PR DESCRIPTION
Summary:
- Prior to commit 8cb615a27594078056b2e4ec2350660e594f5a89
  (Differential Revision: D3394612), `Range:size()` had an assert checking
  that the beginning iterator of the range is less than or equal to the end
  iterator. Unfortunately, due to GCC bug 71448, the `assert` was not allowed
  if we wanted `size()` to remain a `constexpr` function.
- This bug is no longer an issue with our current supported versions of GCC.
  As such, add the assert back in.