### PR TITLE
[clang-tidy] Replace {} with default

### DIFF
--- a/folly/IPAddressV4.cpp
+++ b/folly/IPAddressV4.cpp
@@ -78,7 +78,7 @@ uint32_t IPAddressV4::toLongHBO(StringPiece ip) {
 }
 
 // public default constructor
-IPAddressV4::IPAddressV4() {}
+IPAddressV4::IPAddressV4() = default;
 
 // ByteArray4 constructor
 IPAddressV4::IPAddressV4(const ByteArray4& src) noexcept : addr_(src) {}

--- a/folly/IPAddressV6.cpp
+++ b/folly/IPAddressV6.cpp
@@ -67,7 +67,7 @@ bool IPAddressV6::validate(StringPiece ip) noexcept {
 }
 
 // public default constructor
-IPAddressV6::IPAddressV6() {}
+IPAddressV6::IPAddressV6() = default;
 
 // public string constructor
 IPAddressV6::IPAddressV6(StringPiece addr) {

--- a/folly/Subprocess.cpp
+++ b/folly/Subprocess.cpp
@@ -186,7 +186,7 @@ Subprocess::Options& Subprocess::Options::fd(int fd, int action) {
   return *this;
 }
 
-Subprocess::Subprocess() {}
+Subprocess::Subprocess() = default;
 
 Subprocess::Subprocess(
     const std::vector<std::string>& argv,

--- a/folly/executors/GlobalThreadPoolList.cpp
+++ b/folly/executors/GlobalThreadPoolList.cpp
@@ -35,14 +35,14 @@ class ThreadListHook {
   ~ThreadListHook();
 
  private:
-  ThreadListHook() {}
+  ThreadListHook() = default;
   ThreadPoolListHook* poolId_;
   std::thread::id threadId_;
 };
 
 class GlobalThreadPoolListImpl {
  public:
-  GlobalThreadPoolListImpl() {}
+  GlobalThreadPoolListImpl() = default;
 
   void registerThreadPool(ThreadPoolListHook* threadPoolId, std::string name);
 
@@ -89,7 +89,7 @@ class GlobalThreadPoolListImpl {
 
 class GlobalThreadPoolList {
  public:
-  GlobalThreadPoolList() {}
+  GlobalThreadPoolList() = default;
 
   static GlobalThreadPoolList& instance();
 

--- a/folly/experimental/FunctionScheduler.cpp
+++ b/folly/experimental/FunctionScheduler.cpp
@@ -113,7 +113,7 @@ struct UniformDistributionFunctor {
 
 } // namespace
 
-FunctionScheduler::FunctionScheduler() {}
+FunctionScheduler::FunctionScheduler() = default;
 
 FunctionScheduler::~FunctionScheduler() {
   // make sure to stop the thread (if running)

--- a/folly/experimental/ThreadedRepeatingFunctionRunner.cpp
+++ b/folly/experimental/ThreadedRepeatingFunctionRunner.cpp
@@ -22,7 +22,7 @@
 
 namespace folly {
 
-ThreadedRepeatingFunctionRunner::ThreadedRepeatingFunctionRunner() {}
+ThreadedRepeatingFunctionRunner::ThreadedRepeatingFunctionRunner() = default;
 
 ThreadedRepeatingFunctionRunner::~ThreadedRepeatingFunctionRunner() {
   if (stopImpl()) {

--- a/folly/experimental/exception_tracer/StackTrace.cpp
+++ b/folly/experimental/exception_tracer/StackTrace.cpp
@@ -34,7 +34,7 @@ class StackTraceStack::Node : public StackTrace {
 
  private:
   Node() : next(nullptr) {}
-  ~Node() {}
+  ~Node() = default;
 };
 
 auto StackTraceStack::Node::allocate() -> Node* {

--- a/folly/experimental/io/AsyncIO.cpp
+++ b/folly/experimental/io/AsyncIO.cpp
@@ -96,8 +96,7 @@ void AsyncIOOp::reset(NotificationCallback cb) {
   memset(&iocb_, 0, sizeof(iocb_));
 }
 
-AsyncIOOp::~AsyncIOOp() {
-}
+AsyncIOOp::~AsyncIOOp() = default;
 
 void AsyncIOOp::pread(int fd, void* buf, size_t size, off_t start) {
   init();

--- a/folly/experimental/symbolizer/Symbolizer.cpp
+++ b/folly/experimental/symbolizer/Symbolizer.cpp
@@ -526,7 +526,7 @@ FastStackTracePrinter::FastStackTracePrinter(
           LocationInfoMode::FULL,
           symbolCacheSize) {}
 
-FastStackTracePrinter::~FastStackTracePrinter() {}
+FastStackTracePrinter::~FastStackTracePrinter() = default;
 
 void FastStackTracePrinter::printStackTrace(bool symbolize) {
   SCOPE_EXIT {

--- a/folly/fibers/FiberManagerMap.cpp
+++ b/folly/fibers/FiberManagerMap.cpp
@@ -51,7 +51,7 @@ class GlobalCache {
   }
 
  private:
-  GlobalCache() {}
+  GlobalCache() = default;
 
   // Leak this intentionally. During shutdown, we may call getFiberManager,
   // and want access to the fiber managers during that time.
@@ -126,7 +126,7 @@ class ThreadLocalCache {
   }
 
  private:
-  ThreadLocalCache() {}
+  ThreadLocalCache() = default;
 
   struct ThreadLocalCacheTag {};
   using ThreadThreadLocalCache =

--- a/folly/io/IOBuf.cpp
+++ b/folly/io/IOBuf.cpp
@@ -394,7 +394,7 @@ IOBuf IOBuf::wrapBufferAsValue(const void* buf, std::size_t capacity) noexcept {
   return IOBuf(WrapBufferOp::WRAP_BUFFER, buf, capacity);
 }
 
-IOBuf::IOBuf() noexcept {}
+IOBuf::IOBuf() noexcept = default;
 
 IOBuf::IOBuf(IOBuf&& other) noexcept
     : data_(other.data_),

--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -91,7 +91,7 @@ class AsyncSSLSocketConnector : public AsyncSocket::ConnectCallback,
   std::chrono::steady_clock::time_point startTime_;
 
  protected:
-  ~AsyncSSLSocketConnector() override {}
+  ~AsyncSSLSocketConnector() override = default;
 
  public:
   AsyncSSLSocketConnector(

--- a/folly/io/async/HHWheelTimer.cpp
+++ b/folly/io/async/HHWheelTimer.cpp
@@ -50,7 +50,7 @@ int HHWheelTimerBase<Duration>::DEFAULT_TICK_INTERVAL =
     detail::HHWheelTimerDurationConst<Duration>::DEFAULT_TICK_INTERVAL;
 
 template <class Duration>
-HHWheelTimerBase<Duration>::Callback::Callback() {}
+HHWheelTimerBase<Duration>::Callback::Callback() = default;
 
 template <class Duration>
 HHWheelTimerBase<Duration>::Callback::~Callback() {

--- a/folly/io/async/Request.cpp
+++ b/folly/io/async/Request.cpp
@@ -179,7 +179,7 @@ struct RequestContext::StateHazptr::Combined : hazptr_obj_base<Combined> {
   }
 }; // Combined
 
-RequestContext::StateHazptr::StateHazptr() {}
+RequestContext::StateHazptr::StateHazptr() = default;
 
 RequestContext::StateHazptr::StateHazptr(const StateHazptr& o) {
   Combined* oc = o.combined();

--- a/folly/lang/ColdClass.cpp
+++ b/folly/lang/ColdClass.cpp
@@ -16,4 +16,4 @@
 
 #include <folly/lang/ColdClass.h>
 
-folly::cold_detail::ColdClass::ColdClass() noexcept {}
+folly::cold_detail::ColdClass::ColdClass() noexcept = default;

--- a/folly/logging/LogHandlerConfig.cpp
+++ b/folly/logging/LogHandlerConfig.cpp
@@ -22,7 +22,7 @@ using std::string;
 
 namespace folly {
 
-LogHandlerConfig::LogHandlerConfig() {}
+LogHandlerConfig::LogHandlerConfig() = default;
 
 LogHandlerConfig::LogHandlerConfig(StringPiece t) : type{t.str()} {}
 

--- a/folly/logging/LogStream.cpp
+++ b/folly/logging/LogStream.cpp
@@ -52,5 +52,5 @@ LogStream::LogStream(LogStreamProcessor* processor)
   rdbuf(&buffer_);
 }
 
-LogStream::~LogStream() {}
+LogStream::~LogStream() = default;
 } // namespace folly

--- a/folly/logging/LoggerDB.cpp
+++ b/folly/logging/LoggerDB.cpp
@@ -82,7 +82,7 @@ LoggerDB::LoggerDB() {
 
 LoggerDB::LoggerDB(TestConstructorArg) : LoggerDB() {}
 
-LoggerDB::~LoggerDB() {}
+LoggerDB::~LoggerDB() = default;
 
 LogCategory* LoggerDB::getCategory(StringPiece name) {
   return getOrCreateCategoryLocked(*loggersByName_.wlock(), name);

--- a/folly/logging/StandardLogHandler.cpp
+++ b/folly/logging/StandardLogHandler.cpp
@@ -32,7 +32,7 @@ StandardLogHandler::StandardLogHandler(
       writer_{std::move(writer)},
       config_{config} {}
 
-StandardLogHandler::~StandardLogHandler() {}
+StandardLogHandler::~StandardLogHandler() = default;
 
 void StandardLogHandler::handleMessage(
     const LogMessage& message,


### PR DESCRIPTION
Found with modernize-use-equals-default

Signed-off-by: Rosen Penev <rosenp@gmail.com>