### PR TITLE
[clang-tidy] Get rid of deprecated headers

### DIFF
--- a/folly/ClockGettimeWrappers.cpp
+++ b/folly/ClockGettimeWrappers.cpp
@@ -20,7 +20,7 @@
 
 #include <chrono>
 
-#include <time.h>
+#include <ctime>
 
 #ifndef _WIN32
 #define _GNU_SOURCE 1

--- a/folly/detail/Futex.cpp
+++ b/folly/detail/Futex.cpp
@@ -18,8 +18,8 @@
 #include <folly/ScopeGuard.h>
 #include <folly/hash/Hash.h>
 #include <folly/portability/SysSyscall.h>
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 #include <array>
 #include <cerrno>
 

--- a/folly/detail/MemoryIdler.cpp
+++ b/folly/detail/MemoryIdler.cpp
@@ -27,9 +27,9 @@
 #include <folly/portability/Unistd.h>
 #include <folly/synchronization/CallOnce.h>
 
-#include <limits.h>
-#include <stdio.h>
-#include <string.h>
+#include <climits>
+#include <cstdio>
+#include <cstring>
 #include <utility>
 
 namespace folly {

--- a/folly/executors/ManualExecutor.cpp
+++ b/folly/executors/ManualExecutor.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/executors/ManualExecutor.h>
 
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <tuple>
 

--- a/folly/experimental/QuotientMultiSet.cpp
+++ b/folly/experimental/QuotientMultiSet.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/experimental/QuotientMultiSet.h>
 
-#include <math.h>
+#include <cmath>
 
 #include <folly/Math.h>
 

--- a/folly/fibers/FiberManager.cpp
+++ b/folly/fibers/FiberManager.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/fibers/FiberManagerInternal.h>
 
-#include <signal.h>
+#include <csignal>
 
 #include <cassert>
 #include <stdexcept>

--- a/folly/fibers/GuardPageAllocator.cpp
+++ b/folly/fibers/GuardPageAllocator.cpp
@@ -19,7 +19,7 @@
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
-#include <signal.h>
+#include <csignal>
 
 #include <iostream>
 #include <mutex>

--- a/folly/io/IOBufQueue.cpp
+++ b/folly/io/IOBufQueue.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/io/IOBufQueue.h>
 
-#include <string.h>
+#include <cstring>
 
 #include <stdexcept>
 

--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -19,7 +19,7 @@
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/Sockets.h>
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <chrono>

--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -31,8 +31,8 @@
 #include <folly/portability/Sockets.h>
 #include <folly/portability/Unistd.h>
 
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 #include <sys/types.h>
 
 namespace folly {

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -30,8 +30,8 @@
 #include <folly/portability/Unistd.h>
 
 #include <boost/preprocessor/control/if.hpp>
-#include <errno.h>
-#include <limits.h>
+#include <cerrno>
+#include <climits>
 #include <sys/types.h>
 #include <sstream>
 #include <thread>

--- a/folly/io/async/AsyncTimeout.cpp
+++ b/folly/io/async/AsyncTimeout.cpp
@@ -20,7 +20,7 @@
 #include <folly/io/async/Request.h>
 #include <folly/net/NetworkSocket.h>
 
-#include <assert.h>
+#include <cassert>
 #include <glog/logging.h>
 
 namespace folly {

--- a/folly/io/async/AsyncUDPSocket.cpp
+++ b/folly/io/async/AsyncUDPSocket.cpp
@@ -23,7 +23,7 @@
 #include <folly/portability/Unistd.h>
 
 #include <boost/preprocessor/control/if.hpp>
-#include <errno.h>
+#include <cerrno>
 
 // Due to the way kernel headers are included, this may or may not be defined.
 // Number pulled from 3.10 kernel headers.

--- a/folly/io/async/EventHandler.cpp
+++ b/folly/io/async/EventHandler.cpp
@@ -18,7 +18,7 @@
 #include <folly/String.h>
 #include <folly/io/async/EventBase.h>
 
-#include <assert.h>
+#include <cassert>
 
 namespace folly {
 

--- a/folly/io/async/test/SocketPair.cpp
+++ b/folly/io/async/test/SocketPair.cpp
@@ -22,7 +22,7 @@
 #include <folly/portability/Sockets.h>
 #include <folly/portability/Unistd.h>
 
-#include <errno.h>
+#include <cerrno>
 #include <stdexcept>
 
 namespace folly {

--- a/folly/io/async/test/TimeUtil.cpp
+++ b/folly/io/async/test/TimeUtil.cpp
@@ -20,7 +20,7 @@
 
 #include <folly/io/async/test/TimeUtil.h>
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/folly/net/NetOps.cpp
+++ b/folly/net/NetOps.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/net/NetOps.h>
 
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 
 #include <cstddef>

--- a/folly/portability/Libgen.cpp
+++ b/folly/portability/Libgen.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/portability/Libgen.h>
 
-#include <string.h>
+#include <cstring>
 
 namespace folly {
 namespace portability {

--- a/folly/portability/Semaphore.cpp
+++ b/folly/portability/Semaphore.cpp
@@ -18,7 +18,7 @@
 
 #include <folly/portability/Windows.h>
 
-#include <errno.h>
+#include <cerrno>
 #include <mutex>
 
 #ifdef _WIN32

--- a/folly/portability/SysResource.cpp
+++ b/folly/portability/SysResource.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/portability/SysResource.h>
 
-#include <errno.h>
+#include <cerrno>
 
 #ifdef _WIN32
 #include <folly/portability/Windows.h>

--- a/folly/portability/SysUio.cpp
+++ b/folly/portability/SysUio.cpp
@@ -16,8 +16,8 @@
 
 #include <folly/portability/SysUio.h>
 
-#include <errno.h>
-#include <stdio.h>
+#include <cerrno>
+#include <cstdio>
 
 #include <folly/ScopeGuard.h>
 #include <folly/portability/Sockets.h>

--- a/folly/portability/Time.cpp
+++ b/folly/portability/Time.cpp
@@ -19,7 +19,7 @@
 #include <folly/CPortability.h>
 #include <folly/Likely.h>
 
-#include <assert.h>
+#include <cassert>
 
 #include <chrono>
 

--- a/folly/test/DeterministicSchedule.cpp
+++ b/folly/test/DeterministicSchedule.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/test/DeterministicSchedule.h>
 
-#include <assert.h>
+#include <cassert>
 
 #include <algorithm>
 #include <list>


### PR DESCRIPTION
Found with modernize-deprecated-headers

Note that C++14 deprecated these.

Signed-off-by: Rosen Penev <rosenp@gmail.com>