### PR TITLE
Add instructions for installiing fmt from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ sudo apt-get install \
     pkg-config
 ```
 
+Folly relies on [fmt](https://github.com/fmtlib/fmt) which needs to be installed from source.
+The following commands will download, compile, and install fmt.
+
+```
+git clone https://github.com/fmtlib/fmt.git && cd fmt
+
+mkdir _build && cd _build
+cmake ..
+
+make -j$(nproc)
+sudo make install
+```
+git
 If advanced debugging functionality is required, use:
 
 ```

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ cmake ..
 make -j$(nproc)
 sudo make install
 ```
-git
+
 If advanced debugging functionality is required, use:
 
 ```


### PR DESCRIPTION
Dovetailing off of #1262 ; Folly's dependency on `fmt` isn't explicitly mentioned nor are from-source install instructions provided. This PR adds a short section to the README describing how to build and install fmt from source.