### PR TITLE
asnTimeToTimepoint: Use a const parameter

### DIFF
--- a/folly/ssl/OpenSSLCertUtils.cpp
+++ b/folly/ssl/OpenSSLCertUtils.cpp
@@ -164,7 +164,7 @@ std::string OpenSSLCertUtils::getNotBeforeTime(X509& x509) {
 }
 
 std::chrono::system_clock::time_point OpenSSLCertUtils::asnTimeToTimepoint(
-    ASN1_TIME* asnTime) {
+    const ASN1_TIME* asnTime) {
   int dSecs = 0;
   int dDays = 0;
 

--- a/folly/ssl/OpenSSLCertUtils.h
+++ b/folly/ssl/OpenSSLCertUtils.h
@@ -115,7 +115,7 @@ class OpenSSLCertUtils {
    * std::chrono classes.
    */
   static std::chrono::system_clock::time_point asnTimeToTimepoint(
-      ASN1_TIME* asnTime);
+      const ASN1_TIME* asnTime);
 
  private:
   static std::string getDateTimeStr(const ASN1_TIME* time);


### PR DESCRIPTION
X509_get0_notBefore returns and takes const parameters.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @reanimus 