### PR TITLE
Fix sorted_vector PMR test cases

### DIFF
--- a/folly/test/sorted_vector_test.cpp
+++ b/folly/test/sorted_vector_test.cpp
@@ -22,8 +22,10 @@
 #include <string>
 #include <vector>
 
+#include <folly/CppAttributes.h>
 #include <folly/Range.h>
 #include <folly/Utility.h>
+#include <folly/memory/Malloc.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
 
@@ -856,14 +858,24 @@ TEST(SortedVectorTypes, TestEmplaceHint) {
 
 #if FOLLY_HAS_MEMORY_RESOURCE
 
+using folly::detail::std_pmr::memory_resource;
 using folly::detail::std_pmr::new_delete_resource;
 using folly::detail::std_pmr::null_memory_resource;
 using folly::detail::std_pmr::polymorphic_allocator;
-using folly::detail::std_pmr::resource_adaptor;
 
 namespace {
 
-struct test_resource : public resource_adaptor<std::allocator<char>> {
+struct test_resource : public memory_resource {
+  void* do_allocate(size_t bytes,
+                    FOLLY_MAYBE_UNUSED size_t alignment) override {
+    return folly::checkedMalloc(bytes);
+  }
+
+  void do_deallocate(void* p, FOLLY_MAYBE_UNUSED size_t bytes,
+                     FOLLY_MAYBE_UNUSED size_t alignment) noexcept override {
+    free(p);
+  }
+
   bool do_is_equal(const memory_resource& other) const noexcept override {
     return this == &other;
   }


### PR DESCRIPTION
`folly::detail::std_pmr` uses either `std::pmr` or `std::experimental::pmr`.

"Polymorphic Memory Resources" has been standardized in C++17, but `pmr::resource_adaptor` was [left behind](https://github.com/cplusplus/papers/issues/33), which means `resource_adaptor` is not available when a C++17 ready standard library is detected by folly.

This commit reimplements `test_resource` without using the non-standard adaptor.

```
folly/test/sorted_vector_test.cpp:862:31: error: ‘folly::detail::std_pmr::resource_adaptor’ has not been declared
  862 | using folly::detail::std_pmr::resource_adaptor;
      |                               ^~~~~~~~~~~~~~~~
```