### PR TITLE
Asm: pause under MIPS as well

### DIFF
--- a/folly/portability/Asm.h
+++ b/folly/portability/Asm.h
@@ -36,7 +36,7 @@ inline void asm_volatile_memory() {
 inline void asm_volatile_pause() {
 #if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
   ::_mm_pause();
-#elif defined(__i386__) || FOLLY_X64
+#elif defined(__i386__) || FOLLY_X64 || (__mips_isa_rev > 1)
   asm volatile("pause");
 #elif FOLLY_AARCH64 || (defined(__arm__) && !(__ARM_ARCH < 7))
   asm volatile("yield");


### PR DESCRIPTION
The instruction is identical to the x86 one. First introduced in MIPS32r2.

Signed-off-by: Rosen Penev <rosenp@gmail.com>