### PR TITLE
Check if type is instantiation of a template

### DIFF
--- a/folly/Replaceable.h
+++ b/folly/Replaceable.h
@@ -372,13 +372,8 @@ struct is_convertible_from_replaceable
           std::is_convertible<const Replaceable<T>&&, T>::value> {};
 } // namespace replaceable_detail
 
-// Type trait template to statically test whether a type is a specialization of
-// Replaceable
 template <class T>
-struct is_replaceable : std::false_type {};
-
-template <class T>
-struct is_replaceable<Replaceable<T>> : std::true_type {};
+using is_replaceable = detail::is_instantiation_of<Replaceable, T>;
 
 // Function to make a Replaceable with a type deduced from its input
 template <class T>

--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -213,6 +213,24 @@ struct like_<Src&&> {
   template <typename Dst>
   using apply = typename like_<Src>::template apply<Dst>&&;
 };
+
+/**
+ * A type trait to check if a given type is an instantiation of a class
+ * template.
+ *
+ * Note that this only works with template type parameters.
+ * It does not work when mixing type and non-type template parameters.
+ * It also does not work with alias templates as you cannot pass an alias
+ * template as a template template parameter.
+ */
+template <template <typename...> class, typename>
+struct is_instantiation_of  : std::false_type {};
+
+template <template <typename...> class C, typename... Ts>
+struct is_instantiation_of<C, C<Ts...>> : std::true_type {};
+
+template <template <typename...> class C, typename T>
+constexpr bool is_instantiation_of_v = is_instantiation_of<C, T>::value;
 } // namespace detail
 
 //  mimic: like_t, p0847r0

--- a/folly/container/Array.h
+++ b/folly/container/Array.h
@@ -26,10 +26,8 @@
 namespace folly {
 
 namespace array_detail {
-template <typename>
-struct is_ref_wrapper : std::false_type {};
-template <typename T>
-struct is_ref_wrapper<std::reference_wrapper<T>> : std::true_type {};
+template <class T>
+using is_ref_wrapper = detail::is_instantiation_of<std::reference_wrapper, T>;
 
 template <typename T>
 using not_ref_wrapper =

--- a/folly/experimental/coro/Task.h
+++ b/folly/experimental/coro/Task.h
@@ -24,6 +24,7 @@
 #include <folly/Executor.h>
 #include <folly/Portability.h>
 #include <folly/ScopeGuard.h>
+#include <folly/Traits.h>
 #include <folly/Try.h>
 #include <folly/experimental/coro/CurrentExecutor.h>
 #include <folly/experimental/coro/Traits.h>
@@ -481,9 +482,7 @@ inline Task<void> detail::TaskPromise<void>::get_return_object() noexcept {
 
 namespace detail {
 template <typename T>
-struct is_task : std::false_type {};
-template <typename T>
-struct is_task<Task<T>> : std::true_type {};
+using is_task = detail::is_instantiation_of<Task, T>;
 
 template <typename F, typename... A, typename F_, typename... A_>
 invoke_result_t<F, A...> co_invoke_(F_ f, A_... a) {

--- a/folly/experimental/coro/Traits.h
+++ b/folly/experimental/coro/Traits.h
@@ -26,11 +26,8 @@ namespace coro {
 namespace detail {
 
 template <typename T>
-struct _is_coroutine_handle : std::false_type {};
-
-template <typename T>
-struct _is_coroutine_handle<std::experimental::coroutine_handle<T>>
-    : std::true_type {};
+using _is_coroutine_handle =
+    is_instantiation_of<std::experimental::coroutine_handle, T>;
 
 template <typename T>
 struct _is_valid_await_suspend_return_type : folly::Disjunction<

--- a/folly/lang/PropagateConst.h
+++ b/folly/lang/PropagateConst.h
@@ -39,10 +39,8 @@ constexpr Pointer const& get_underlying(propagate_const<Pointer> const& obj) {
 }
 
 namespace detail {
-template <typename>
-struct is_propagate_const : std::false_type {};
-template <typename Pointer>
-struct is_propagate_const<propagate_const<Pointer>> : std::true_type {};
+template <class Pointer>
+using is_propagate_const = is_instantiation_of<propagate_const, Pointer>;
 template <typename T>
 using is_decay_propagate_const = is_propagate_const<std::decay_t<T>>;
 

--- a/folly/test/TraitsTest.cpp
+++ b/folly/test/TraitsTest.cpp
@@ -62,6 +62,9 @@ struct F3 : T3 {
 };
 struct F4 : T1 {};
 
+template<class> struct A{};
+struct B{};
+
 namespace folly {
 template <>
 struct IsRelocatable<T1> : std::true_type {};
@@ -391,4 +394,9 @@ TEST(Traits, like) {
   EXPECT_TRUE(
       (std::is_same<like_t<int const volatile&&, char>, char const volatile&&>::
            value));
+}
+
+TEST(Traits, is_instantiation_of) {
+  EXPECT_TRUE((detail::is_instantiation_of_v<A, A<int>>));
+  EXPECT_FALSE((detail::is_instantiation_of_v<A, B>));
 }


### PR DESCRIPTION
Summary:
- There is not an easy way to check if a given type is an instantiation
  of a class template.
- The common solution is to write a custom trait each time and
  specialize it for the given instantiation so that the trait returns
  `std:true_type`.
- Add `is_instantiation_of` to help with DRY in custom traits for
  checking if a type is an instance of a given class template. Note that
  this does not work when the class template has a mix of type and
  non-type template parameters. It only works with types.