### PR TITLE
Evaluate generator expressions in generated pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,8 +397,13 @@ install(
 # CMake can depend on folly using pkg-config.
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/CMake/libfolly.pc.in
-  ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc
+  ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc.gen
   @ONLY
+)
+file(
+  GENERATE
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc
+  INPUT ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc.gen
 )
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc


### PR DESCRIPTION
Summary:
The variables written to `libfolly.pc` by CMake may contain generator
expressions, in which case `libfolly.pc` ends up containing them
verbatim.  This adds a postprocessing stage in which the variables are
evaluated to yield the final `libfolly.pc`.