### PR TITLE
folly | Improve support for clang-cl compiler in folly/Portability.h

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -250,10 +250,6 @@ constexpr bool kIsSanitize = false;
 #ifdef _MSC_VER
 #include <folly/portability/SysTypes.h>
 
-// compiler specific to compiler specific
-// nolint
-#define __PRETTY_FUNCTION__ __FUNCSIG__
-
 // Hide a GCC specific thing that breaks MSVC if left alone.
 #define __extension__
 
@@ -265,6 +261,9 @@ constexpr bool kIsSanitize = false;
 // So cannot unconditionally define __SSE4_2__ in clang.
 #ifndef __clang__
 #define __SSE4_2__ 1
+// compiler specific to compiler specific
+// nolint
+#define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 
 #endif


### PR DESCRIPTION
Summary: `clang-cl` on Windows also defines `__PRETTY_FUNCTION__` which has a format different from `__FUNCSIG__`. Therefore folly breaks users of this macro. Alias should be defined only when "real" MSVC compiler is used.

Differential Revision: D17094657

