### PR TITLE
allow overriding of receiving in AsyncUDPSocket

### DIFF
--- a/folly/io/async/AsyncUDPSocket.cpp
+++ b/folly/io/async/AsyncUDPSocket.cpp
@@ -495,7 +495,7 @@ size_t AsyncUDPSocket::handleErrMessages() noexcept {
   int ret;
   size_t num = 0;
   while (fd_ != NetworkSocket()) {
-    ret = netops::recvmsg(fd_, &msg, MSG_ERRQUEUE);
+    ret = recvmsg(fd_, &msg, MSG_ERRQUEUE);
     VLOG(5) << "AsyncSocket::handleErrMessages(): recvmsg returned " << ret;
 
     if (ret < 0) {
@@ -584,7 +584,7 @@ void AsyncUDPSocket::handleRead() noexcept {
   rawAddr->sa_family = localAddress_.getFamily();
 
   ssize_t bytesRead =
-      netops::recvfrom(fd_, buf, len, MSG_TRUNC, rawAddr, &addrLen);
+      recvfrom(fd_, buf, len, MSG_TRUNC, rawAddr, &addrLen);
   if (bytesRead >= 0) {
     clientAddress_.setFromSockaddr(rawAddr, addrLen);
 

--- a/folly/io/async/AsyncUDPSocket.h
+++ b/folly/io/async/AsyncUDPSocket.h
@@ -295,6 +295,21 @@ class AsyncUDPSocket : public EventHandler {
 
  protected:
   virtual ssize_t
+  recvmsg(NetworkSocket socket, msghdr* message, int flags) {
+    return netops::recvmsg(socket, message, flags);
+  }
+
+  virtual ssize_t recvfrom(
+    NetworkSocket socket,
+    void* buf,
+    size_t len,
+    int flags,
+    sockaddr* from,
+    socklen_t* fromlen) {
+    return netops::recvfrom(socket, buf, len, flags, from, fromlen);
+  }
+
+  virtual ssize_t
   sendmsg(NetworkSocket socket, const struct msghdr* message, int flags) {
     return netops::sendmsg(socket, message, flags);
   }
@@ -326,15 +341,15 @@ class AsyncUDPSocket : public EventHandler {
 
   void failErrMessageRead(const AsyncSocketException& ex);
 
+  // EventHandler
+  void handlerReady(uint16_t events) noexcept override;
+
   // Non-null only when we are reading
   ReadCallback* readCallback_;
 
  private:
   AsyncUDPSocket(const AsyncUDPSocket&) = delete;
   AsyncUDPSocket& operator=(const AsyncUDPSocket&) = delete;
-
-  // EventHandler
-  void handlerReady(uint16_t events) noexcept override;
 
   void handleRead() noexcept;
   bool updateRegistration() noexcept;


### PR DESCRIPTION
I'd like to inherit from AsyncUDPSocket and forward data from a tunnel to it.
sendmsg is already virtual, which allows me to send into my tunnel.
Making recv* virtual allows me to receive from the tunnel. I'll need to call handlerReady to trigger that.