### PR TITLE
libfolly.pc: Fix for cross compilation

### DIFF
--- a/CMake/libfolly.pc.in
+++ b/CMake/libfolly.pc.in
@@ -1,6 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: libfolly
 Description: Facebook (Folly) C++ library


### PR DESCRIPTION
Changes libfolly.pc to a more standard format.

Allows overriding of the variables by pkgconfig.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

I'm not sure of anything that uses pkgconfig to find libfolly but might as well fix it.