### PR TITLE
Handle noexcept in SignatureOf_ and ArgTypes_, take 2

### DIFF
--- a/folly/detail/PolyDetail.h
+++ b/folly/detail/PolyDetail.h
@@ -404,6 +404,7 @@ struct SignatureOf_<R (C::*)(As...) const, I> {
   using type = Ret<R, I> (*)(Data const&, Arg<As, I>...);
 };
 
+#ifdef __cpp_noexcept_function_type
 template <class R, class C, class... As, class I>
 struct SignatureOf_<R(C::*)(As...) noexcept, I> {
 	using type = std::add_pointer_t<Ret<R, I>(Data&, Arg<As, I>...) noexcept>;
@@ -413,6 +414,7 @@ template <class R, class C, class... As, class I>
 struct SignatureOf_<R(C::*)(As...) const noexcept, I> {
 	using type = std::add_pointer_t<Ret<R, I>(Data const&, Arg<As, I>...) noexcept>;
 };
+#endif
 
 template <class R, class This, class... As, class I>
 struct SignatureOf_<R (*)(This&, As...), I> {
@@ -435,10 +437,12 @@ struct ArgTypes_<User, I, Ret (*)(Data, Args...)> {
   using type = TypeList<Args...>;
 };
 
+#ifdef __cpp_noexcept_function_type
 template <FOLLY_AUTO User, class I, class Ret, class Data, class... Args>
 struct ArgTypes_<User, I, Ret (*)(Data, Args...) noexcept> {
   using type = TypeList<Args...>;
 };
+#endif
 
 template <FOLLY_AUTO User, class I>
 using ArgTypes = _t<ArgTypes_<User, I>>;


### PR DESCRIPTION
Second attempt at https://github.com/facebook/folly/pull/1173

This time the class template specializations are guarded with the `__cpp_noexcept_function_type` feature test macro to maintain compatibility with C++14. 

Open to replacing the raw macro with something like `FOLLY_POLY_NOEXCEPT_FUNCTION_TYPE` but that was not my first approach since it's more characters and there is not an extra case to test like with `FOLLY_POLY_NTTP_AUTO`. 