### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ Folly is published on GitHub at https://github.com/facebook/folly
 
 ### Build Notes
 
+You can download and install folly using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install folly
+
+The folly port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 #### Dependencies
 
 folly requires gcc 5.1+ and a version of boost compiled with C++14 support.


### PR DESCRIPTION
Folly is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for folly and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build folly, ready to be included in their projects. 

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/folly/portfile.cmake). We try to keep the library maintained as close as possible to the original library.