### PR TITLE
FreeBSD build fix proposal.

### DIFF
--- a/folly/lang/UncaughtExceptions.h
+++ b/folly/lang/UncaughtExceptions.h
@@ -28,7 +28,7 @@ struct __cxa_eh_globals;
 extern "C" __cxa_eh_globals* __cxa_get_globals() noexcept;
 #else
 // Signature mismatch with FreeBSD case
-extern "C" __cxa_eh_globals* __cxa_get_globals();
+extern "C" __cxa_eh_globals* __cxa_get_globals(void);
 #endif
 } // namespace __cxxabiv1
 #elif defined(FOLLY_FORCE_EXCEPTION_COUNT_USE_STD) || defined(_MSC_VER)

--- a/folly/memory/Malloc.h
+++ b/folly/memory/Malloc.h
@@ -45,8 +45,11 @@
 // for malloc_usable_size
 // NOTE: FreeBSD 9 doesn't have malloc.h.  Its definitions
 // are found in stdlib.h.
+// However FreeBSD 11 and so does have it.
+#if !defined(__FreeBSD__)
 #if __has_include(<malloc.h>)
 #include <malloc.h>
+#endif
 #endif
 
 #include <cassert>

--- a/folly/portability/Malloc.h
+++ b/folly/portability/Malloc.h
@@ -30,8 +30,10 @@
 // malloc_usable_size, and that's what we should be using.
 #include <jemalloc/jemalloc.h> // @manual
 #else
+#if !defined(__FreeBSD__)
 #if __has_include(<malloc.h>)
 #include <malloc.h>
+#endif
 #endif
 
 #if defined(__APPLE__) && !defined(FOLLY_HAVE_MALLOC_USABLE_SIZE)


### PR DESCRIPTION
- __cxa_get_globals signature closer of the libcxxabi.
- malloc.h exists now on FreeBSD but prevents stdlib.h inclusion if __STDC__.