### PR TITLE
Cut FOLLY_HAVE_COMPARE_EQUIVALENT from StringKeyedBenchmark.cpp

### DIFF
--- a/folly/experimental/test/StringKeyedBenchmark.cpp
+++ b/folly/experimental/test/StringKeyedBenchmark.cpp
@@ -55,18 +55,8 @@ static const std::string lookup = "1234567890abcdefghijklmnopqrstuvwxyz"s;
 static const folly::StringPiece lookupPiece{
     "1234567890abcdefghijklmnopqrstuvwxyz"};
 
-#if !defined(FOLLY_HAVE_COMPARE_EQUIVALENT) && _LIBCPP_VERSION >= 3400
-#define FOLLY_HAVE_COMPARE_EQUIVALENT 1
-#endif
-
-#if !defined(FOLLY_HAVE_COMPARE_EQUIVALENT) && __GNUC__ >= 5
-#define FOLLY_HAVE_COMPARE_EQUIVALENT 1
-#endif
-
-#if FOLLY_HAVE_COMPARE_EQUIVALENT
 static map<string, int, std::less<void>> m_equiv;
 static set<string, std::less<void>> s_equiv;
-#endif
 
 static void initBenchmarks() {
   for (int i = 0; i < 1000; ++i) {
@@ -84,10 +74,8 @@ static void initBenchmarks() {
   sks = decltype(sks){s.begin(), s.end()};
   us = decltype(us){s.begin(), s.end()};
   skus = decltype(skus){s.begin(), s.end()};
-#if FOLLY_HAVE_COMPARE_EQUIVALENT
   m_equiv = decltype(m_equiv){m.begin(), m.end()};
   s_equiv = decltype(s_equiv){s.begin(), s.end()};
-#endif
 }
 
 BENCHMARK(std_map_benchmark_find_native) {
@@ -98,11 +86,9 @@ BENCHMARK_RELATIVE(std_map_benchmark_find_cross) {
   folly::doNotOptimizeAway(m.find(lookupPiece.str())->second);
 }
 
-#if FOLLY_HAVE_COMPARE_EQUIVALENT
 BENCHMARK_RELATIVE(std_map_benchmark_find_equiv) {
   folly::doNotOptimizeAway(m_equiv.find(lookupPiece)->second);
 }
-#endif
 
 BENCHMARK_RELATIVE(sk_map_benchmark_find_native) {
   folly::doNotOptimizeAway(skm.find(lookupPiece)->second);
@@ -178,11 +164,9 @@ BENCHMARK_RELATIVE(std_set_benchmark_find_cross) {
   folly::doNotOptimizeAway(s.find(lookupPiece.str()));
 }
 
-#if FOLLY_HAVE_COMPARE_EQUIVALENT
 BENCHMARK_RELATIVE(std_set_benchmark_find_equiv) {
   folly::doNotOptimizeAway(s_equiv.find(lookupPiece));
 }
-#endif
 
 BENCHMARK_RELATIVE(sk_set_benchmark_find_native) {
   folly::doNotOptimizeAway(sks.find(lookupPiece));


### PR DESCRIPTION
Summary:
- Cut `FOLLY_HAVE_COMPARE_EQUIVALENT` as this is `1` for Clang 3.4
  onward (regardless of `libstdc++` or `libc++`) and also `1` for GCC
  versions we support.