### PR TITLE
handle noexcept in SignatureOf_ and ArgTypes_

### DIFF
--- a/folly/detail/PolyDetail.h
+++ b/folly/detail/PolyDetail.h
@@ -397,6 +397,16 @@ struct SignatureOf_<R (C::*)(As...) const, I> {
   using type = Ret<R, I> (*)(Data const&, Arg<As, I>...);
 };
 
+template <class R, class C, class... As, class I>
+struct SignatureOf_<R(C::*)(As...) noexcept, I> {
+	using type = std::add_pointer_t<Ret<R, I>(Data&, Arg<As, I>...) noexcept>;
+};
+
+template <class R, class C, class... As, class I>
+struct SignatureOf_<R(C::*)(As...) const noexcept, I> {
+	using type = std::add_pointer_t<Ret<R, I>(Data const&, Arg<As, I>...) noexcept>;
+};
+
 template <class R, class This, class... As, class I>
 struct SignatureOf_<R (*)(This&, As...), I> {
   using type = Ret<R, I> (*)(Data&, Arg<As, I>...);
@@ -415,6 +425,11 @@ struct ArgTypes_;
 
 template <FOLLY_AUTO User, class I, class Ret, class Data, class... Args>
 struct ArgTypes_<User, I, Ret (*)(Data, Args...)> {
+  using type = TypeList<Args...>;
+};
+
+template <FOLLY_AUTO User, class I, class Ret, class Data, class... Args>
+struct ArgTypes_<User, I, Ret (*)(Data, Args...) noexcept> {
   using type = TypeList<Args...>;
 };
 


### PR DESCRIPTION
Fixes #737 

My use of `std::add_pointer_t` deviates in style from the alias decls in other `SignatureOf_` specializations because it is not possible with that syntax to declare a pointer to `noexcept` function. 