### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ sudo apt-get install \
     binutils-dev \
     libjemalloc-dev \
     libssl-dev \
-    pkg-config
+    pkg-config \
+    libunwind-dev
 ```
 
 Folly relies on [fmt](https://github.com/fmtlib/fmt) which needs to be installed from source.


### PR DESCRIPTION
I tried building on a fresh docker image ubuntu:16.04, the current setup doesn't work because libunwind-dev is missing. Adding this fixed the problem for me.