### PR TITLE
Update Demangle.h

### DIFF
--- a/folly/detail/Demangle.h
+++ b/folly/detail/Demangle.h
@@ -18,7 +18,7 @@
 
 #include <cstddef>
 
-#if __has_include(<demangle.h>)
+#if __has_include(<Demangle.h>)
 #define FOLLY_DETAIL_HAVE_DEMANGLE_H 1
 #else
 #define FOLLY_DETAIL_HAVE_DEMANGLE_H 0


### PR DESCRIPTION
When I compile WDT in CentOS system, I will report an error "
libfolly4wdt.so: undefined reference to `folly::detail::cplus_demangle_v3_callback_wrapper(char const*, void (*)(char const*, unsigned long, void*), void*)'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/histogram.dir/build.make:92: _bin/wdt/histogram] Error 1
make[1]: *** [CMakeFiles/Makefile2:667: CMakeFiles/histogram.dir/all] Error 2
"
It is confirmed that follyfollydetailDemangle.h in the folly project results, so modify the file to avoid errors.