### PR TITLE
do not rely on deprecated __cpp_template_auto macro

### DIFF
--- a/folly/detail/PolyDetail.h
+++ b/folly/detail/PolyDetail.h
@@ -32,6 +32,12 @@
 
 #include <folly/PolyException.h>
 
+#if defined(__cpp_template_auto) || defined(__cpp_nontype_template_parameter_auto)
+#define FOLLY_NTTP_AUTO 1
+#else
+#define FOLLY_NTTP_AUTO 0
+#endif
+
 namespace folly {
 /// \cond
 namespace detail {
@@ -66,7 +72,7 @@ detail::AddCvrefOf<T, I>& poly_cast(detail::PolyRoot<I>&);
 template <class T, class I>
 detail::AddCvrefOf<T, I> const& poly_cast(detail::PolyRoot<I> const&);
 
-#if !defined(__cpp_template_auto)
+#if !FOLLY_NTTP_AUTO
 #define FOLLY_AUTO class
 template <class... Ts>
 using PolyMembers = detail::TypeList<Ts...>;
@@ -233,7 +239,7 @@ using MembersOf = typename I::template Members<remove_cvref_t<T>>;
 template <class I, class T>
 using InterfaceOf = typename I::template Interface<T>;
 
-#if !defined(__cpp_template_auto)
+#if !FOLLY_NTTP_AUTO
 template <class T, T V>
 using Member = std::integral_constant<T, V>;
 

--- a/folly/detail/PolyDetail.h
+++ b/folly/detail/PolyDetail.h
@@ -33,9 +33,9 @@
 #include <folly/PolyException.h>
 
 #if defined(__cpp_template_auto) || defined(__cpp_nontype_template_parameter_auto)
-#define FOLLY_POLLY_NTTP_AUTO 1
+#define FOLLY_POLY_NTTP_AUTO 1
 #else
-#define FOLLY_POLLY_NTTP_AUTO 0
+#define FOLLY_POLY_NTTP_AUTO 0
 #endif
 
 namespace folly {
@@ -72,7 +72,7 @@ detail::AddCvrefOf<T, I>& poly_cast(detail::PolyRoot<I>&);
 template <class T, class I>
 detail::AddCvrefOf<T, I> const& poly_cast(detail::PolyRoot<I> const&);
 
-#if !FOLLY_POLLY_NTTP_AUTO
+#if !FOLLY_POLY_NTTP_AUTO
 #define FOLLY_AUTO class
 template <class... Ts>
 using PolyMembers = detail::TypeList<Ts...>;
@@ -239,7 +239,7 @@ using MembersOf = typename I::template Members<remove_cvref_t<T>>;
 template <class I, class T>
 using InterfaceOf = typename I::template Interface<T>;
 
-#if !FOLLY_POLLY_NTTP_AUTO
+#if !FOLLY_POLY_NTTP_AUTO
 template <class T, T V>
 using Member = std::integral_constant<T, V>;
 

--- a/folly/detail/PolyDetail.h
+++ b/folly/detail/PolyDetail.h
@@ -33,9 +33,9 @@
 #include <folly/PolyException.h>
 
 #if defined(__cpp_template_auto) || defined(__cpp_nontype_template_parameter_auto)
-#define FOLLY_NTTP_AUTO 1
+#define FOLLY_POLLY_NTTP_AUTO 1
 #else
-#define FOLLY_NTTP_AUTO 0
+#define FOLLY_POLLY_NTTP_AUTO 0
 #endif
 
 namespace folly {
@@ -72,7 +72,7 @@ detail::AddCvrefOf<T, I>& poly_cast(detail::PolyRoot<I>&);
 template <class T, class I>
 detail::AddCvrefOf<T, I> const& poly_cast(detail::PolyRoot<I> const&);
 
-#if !FOLLY_NTTP_AUTO
+#if !FOLLY_POLLY_NTTP_AUTO
 #define FOLLY_AUTO class
 template <class... Ts>
 using PolyMembers = detail::TypeList<Ts...>;
@@ -239,7 +239,7 @@ using MembersOf = typename I::template Members<remove_cvref_t<T>>;
 template <class I, class T>
 using InterfaceOf = typename I::template Interface<T>;
 
-#if !FOLLY_NTTP_AUTO
+#if !FOLLY_POLLY_NTTP_AUTO
 template <class T, T V>
 using Member = std::integral_constant<T, V>;
 


### PR DESCRIPTION
Introduces a `FOLLY_NTTP_AUTO` macro to test if NTTP is available.

As per [cppreference](https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros), the macro `__cpp_nontype_template_parameter_auto` is the correct feature test macro to use for the NTTP used to define poly member list. The `__cpp_template_auto` version is checked too, but it was [deprecated](https://fossies.org/diffs/gcc/8.2.0_vs_8.3.0/gcc/c-family/ChangeLog-diff.html) in gcc 8.3 and not supported at all in MSVC. 

