### PR TITLE
Do not use undefined behavior of adding to std namespace

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -22,6 +22,12 @@
 #include <limits>
 #include <memory>
 #include <type_traits>
+#include <string>
+#include <vector>
+#include <set>
+#include <deque>
+#include <map>
+#include <utility>
 
 #include <folly/Portability.h>
 
@@ -610,23 +616,6 @@ struct is_transparent : detail::is_transparent_<void, T> {};
  * are. Furthermore, all STL containers can be assumed to comply,
  * although that is not guaranteed by the standard.
  */
-
-FOLLY_NAMESPACE_STD_BEGIN
-
-template <class T, class U>
-struct pair;
-template <class T, class A>
-class vector;
-template <class T, class A>
-class deque;
-template <class T, class C, class A>
-class set;
-template <class K, class V, class C, class A>
-class map;
-template <class T>
-class shared_ptr;
-
-FOLLY_NAMESPACE_STD_END
 
 namespace folly {
 


### PR DESCRIPTION
Adding to the std namespace is undefined behavior, and this code is causing us some issues when updating to use libcpp stl on android.

16.5.4.2.1 [namespace.std]\1
Unless otherwise specified, the behavior of a C++ program is undefined if it adds declarations or definitions to namespace std or to a namespace within namespace std.


This version of the change removes the use of adding declarations to the std namespace altogether and just includes the required files.

I submitted another PR, #1204 that uses #ifdefs to achieve the same result, if its strongly desired that traits.h shouldn't include the stl headers.