### PR TITLE
Fix CMake build: EventBaseTestLib.cpp doesn't exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -723,7 +723,7 @@ if (BUILD_TESTS)
       TEST DelayedDestructionTest SOURCES DelayedDestructionTest.cpp
       TEST DelayedDestructionBaseTest SOURCES DelayedDestructionBaseTest.cpp
       TEST DestructorCheckTest SOURCES DestructorCheckTest.cpp
-      TEST EventBaseTest SOURCES EventBaseTest.cpp EventBaseTestLib.cpp
+      TEST EventBaseTest SOURCES EventBaseTest.cpp EventBaseTestLibProvider.cpp
       TEST EventBaseLocalTest SOURCES EventBaseLocalTest.cpp
       TEST HHWheelTimerTest SOURCES HHWheelTimerTest.cpp
       TEST HHWheelTimerSlowTests SLOW


### PR DESCRIPTION
Summary:
- EventBaseTestLib.cpp file was moved to EventBaseTestLibProvider.cpp
  in Differential Revision: D19001877.
- Change CMakeLists.txt to specify EventBaseTestLibProvider.cpp so that
  CMake does not fail at configure time due to EventBaseTestLib.cpp not
  existing in the source tree.