### PR TITLE
Add ARM64 support.

### DIFF
--- a/folly/portability/Builtins.h
+++ b/folly/portability/Builtins.h
@@ -50,7 +50,7 @@ FOLLY_ALWAYS_INLINE int __builtin_clzl(unsigned long x) {
   return __builtin_clz((unsigned int)x);
 }
 
-#if defined(_M_IX86) || defined(_M_ARM)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
 FOLLY_ALWAYS_INLINE int __builtin_clzll(unsigned long long x) {
   if (x == 0) {
     return 64;
@@ -75,7 +75,7 @@ FOLLY_ALWAYS_INLINE int __builtin_ctzl(unsigned long x) {
   return __builtin_ctz((unsigned int)x);
 }
 
-#if defined(_M_IX86) || defined(_M_ARM)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
 FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
   unsigned long index;
   unsigned int msb = (unsigned int)(x >> 32);
@@ -102,7 +102,7 @@ FOLLY_ALWAYS_INLINE int __builtin_ffsl(long x) {
   return __builtin_ffs(int(x));
 }
 
-#if defined(_M_IX86) || defined(_M_ARM)
+#if defined(_M_IX86) || defined(_M_ARM) || defined(_M_ARM64)
 FOLLY_ALWAYS_INLINE int __builtin_ffsll(long long x) {
   int ctzll = __builtin_ctzll((unsigned long long)x);
   return ctzll != 64 ? ctzll + 1 : 0;


### PR DESCRIPTION
Allow builds for 64-bit ARM (MSVC) to use the same implementation of `__builtin_clzll` as ARM and x86 architectures.