### PR TITLE
Build fix for latest version of MSVC

### DIFF
--- a/folly/portability/Builtins.h
+++ b/folly/portability/Builtins.h
@@ -41,6 +41,7 @@ FOLLY_ALWAYS_INLINE void __builtin___clear_cache(char* begin, char* end) {
   }
 }
 
+#if !defined(_MSC_VER) || (_MSC_VER < 1923)
 FOLLY_ALWAYS_INLINE int __builtin_clz(unsigned int x) {
   unsigned long index;
   return int(_BitScanReverse(&index, (unsigned long)x) ? 31 - index : 32);
@@ -92,6 +93,7 @@ FOLLY_ALWAYS_INLINE int __builtin_ctzll(unsigned long long x) {
   return int(_BitScanForward64(&index, x) ? index : 64);
 }
 #endif
+#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
 
 FOLLY_ALWAYS_INLINE int __builtin_ffs(int x) {
   unsigned long index;
@@ -117,12 +119,15 @@ FOLLY_ALWAYS_INLINE int __builtin_popcount(unsigned int x) {
   return int(__popcnt(x));
 }
 
+#if !defined(_MSC_VER) || (_MSC_VER < 1923)
 FOLLY_ALWAYS_INLINE int __builtin_popcountl(unsigned long x) {
   static_assert(sizeof(x) == 4, "");
   return int(__popcnt(x));
 }
+#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
 #endif
 
+#if !defined(_MSC_VER) || (_MSC_VER < 1923)
 #if defined(_M_IX86)
 FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
   return int(__popcnt((unsigned int)(x >> 32))) +
@@ -133,6 +138,7 @@ FOLLY_ALWAYS_INLINE int __builtin_popcountll(unsigned long long x) {
   return int(__popcnt64(x));
 }
 #endif
+#endif // !defined(_MSC_VER) || (_MSC_VER < 1923)
 
 FOLLY_ALWAYS_INLINE void* __builtin_return_address(unsigned int frame) {
   // I really hope frame is zero...


### PR DESCRIPTION
Newest builds of MSVC have a few more builtin's supported, so those polyfills need to be removed when using newer builds of MSVC.