### PR TITLE
Fix the implementation of max_align_t in lang/Align.h.

### DIFF
--- a/folly/lang/Align.h
+++ b/folly/lang/Align.h
@@ -31,7 +31,7 @@ constexpr size_t max_align_(std::size_t a) {
 }
 template <typename... Es>
 constexpr std::size_t max_align_(std::size_t a, std::size_t e, Es... es) {
-  return !(a < e) ? a : max_align_(e, es...);
+  return !(a < max_align_(e, es...)) ? a : max_align_(e, es...);
 }
 template <typename... Ts>
 struct max_align_t_ {

--- a/folly/lang/Align.h
+++ b/folly/lang/Align.h
@@ -31,7 +31,7 @@ constexpr size_t max_align_(std::size_t a) {
 }
 template <typename... Es>
 constexpr std::size_t max_align_(std::size_t a, std::size_t e, Es... es) {
-  return !(a < max_align_(e, es...)) ? a : max_align_(e, es...);
+  return !(a < e) ? max_align_(a, es...) : max_align_(e, es...);
 }
 template <typename... Ts>
 struct max_align_t_ {


### PR DESCRIPTION
Folly's Align.h header overwrites `max_align_t`, which is usually taken from stdlib. This is to correct an error in legacy implementations of `max_align_t`, by logically reconstructing the maximum alignment value in a constexpr.

max_align_t depends on the function `folly::details::max_align_`, which is supposed to implement a recursive max value function using templates. However, the expression

```
!(a < max_align_(e, es...)) ? a : max_align_(e, es...)
```

does not recursively compute the maximum value over `e` and `es...`

This implementation actually selects the first value of `e` and `es...` that is followed by a lower value.

The correct implementation is provided in this pull request.

This error prevents folly from compiling on newer versions of clang, targeting x86, because CachelinePadded.h statically checks max_align_t in an assertion, and then fails, because it thinks that AtomicStruct<LifoSemHead, atomic> is over-aligned.