### PR TITLE
[clang-tidy] Use uppercase literals suffixes

### DIFF
--- a/folly/GroupVarint.cpp
+++ b/folly/GroupVarint.cpp
@@ -43,7 +43,7 @@ namespace detail {
 
 struct group_varint_table_base_make_item {
   constexpr std::size_t get_d(std::size_t index, std::size_t j) const {
-    return 1u + ((index >> (2 * j)) & 3u);
+    return 1U + ((index >> (2 * j)) & 3U);
   }
   constexpr std::size_t get_offset(std::size_t index, std::size_t j) const {
     // clang-format off
@@ -59,7 +59,7 @@ struct group_varint_table_base_make_item {
 
 struct group_varint_table_length_make_item : group_varint_table_base_make_item {
   constexpr std::uint8_t operator()(std::size_t index) const {
-    return 1u + get_offset(index, 4);
+    return 1U + get_offset(index, 4);
   }
 };
 

--- a/folly/String.cpp
+++ b/folly/String.cpp
@@ -721,7 +721,7 @@ hexDumpLine(const void* ptr, size_t offset, size_t size, std::string& line) {
   }
   line.append(16 - n, ' ');
   line.push_back('|');
-  DCHECK_EQ(line.size(), 78u);
+  DCHECK_EQ(line.size(), 78U);
 
   return n;
 }

--- a/folly/detail/ThreadLocalDetail.cpp
+++ b/folly/detail/ThreadLocalDetail.cpp
@@ -135,7 +135,7 @@ void StaticMetaBase::onThreadExit(void* ptr) {
       // mark it as removed
       threadEntry->removed_ = true;
       auto elementsCapacity = threadEntry->getElementsCapacity();
-      for (size_t i = 0u; i < elementsCapacity; ++i) {
+      for (size_t i = 0U; i < elementsCapacity; ++i) {
         threadEntry->elements[i].node.eraseZero();
       }
       // No need to hold the lock any longer; the ThreadEntry is private to this
@@ -159,7 +159,7 @@ void StaticMetaBase::onThreadExit(void* ptr) {
   }
 
   auto threadEntryList = threadEntry->list;
-  DCHECK_GT(threadEntryList->count, 0u);
+  DCHECK_GT(threadEntryList->count, 0U);
 
   --threadEntryList->count;
 

--- a/folly/experimental/DynamicParser.cpp
+++ b/folly/experimental/DynamicParser.cpp
@@ -110,7 +110,7 @@ void DynamicParser::ParserStack::Pop::operator()() noexcept {
   stackPtr_->value_ = value_;
   if (stackPtr_->unmaterializedSubErrorKeys_.empty()) {
     // There should be the current error, and the root.
-    CHECK_GE(stackPtr_->subErrors_.size(), 2u)
+    CHECK_GE(stackPtr_->subErrors_.size(), 2U)
         << "Internal bug: out of suberrors";
     stackPtr_->subErrors_.pop_back();
   } else {

--- a/folly/fibers/Fiber.cpp
+++ b/folly/fibers/Fiber.cpp
@@ -39,8 +39,8 @@ std::thread::id localThreadId() {
 
 /* Size of the region from p + nBytes down to the last non-magic value */
 static size_t nonMagicInBytes(unsigned char* stackLimit, size_t stackSize) {
-  CHECK_EQ(reinterpret_cast<intptr_t>(stackLimit) % sizeof(uint64_t), 0u);
-  CHECK_EQ(stackSize % sizeof(uint64_t), 0u);
+  CHECK_EQ(reinterpret_cast<intptr_t>(stackLimit) % sizeof(uint64_t), 0U);
+  CHECK_EQ(stackSize % sizeof(uint64_t), 0U);
   auto begin = reinterpret_cast<uint64_t*>(stackLimit);
   auto end = reinterpret_cast<uint64_t*>(stackLimit + stackSize);
 
@@ -83,8 +83,8 @@ void Fiber::init(bool recordStackUsed) {
   recordStackUsed_ = recordStackUsed;
   if (UNLIKELY(recordStackUsed_ && !stackFilledWithMagic_)) {
     CHECK_EQ(
-        reinterpret_cast<intptr_t>(fiberStackLimit_) % sizeof(uint64_t), 0u);
-    CHECK_EQ(fiberStackSize_ % sizeof(uint64_t), 0u);
+        reinterpret_cast<intptr_t>(fiberStackLimit_) % sizeof(uint64_t), 0U);
+    CHECK_EQ(fiberStackSize_ % sizeof(uint64_t), 0U);
     std::fill(
         reinterpret_cast<uint64_t*>(fiberStackLimit_),
         reinterpret_cast<uint64_t*>(fiberStackLimit_ + fiberStackSize_),

--- a/folly/fibers/FiberManagerMap.cpp
+++ b/folly/fibers/FiberManagerMap.cpp
@@ -89,7 +89,7 @@ class GlobalCache {
   std::unique_ptr<FiberManager> eraseImpl(const Key<EventBaseT>& key) {
     std::lock_guard<std::mutex> lg(mutex_);
 
-    DCHECK_EQ(map_.count(key), 1u);
+    DCHECK_EQ(map_.count(key), 1U);
 
     auto ret = std::move(map_[key]);
     map_.erase(key);

--- a/folly/futures/Barrier.cpp
+++ b/folly/futures/Barrier.cpp
@@ -28,7 +28,7 @@ Barrier::Barrier(uint32_t n)
 Barrier::~Barrier() {
   auto block = controlBlock_.load(std::memory_order_relaxed);
   auto prev = block->valueAndReaderCount.load(std::memory_order_relaxed);
-  DCHECK_EQ(prev >> kReaderShift, 0u);
+  DCHECK_EQ(prev >> kReaderShift, 0U);
   auto val = prev & kValueMask;
   auto p = promises(block);
 

--- a/folly/io/IOBuf.cpp
+++ b/folly/io/IOBuf.cpp
@@ -1206,7 +1206,7 @@ ordering IOBufCompare::impl(const IOBuf& a, const IOBuf& b) const noexcept {
       return to_ordering(int(bb.empty()) - int(ba.empty()));
     }
     const size_t n = std::min(ba.size(), bb.size());
-    DCHECK_GT(n, 0u);
+    DCHECK_GT(n, 0U);
     const ordering r = to_ordering(std::memcmp(ba.data(), bb.data(), n));
     if (r != ordering::eq) {
       return r;

--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -239,7 +239,7 @@ EventBase::~EventBase() {
 
   clearCobTimeouts();
 
-  DCHECK_EQ(0u, runBeforeLoopCallbacks_.size());
+  DCHECK_EQ(0U, runBeforeLoopCallbacks_.size());
 
   (void)runLoopCallbacks();
 

--- a/folly/json.cpp
+++ b/folly/json.cpp
@@ -831,7 +831,7 @@ void escapeStringImpl(
         out.append(buf, 6);
       };
       // From the ECMA-404 The JSON Data Interchange Syntax 2nd Edition Dec 2017
-      if (cp < 0x10000u) {
+      if (cp < 0x10000U) {
         // If the code point is in the Basic Multilingual Plane (U+0000 through
         // U+FFFF), then it may be represented as a six-character sequence:
         // a reverse solidus, followed by the lowercase letter u, followed by
@@ -842,8 +842,8 @@ void escapeStringImpl(
         // the character may be represented as a twelve-character sequence,
         // encoding the UTF-16 surrogate pair corresponding to the code point.
         writeHex(static_cast<char16_t>(
-            0xd800u + (((cp - 0x10000u) >> 10) & 0x3ffu)));
-        writeHex(static_cast<char16_t>(0xdc00u + ((cp - 0x10000u) & 0x3ffu)));
+            0xd800U + (((cp - 0x10000U) >> 10) & 0x3ffU)));
+        writeHex(static_cast<char16_t>(0xdc00U + ((cp - 0x10000U) & 0x3ffU)));
       }
     } else if (*p == '\\' || *p == '\"') {
       char buf[] = "\\\0";


### PR DESCRIPTION
Found with hicpp-uppercase-literal-suffix

Signed-off-by: Rosen Penev <rosenp@gmail.com>