### PR TITLE
Replace Boost iterator_facade with Folly analogue

### DIFF
--- a/folly/AtomicHashArray-inl.h
+++ b/folly/AtomicHashArray-inl.h
@@ -20,6 +20,7 @@
 
 #include <type_traits>
 
+#include <folly/detail/Iterators.h>
 #include <folly/detail/AtomicHashUtils.h>
 #include <folly/lang/Bits.h>
 #include <folly/lang/Exception.h>
@@ -485,10 +486,10 @@ struct AtomicHashArray<
     Allocator,
     ProbeFcn,
     KeyConvertFcn>::aha_iterator
-    : boost::iterator_facade<
+    : detail::IteratorFacade<
           aha_iterator<ContT, IterVal>,
           IterVal,
-          boost::forward_traversal_tag> {
+          std::forward_iterator_tag> {
   explicit aha_iterator() : aha_(nullptr) {}
 
   // Conversion ctor for interoperability between const_iterator and
@@ -519,7 +520,8 @@ struct AtomicHashArray<
 
  private:
   friend class AtomicHashArray;
-  friend class boost::iterator_core_access;
+  friend class detail::IteratorFacade<
+    aha_iterator, IterVal, std::forward_iterator_tag>;
 
   void increment() {
     ++offset_;

--- a/folly/AtomicHashArray.h
+++ b/folly/AtomicHashArray.h
@@ -34,8 +34,6 @@
 
 #include <atomic>
 
-#include <boost/iterator/iterator_facade.hpp>
-
 #include <folly/ThreadCachedInt.h>
 #include <folly/Utility.h>
 #include <folly/hash/Hash.h>

--- a/folly/AtomicHashMap-inl.h
+++ b/folly/AtomicHashMap-inl.h
@@ -19,6 +19,7 @@
 #endif
 
 #include <folly/detail/AtomicHashUtils.h>
+#include <folly/detail/Iterators.h>
 
 #include <type_traits>
 
@@ -568,10 +569,10 @@ struct AtomicHashMap<
     Allocator,
     ProbeFcn,
     KeyConvertFcn>::ahm_iterator
-    : boost::iterator_facade<
+    : detail::IteratorFacade<
           ahm_iterator<ContT, IterVal, SubIt>,
           IterVal,
-          boost::forward_traversal_tag> {
+          std::forward_iterator_tag> {
   explicit ahm_iterator() : ahm_(nullptr) {}
 
   // Conversion ctor for interoperability between const_iterator and
@@ -598,7 +599,8 @@ struct AtomicHashMap<
   explicit ahm_iterator(ContT* ahm, uint32_t subMap, const SubIt& subIt)
       : ahm_(ahm), subMap_(subMap), subIt_(subIt) {}
 
-  friend class boost::iterator_core_access;
+  friend class detail::IteratorFacade<
+    ahm_iterator, IterVal, std::forward_iterator_tag>;
 
   void increment() {
     CHECK(!isEnd());

--- a/folly/AtomicHashMap.h
+++ b/folly/AtomicHashMap.h
@@ -81,8 +81,6 @@
 #pragma once
 #define FOLLY_ATOMICHASHMAP_H_
 
-#include <boost/iterator/iterator_facade.hpp>
-
 #include <atomic>
 #include <functional>
 #include <stdexcept>

--- a/folly/ConcurrentSkipList.h
+++ b/folly/ConcurrentSkipList.h
@@ -125,13 +125,13 @@ Sample usage:
 #include <memory>
 #include <type_traits>
 
-#include <boost/iterator/iterator_facade.hpp>
 #include <glog/logging.h>
 
 #include <folly/ConcurrentSkipList-inl.h>
 #include <folly/Likely.h>
 #include <folly/Memory.h>
 #include <folly/synchronization/MicroSpinLock.h>
+#include <folly/detail/Iterators.h>
 
 namespace folly {
 
@@ -158,7 +158,7 @@ class ConcurrentSkipList {
   typedef T key_type;
 
   typedef detail::csl_iterator<value_type, NodeType> iterator;
-  typedef detail::csl_iterator<const value_type, const NodeType> const_iterator;
+  typedef detail::csl_iterator<const value_type, NodeType> const_iterator;
 
   class Accessor;
   class Skipper;
@@ -709,10 +709,10 @@ class ConcurrentSkipList<T, Comp, NodeAlloc, MAX_HEIGHT>::Accessor {
 
 // implements forward iterator concept.
 template <typename ValT, typename NodeT>
-class detail::csl_iterator : public boost::iterator_facade<
+class detail::csl_iterator : public detail::IteratorFacade<
                                  csl_iterator<ValT, NodeT>,
                                  ValT,
-                                 boost::forward_traversal_tag> {
+                                 std::forward_iterator_tag> {
  public:
   typedef ValT value_type;
   typedef value_type& reference;
@@ -738,9 +738,10 @@ class detail::csl_iterator : public boost::iterator_facade<
   }
 
  private:
-  friend class boost::iterator_core_access;
   template <class, class>
   friend class csl_iterator;
+  friend class detail::IteratorFacade<
+    csl_iterator, ValT, std::forward_iterator_tag>;
 
   void increment() {
     node_ = node_->next();

--- a/folly/io/RecordIO-inl.h
+++ b/folly/io/RecordIO-inl.h
@@ -18,17 +18,17 @@
 #error This file may only be included from folly/io/RecordIO.h
 #endif
 
-#include <boost/iterator/iterator_facade.hpp>
-
 #include <folly/hash/SpookyHashV2.h>
+#include <folly/detail/Iterators.h>
 
 namespace folly {
 
-class RecordIOReader::Iterator : public boost::iterator_facade<
+class RecordIOReader::Iterator : public detail::IteratorFacade<
                                      RecordIOReader::Iterator,
                                      const std::pair<ByteRange, off_t>,
-                                     boost::forward_traversal_tag> {
-  friend class boost::iterator_core_access;
+                                     std::forward_iterator_tag> {
+  friend class detail::IteratorFacade<
+    Iterator, value_type, std::forward_iterator_tag>;
   friend class RecordIOReader;
 
  private:


### PR DESCRIPTION
Folly already has its own lightweight implementation `IteratorFacade`. It depends only a few STL headers thus saves compilation time.