### PR TITLE
Support offline CPUs in CacheLocality::readFromProcCpuinfo

### DIFF
--- a/folly/concurrency/CacheLocality.cpp
+++ b/folly/concurrency/CacheLocality.cpp
@@ -228,10 +228,6 @@ CacheLocality CacheLocality::readFromProcCpuinfoLines(
   if (cpus.empty()) {
     throw std::runtime_error("no CPUs parsed from /proc/cpuinfo");
   }
-  if (maxCpu != cpus.size() - 1) {
-    throw std::runtime_error(
-        "offline CPUs not supported for /proc/cpuinfo cache locality source");
-  }
 
   std::sort(cpus.begin(), cpus.end());
   size_t cpusPerCore = 1;
@@ -249,7 +245,7 @@ CacheLocality CacheLocality::readFromProcCpuinfoLines(
   numCachesByLevel.push_back(cpus.size() / cpusPerCore);
   numCachesByLevel.push_back(std::get<0>(cpus.back()) + 1);
 
-  std::vector<size_t> indexes(cpus.size());
+  std::vector<size_t> indexes(maxCpu + 1, std::numeric_limits<size_t>::max());
   for (size_t i = 0; i < cpus.size(); ++i) {
     indexes[std::get<2>(cpus[i])] = i;
   }

--- a/folly/concurrency/CacheLocality.h
+++ b/folly/concurrency/CacheLocality.h
@@ -83,6 +83,8 @@ struct CacheLocality {
   /// For example, if numCpus is 32 and numCachesByLevel.back() is 2,
   /// then cpus with a locality index < 16 will share one last-level
   /// cache and cpus with a locality index >= 16 will share the other.
+  /// A value of size_t::max() indicates that cpu is not online and
+  /// hence locality information is not available.
   std::vector<size_t> localityIndexByCpu;
 
   /// Returns the best CacheLocality information available for the current
@@ -368,6 +370,10 @@ struct AccessSpreader {
       auto numStripes = std::max(size_t{1}, width);
       for (size_t cpu = 0; cpu < kMaxCpus && cpu < n; ++cpu) {
         auto index = cacheLocality.localityIndexByCpu[cpu];
+        if (index == std::numeric_limits<size_t>::max()) {
+          // offline (not present) CPU, skip.
+          continue;
+        }
         assert(index < n);
         // as index goes from 0..n, post-transform value goes from
         // 0..numStripes


### PR DESCRIPTION
Ensure that CacheLocality::readFromProcCpuinfo() sizes the cache
locality `indexes` vector based on the maximum core number, correclty
handling instances where one or more CPU cores are offline.

Fixes #1219.