### PR TITLE
Add an optional ifdef before using undefined behavior - ifdefs

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -611,6 +611,21 @@ struct is_transparent : detail::is_transparent_<void, T> {};
  * although that is not guaranteed by the standard.
  */
 
+
+#if FOLLY_NO_ALLOW_DECLARATIONS_ADDED_TO_STD
+
+// 16.5.4.2.1 [namespace.std]
+// Unless otherwise specified, the behavior of a C++ program is undefined if it adds declarations or definitions to namespace std or to a namespace within namespace std.
+
+#include <string>
+#include <vector>
+#include <set>
+#include <deque>
+#include <map>
+#include <utility>
+
+#else
+
 FOLLY_NAMESPACE_STD_BEGIN
 
 template <class T, class U>
@@ -627,6 +642,8 @@ template <class T>
 class shared_ptr;
 
 FOLLY_NAMESPACE_STD_END
+
+#endif
 
 namespace folly {
 


### PR DESCRIPTION
Adding to the std namespace is undefined behavior, and this code is causing us some issues when updating to use libcpp stl on android.

16.5.4.2.1 [namespace.std]\1
Unless otherwise specified, the behavior of a C++ program is undefined if it adds declarations or definitions to namespace std or to a namespace within namespace std.

This version of the change uses #ifdefs to conditionally not add to the stl namespace, in case its strongly desirable to not include the stl headers, even if it uses undefined behavior.

I submitted another PR, #1203  which removes the use of adding declarations to the std namespace altogether and just includes the required files.
