### PR TITLE
[clang-tidy] Use ranged based for loops

### DIFF
--- a/folly/Fingerprint.cpp
+++ b/folly/Fingerprint.cpp
@@ -98,10 +98,10 @@ constexpr poly_table<Deg> make_poly_table() {
   for (uint16_t x = 0; x < 256; x++) {
     FingerprintPolynomial<Deg> t;
     t.setHigh8Bits(uint8_t(x));
-    for (int i = 0; i < 8; i++) {
+    for (auto& entry : table) {
       t.mulXkmod(8, poly);
       for (size_t j = 0; j < poly_size(Deg); ++j) {
-        table[i][x][j] = t.get(j);
+        entry[x][j] = t.get(j);
       }
     }
   }

--- a/folly/dynamic.cpp
+++ b/folly/dynamic.cpp
@@ -380,7 +380,7 @@ dynamic::try_get_ptr(json_pointer const& jsonPtr) const& {
   size_t curr_idx{0};
   StringPiece curr_key{};
 
-  for (auto&& it : enumerate(tokens)) {
+  for (auto it : enumerate(tokens)) {
     // hit bottom but pointer not exhausted yet
     if (!curr) {
       return makeUnexpected(

--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -212,16 +212,14 @@ int AsyncServerSocket::stopAccepting(int shutdownFlags) {
   // removeAcceptCallback().
   std::vector<CallbackInfo> callbacksCopy;
   callbacks_.swap(callbacksCopy);
-  for (auto it = callbacksCopy.begin();
-       it != callbacksCopy.end();
-       ++it) {
+  for (const auto& callback : callbacksCopy) {
     // consumer may not be set if we are running in primary event base
-    if (it->consumer) {
-      DCHECK(it->eventBase);
-      it->consumer->stop(it->eventBase, it->callback);
+    if (callback.consumer) {
+      DCHECK(callback.eventBase);
+      callback.consumer->stop(callback.eventBase, callback.callback);
     } else {
-      DCHECK(it->callback);
-      it->callback->acceptStopped();
+      DCHECK(callback.callback);
+      callback.callback->acceptStopped();
     }
   }
 

--- a/folly/io/async/AsyncSignalHandler.cpp
+++ b/folly/io/async/AsyncSignalHandler.cpp
@@ -31,10 +31,8 @@ AsyncSignalHandler::AsyncSignalHandler(EventBase* eventBase)
 
 AsyncSignalHandler::~AsyncSignalHandler() {
   // Unregister any outstanding events
-  for (auto it = signalEvents_.begin();
-       it != signalEvents_.end();
-       ++it) {
-    event_del(&it->second);
+  for (auto & signalEvent : signalEvents_) {
+    event_del(&signalEvent.second);
   }
 }
 

--- a/folly/io/async/test/AsyncSocketTest.h
+++ b/folly/io/async/test/AsyncSocketTest.h
@@ -97,10 +97,8 @@ class ReadCallback : public folly::AsyncTransportWrapper::ReadCallback {
         maxBufferSz(_maxBufferSz) {}
 
   ~ReadCallback() override {
-    for (std::vector<Buffer>::iterator it = buffers.begin();
-         it != buffers.end();
-         ++it) {
-      it->free();
+    for (const auto& buffer : buffers) {
+      buffers.free();
     }
     currentBuffer.free();
   }

--- a/folly/io/async/test/AsyncSocketTest2.cpp
+++ b/folly/io/async/test/AsyncSocketTest2.cpp
@@ -918,15 +918,13 @@ void testConnectOptWrite(size_t size1, size_t size2, bool close = false) {
 
   // Make sure the read callback received all of the data
   size_t bytesRead = 0;
-  for (vector<ReadCallback::Buffer>::const_iterator it = rcb.buffers.begin();
-       it != rcb.buffers.end();
-       ++it) {
+  for (const auto& buffer : rcb.buffers) {
     size_t start = bytesRead;
-    bytesRead += it->length;
+    bytesRead += buffer.length;
     size_t end = bytesRead;
     if (start < size1) {
       size_t cmpLen = min(size1, end) - start;
-      ASSERT_EQ(memcmp(it->buffer, buf1.get() + start, cmpLen), 0);
+      ASSERT_EQ(memcmp(buffer.buffer, buf1.get() + start, cmpLen), 0);
     }
     if (end > size1 && end <= size1 + size2) {
       size_t itOffset;
@@ -942,7 +940,7 @@ void testConnectOptWrite(size_t size1, size_t size2, bool close = false) {
         cmpLen = end - size1;
       }
       ASSERT_EQ(
-          memcmp(it->buffer + itOffset, buf2.get() + buf2Offset, cmpLen), 0);
+          memcmp(buffer.buffer + itOffset, buf2.get() + buf2Offset, cmpLen), 0);
     }
   }
   ASSERT_EQ(bytesRead, size1 + size2);
@@ -1509,10 +1507,8 @@ TEST(AsyncSocketTest, ClosePendingWritesWhileClosing) {
   socket->closeNow();
 
   // Make sure writeError() was invoked on all of the pending write callbacks
-  for (WriteCallbackVector::const_iterator it = writeCallbacks.begin();
-       it != writeCallbacks.end();
-       ++it) {
-    ASSERT_EQ((*it)->state, STATE_FAILED);
+  for (const auto& writeCallback : writeCallbacks) {
+    ASSERT_EQ((writeCallback)->state, STATE_FAILED);
   }
 
   ASSERT_TRUE(socket->isClosedBySelf());

--- a/folly/io/async/test/EventBaseTest.cpp
+++ b/folly/io/async/test/EventBaseTest.cpp
@@ -1252,11 +1252,9 @@ TEST_F(EventBaseTest, RunInThread) {
   for (uint32_t n = 0; n < numThreads; ++n) {
     expectedValues[n] = 0;
   }
-  for (deque<pair<int, int>>::const_iterator it = data.values.begin();
-       it != data.values.end();
-       ++it) {
-    int threadID = it->first;
-    int value = it->second;
+  for (const auto& dataValue : data.values) {
+    int threadID = dataValue.first;
+    int value = dataValue.second;
     ASSERT_EQ(expectedValues[threadID], value);
     ++expectedValues[threadID];
   }

--- a/folly/json_patch.cpp
+++ b/folly/json_patch.cpp
@@ -243,7 +243,7 @@ json_patch::apply(dynamic& obj) {
   using error_code = patch_application_error_code;
   using error = patch_application_error;
 
-  for (auto&& it : enumerate(ops_)) {
+  for (auto it : enumerate(ops_)) {
     auto const index = it.index;
     auto const& op = *it;
     auto resolved_path = obj.try_get_ptr(op.path);


### PR DESCRIPTION
Found with modernize-loop-convert

Signed-off-by: Rosen Penev <rosenp@gmail.com>