### PR TITLE
[ThreadName.cpp] Add explicit return in the default case

### DIFF
--- a/folly/system/ThreadName.cpp
+++ b/folly/system/ThreadName.cpp
@@ -199,10 +199,10 @@ bool setThreadName(std::thread::id tid, StringPiece name) {
   if (pthread_equal(pthread_self(), id)) {
     return 0 == prctl(PR_SET_NAME, buf, 0L, 0L, 0L);
   }
-#else
+#endif
+
   (void)id;
   return false;
-#endif
 #endif
 }
 


### PR DESCRIPTION
Fixes cases where control would reach the end of the setThreadName function without an explicit return