### PR TITLE
folly: Don't include wait.h

### DIFF
--- a/folly/Subprocess.h
+++ b/folly/Subprocess.h
@@ -94,12 +94,7 @@
 
 #include <signal.h>
 #include <sys/types.h>
-
-#if __APPLE__
 #include <sys/wait.h>
-#else
-#include <wait.h>
-#endif
 
 #include <exception>
 #include <string>


### PR DESCRIPTION
wait.h is a GNU header. The POSIX one is sys/wait.h. Fixes musl warning:

warning redirecting incorrect #include <wait.h> to <sys/wait.h>