### PR TITLE
Remove std::move() calls that prevent NRVO

### DIFF
--- a/folly/futures/Future-inl.h
+++ b/folly/futures/Future-inl.h
@@ -2061,7 +2061,7 @@ SemiFuture<T> SemiFuture<T>::within(Duration dur, E e, Timekeeper* tk) && {
   nestedExecutors.emplace_back(ctx->afterFuture.stealDeferredExecutor());
   futures::detail::getDeferredExecutor(fut)->setNestedExecutors(
       std::move(nestedExecutors));
-  return std::move(fut);
+  return fut;
 }
 
 // delayed


### PR DESCRIPTION
> Under the following circumstances, the compilers are permitted to omit the copy and move construction of class objects:

> In a return statement, when the operand is the name of a non-volatile object with automatic storage duration, which isn't a function parameter or a catch clause parameter, and which is of the same class type (ignoring cv-qualification) as the function return type. This variant of copy elision is known as NRVO, "named return value optimization". 

`std::move()` prevents this optimization.

GCC 9.1.0 warning:
```
moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
```