### PR TITLE
Fix tests on Arch Linux

### DIFF
--- a/folly/container/test/F14MapTest.cpp
+++ b/folly/container/test/F14MapTest.cpp
@@ -1365,14 +1365,16 @@ TEST(F14ValueMap, maxSize) {
   F14ValueMap<int, int> m;
   EXPECT_EQ(
       m.max_size(),
-      std::numeric_limits<std::size_t>::max() / sizeof(std::pair<int, int>));
+      std::allocator_traits<decltype(m)::allocator_type>::max_size(
+          m.get_allocator()));
 }
 
 TEST(F14NodeMap, maxSize) {
   F14NodeMap<int, int> m;
   EXPECT_EQ(
       m.max_size(),
-      std::numeric_limits<std::size_t>::max() / sizeof(std::pair<int, int>));
+      std::allocator_traits<decltype(m)::allocator_type>::max_size(
+          m.get_allocator()));
 }
 
 TEST(F14VectorMap, vectorMaxSize) {
@@ -1381,8 +1383,8 @@ TEST(F14VectorMap, vectorMaxSize) {
       m.max_size(),
       std::min(
           std::size_t{std::numeric_limits<uint32_t>::max()},
-          std::numeric_limits<std::size_t>::max() /
-              sizeof(std::pair<int, int>)));
+          std::allocator_traits<decltype(m)::allocator_type>::max_size(
+              m.get_allocator())));
 }
 
 template <typename M>

--- a/folly/container/test/F14SetTest.cpp
+++ b/folly/container/test/F14SetTest.cpp
@@ -982,13 +982,17 @@ TEST(F14VectorSet, destructuring) {
 TEST(F14ValueSet, maxSize) {
   F14ValueSet<int> s;
   EXPECT_EQ(
-      s.max_size(), std::numeric_limits<std::size_t>::max() / sizeof(int));
+      s.max_size(),
+      std::allocator_traits<decltype(s)::allocator_type>::max_size(
+          s.get_allocator()));
 }
 
 TEST(F14NodeSet, maxSize) {
   F14NodeSet<int> s;
   EXPECT_EQ(
-      s.max_size(), std::numeric_limits<std::size_t>::max() / sizeof(int));
+      s.max_size(),
+      std::allocator_traits<decltype(s)::allocator_type>::max_size(
+          s.get_allocator()));
 }
 
 TEST(F14VectorSet, maxSize) {
@@ -997,7 +1001,8 @@ TEST(F14VectorSet, maxSize) {
       s.max_size(),
       std::min(
           std::size_t{std::numeric_limits<uint32_t>::max()},
-          std::numeric_limits<std::size_t>::max() / sizeof(int)));
+          std::allocator_traits<decltype(s)::allocator_type>::max_size(
+              s.get_allocator())));
 }
 
 template <typename S>

--- a/folly/experimental/io/test/AsyncIOTest.cpp
+++ b/folly/experimental/io/test/AsyncIOTest.cpp
@@ -34,6 +34,7 @@
 #include <folly/experimental/io/FsUtil.h>
 #include <folly/portability/GTest.h>
 #include <folly/portability/Sockets.h>
+#include <folly/test/TestUtils.h>
 
 namespace fs = folly::fs;
 
@@ -137,7 +138,8 @@ void testReadsSerially(
   AsyncIO aioReader(1, pollMode);
   AsyncIO::Op op;
   int fd = ::open(tempFile.path().c_str(), O_DIRECT | O_RDONLY);
-  PCHECK(fd != -1);
+  SKIP_IF(fd == -1)
+    << "Tempfile can't be opened with O_DIRECT: " << errnoStr(errno);
   SCOPE_EXIT {
     ::close(fd);
   };
@@ -169,7 +171,8 @@ void testReadsParallel(
   bufs.reserve(specs.size());
 
   int fd = ::open(tempFile.path().c_str(), O_DIRECT | O_RDONLY);
-  PCHECK(fd != -1);
+  SKIP_IF(fd == -1)
+    << "Tempfile can't be opened with O_DIRECT: " << errnoStr(errno);
   SCOPE_EXIT {
     ::close(fd);
   };
@@ -234,7 +237,8 @@ void testReadsQueued(
   std::vector<ManagedBuffer> bufs;
 
   int fd = ::open(tempFile.path().c_str(), O_DIRECT | O_RDONLY);
-  PCHECK(fd != -1);
+  SKIP_IF(fd == -1)
+    << "Tempfile can't be opened with O_DIRECT: " << errnoStr(errno);
   SCOPE_EXIT {
     ::close(fd);
   };
@@ -373,7 +377,8 @@ TEST(AsyncIO, NonBlockingWait) {
   AsyncIO aioReader(1, AsyncIO::NOT_POLLABLE);
   AsyncIO::Op op;
   int fd = ::open(tempFile.path().c_str(), O_DIRECT | O_RDONLY);
-  PCHECK(fd != -1);
+  SKIP_IF(fd == -1)
+    << "Tempfile can't be opened with O_DIRECT: " << errnoStr(errno);
   SCOPE_EXIT {
     ::close(fd);
   };
@@ -403,7 +408,8 @@ TEST(AsyncIO, Cancel) {
 
   AsyncIO aioReader(kNumOpsBatch1 + kNumOpsBatch2, AsyncIO::NOT_POLLABLE);
   int fd = ::open(tempFile.path().c_str(), O_DIRECT | O_RDONLY);
-  PCHECK(fd != -1);
+  SKIP_IF(fd == -1)
+    << "Tempfile can't be opened with O_DIRECT: " << errnoStr(errno);
   SCOPE_EXIT {
     ::close(fd);
   };

--- a/folly/test/common/TestMain.cpp
+++ b/folly/test/common/TestMain.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <glog/logging.h>
+
 #include <folly/init/Init.h>
 
 #include <folly/Portability.h>
@@ -28,11 +30,8 @@
 FOLLY_ATTR_WEAK int main(int argc, char** argv);
 
 int main(int argc, char** argv) {
-#if FOLLY_HAVE_LIBGFLAGS
   // Enable glog logging to stderr by default.
-  gflags::SetCommandLineOptionWithMode(
-      "logtostderr", "1", gflags::SET_FLAGS_DEFAULT);
-#endif
+  FLAGS_logtostderr = true;
 
   ::testing::InitGoogleTest(&argc, argv);
   folly::Init init(&argc, &argv);


### PR DESCRIPTION
Compiling folly on Arch Linux triggered a few platform-specific behaviors that were not covered correctly by tests.

- Fix F14{Map,Set} maxSize test cases
    The maximum size of `F14Table` is dependent of its allocator's max_size:

    ```
    max_size() -> std::min<std::size_t>(
        (std::numeric_limits<InternalSizeType>::max)(),
        AllocTraits::max_size(a)
    )
    ```

    This commit fixes the `F14{Map,Set}` maxSize tests, so they won't fail
    on platforms where the standard allocator's `max_size()` is based on
    `ptrdiff_t` (signed).

-  Fix TestUtilTest
    If glog is compiled without gflags support, `SetCommandLineOptionWithMode()`
    can't force glog to use stderr.

    glog has its own compatibility layer for `FLAGS_*` in case gflags is missing,
    that's why `FLAGS_logtostderr` is always available.

- Skip AsyncIOTest tests if O_DIRECT is not supported by the file system
    `fs::temp_directory_path()` returns `"/tmp"` on Linux.

    When using systemd, the /tmp directory is mounted by default as tmpfs;
    and tmpfs does not support the `O_DIRECT` flag.

    This commit skips tests in case the file can't be opened with `O_DIRECT`.