### PR TITLE
folly | Add explicit bool conversion operator to Function::SharedProxy

### DIFF
--- a/folly/Function.h
+++ b/folly/Function.h
@@ -333,6 +333,10 @@ class FunctionTraitsSharedProxy {
     return (*sp_)(static_cast<A&&>(args)...);
   }
 
+  explicit operator bool() const noexcept {
+    return sp_ && *sp_;
+  }
+
   friend bool operator==(
       FunctionTraitsSharedProxy<F, R, A...> const& proxy,
       std::nullptr_t) noexcept {

--- a/folly/test/FunctionTest.cpp
+++ b/folly/test/FunctionTest.cpp
@@ -1092,6 +1092,20 @@ TEST(Function, asSharedProxy_args_const) {
   EXPECT_EQ(562, spcopy(5, 6));
 }
 
+TEST(Function, asSharedProxy_explicit_bool_conversion) {
+  folly::Function<void(void)> f = []() {};
+  auto sp = std::move(f).asSharedProxy();
+  auto spcopy = sp;
+  EXPECT_TRUE(sp);
+  EXPECT_TRUE(spcopy);
+
+  folly::Function<void(void)> emptyF;
+  auto emptySp = std::move(emptyF).asSharedProxy();
+  auto emptySpcopy = emptySp;
+  EXPECT_FALSE(emptySp);
+  EXPECT_FALSE(emptySpcopy);
+}
+
 TEST(Function, NoAllocatedMemoryAfterMove) {
   Functor<int, 100> foo;
 


### PR DESCRIPTION
Summary: `folly::Function` has this explicit bool conversion operator and it makes sense to also have it for `SharedProxy`.

Differential Revision: D18504667

