### PR TITLE
ExceptionTracerLib: allow overriding the deleter method for thrown exceptions

### DIFF
--- a/folly/experimental/exception_tracer/ExceptionCounterLib.cpp
+++ b/folly/experimental/exception_tracer/ExceptionCounterLib.cpp
@@ -103,7 +103,7 @@ namespace {
  * This handler gathers statistics on all exceptions thrown by the program
  * Information is being stored in thread local storage.
  */
-void throwHandler(void*, std::type_info* exType, void (*)(void*)) noexcept {
+void throwHandler(void*, std::type_info* exType, void (**)(void*)) noexcept {
   // This array contains the exception type and the stack frame
   // pointers so they get all hashed together.
   uintptr_t frames[kMaxFrames + 1];

--- a/folly/experimental/exception_tracer/ExceptionStackTraceLib.cpp
+++ b/folly/experimental/exception_tracer/ExceptionStackTraceLib.cpp
@@ -67,7 +67,7 @@ void moveTopException(StackTraceStack& from, StackTraceStack& to) {
 struct Initializer {
   Initializer() {
     registerCxaThrowCallback(
-        [](void*, std::type_info*, void (*)(void*)) noexcept {
+        [](void*, std::type_info*, void (**)(void*)) noexcept {
           addActiveException();
         });
 

--- a/folly/experimental/exception_tracer/ExceptionTracerLib.cpp
+++ b/folly/experimental/exception_tracer/ExceptionTracerLib.cpp
@@ -103,7 +103,7 @@ void __cxa_throw(
     void (*destructor)(void*)) {
   static auto orig_cxa_throw =
       reinterpret_cast<decltype(&__cxa_throw)>(dlsym(RTLD_NEXT, "__cxa_throw"));
-  getCxaThrowCallbacks().invoke(thrownException, type, destructor);
+  getCxaThrowCallbacks().invoke(thrownException, type, &destructor);
   orig_cxa_throw(thrownException, type, destructor);
   __builtin_unreachable(); // orig_cxa_throw never returns
 }

--- a/folly/experimental/exception_tracer/ExceptionTracerLib.h
+++ b/folly/experimental/exception_tracer/ExceptionTracerLib.h
@@ -29,7 +29,7 @@ namespace detail {
  * We, however, want callbacks to be exception safe.
  * This dummies are an ugly workaround that problem.
  */
-void dummyCxaThrow(void*, std::type_info*, void (*)(void*)) noexcept;
+void dummyCxaThrow(void*, std::type_info*, void (**)(void*)) noexcept;
 void dummyCxaBeginCatch(void*) noexcept;
 void dummyCxaRethrow() noexcept;
 void dummyCxaEndCatch() noexcept;


### PR DESCRIPTION
Summary: The folly changes allow overriding the deleter method when an exception is thrown.

Differential Revision: D16533296

