### PR TITLE
[clang-tidy] Use empty instead of size

### DIFF
--- a/folly/Conv.cpp
+++ b/folly/Conv.cpp
@@ -778,7 +778,7 @@ ConversionError makeConversionError(ConversionCode code, StringPiece input) {
   if (err.quote) {
     tmp.append(1, '"');
   }
-  if (input.size() > 0) {
+  if (!input.empty()) {
     tmp.append(input.data(), input.size());
   }
   if (err.quote) {

--- a/folly/Singleton.cpp
+++ b/folly/Singleton.cpp
@@ -98,7 +98,7 @@ std::string TypeDescriptor::name() const {
   auto trace = detail::getSingletonStackTrace();
   LOG(FATAL) << "Creating instance for unregistered singleton: " << type.name()
              << "\n"
-             << "Stacktrace:\n" << (trace != "" ? trace : "(not available)");
+             << "Stacktrace:\n" << (!trace.empty() ? trace : "(not available)");
 }
 
 [[noreturn]] void singletonWarnRegisterMockEarlyAndAbort(
@@ -130,7 +130,7 @@ void singletonWarnDestroyInstanceLeak(
   auto trace = detail::getSingletonStackTrace();
   LOG(FATAL) << "Creating instance for unregistered singleton: " << type.name()
              << "\n"
-             << "Stacktrace:\n" << (trace != "" ? trace : "(not available)");
+             << "Stacktrace:\n" << (!trace.empty() ? trace : "(not available)");
 }
 
 [[noreturn]] void singletonWarnCreateBeforeRegistrationCompleteAndAbort(
@@ -141,13 +141,13 @@ void singletonWarnDestroyInstanceLeak(
              << "This usually means that either main() never called "
              << "folly::init, or singleton was requested before main() "
              << "(which is not allowed).\n"
-             << "Stacktrace:\n" << (trace != "" ? trace : "(not available)");
+             << "Stacktrace:\n" << (!trace.empty() ? trace : "(not available)");
 }
 
 void singletonPrintDestructionStackTrace(const TypeDescriptor& type) {
   auto trace = detail::getSingletonStackTrace();
   LOG(ERROR) << "Singleton " << type.name() << " was released.\n"
-             << "Stacktrace:\n" << (trace != "" ? trace : "(not available)");
+             << "Stacktrace:\n" << (!trace.empty() ? trace : "(not available)");
 }
 
 [[noreturn]] void singletonThrowNullCreator(const std::type_info& type) {

--- a/folly/String.cpp
+++ b/folly/String.cpp
@@ -417,7 +417,7 @@ double prettyToDouble(
     folly::StringPiece* const prettyString,
     const PrettyType type) {
   auto value = folly::to<double>(prettyString);
-  while (prettyString->size() > 0 && std::isspace(prettyString->front())) {
+  while (!prettyString->empty() && std::isspace(prettyString->front())) {
     prettyString->advance(1); // Skipping spaces between number and suffix
   }
   const PrettySuffix* suffixes = kPrettySuffixes[type];

--- a/folly/Uri.cpp
+++ b/folly/Uri.cpp
@@ -126,7 +126,7 @@ std::string Uri::authority() const {
 }
 
 std::string Uri::hostname() const {
-  if (host_.size() > 0 && host_[0] == '[') {
+  if (!host_.empty() && host_[0] == '[') {
     // If it starts with '[', then it should end with ']', this is ensured by
     // regex
     return host_.substr(1, host_.size() - 2);

--- a/folly/compression/Compression.cpp
+++ b/folly/compression/Compression.cpp
@@ -1754,7 +1754,7 @@ bool Bzip2StreamCodec::doCompressStream(
     case StreamCodec::FlushOp::FLUSH:
       if (rc == BZ_RUN_OK) {
         DCHECK_EQ(cstream_->avail_in, 0);
-        DCHECK(input.size() == 0 || cstream_->avail_out != output.size());
+        DCHECK(input.empty() || cstream_->avail_out != output.size());
         return true;
       }
       return false;

--- a/folly/concurrency/CacheLocality.cpp
+++ b/folly/concurrency/CacheLocality.cpp
@@ -112,7 +112,7 @@ CacheLocality CacheLocality::readFromSysfsTree(
           sformat("/sys/devices/system/cpu/cpu{}/cache/index{}/", cpu, index);
       auto cacheType = mapping(dir + "type");
       auto equivStr = mapping(dir + "shared_cpu_list");
-      if (cacheType.size() == 0 || equivStr.size() == 0) {
+      if (cacheType.empty() || equivStr.empty()) {
         // no more caches
         break;
       }
@@ -134,7 +134,7 @@ CacheLocality CacheLocality::readFromSysfsTree(
       }
     }
 
-    if (levels.size() == 0) {
+    if (levels.empty()) {
       // no levels at all for this cpu, we must be done
       break;
     }
@@ -142,7 +142,7 @@ CacheLocality CacheLocality::readFromSysfsTree(
     cpus.push_back(cpu);
   }
 
-  if (cpus.size() == 0) {
+  if (cpus.empty()) {
     throw std::runtime_error("unable to load cache sharing info");
   }
 

--- a/folly/executors/ThreadPoolExecutor.cpp
+++ b/folly/executors/ThreadPoolExecutor.cpp
@@ -169,9 +169,9 @@ void ThreadPoolExecutor::setNumThreads(size_t numThreads) {
       ThreadPoolExecutor::removeThreads(numThreadsToJoin, false);
       activeThreads_.store(
           active - numThreadsToJoin, std::memory_order_relaxed);
-    } else if (pending > 0 || observers_.size() > 0 || active < minthreads) {
+    } else if (pending > 0 || !observers_.empty() || active < minthreads) {
       size_t numToAdd = std::min(pending, numThreads - active);
-      if (observers_.size() > 0) {
+      if (!observers_.empty()) {
         numToAdd = numThreads - active;
       }
       if (active + numToAdd < minthreads) {
@@ -323,7 +323,7 @@ ThreadPoolExecutor::ThreadPtr ThreadPoolExecutor::StoppedThreadQueue::take() {
   while (true) {
     {
       std::lock_guard<std::mutex> guard(mutex_);
-      if (queue_.size() > 0) {
+      if (!queue_.empty()) {
         auto item = std::move(queue_.front());
         queue_.pop();
         return item;
@@ -339,7 +339,7 @@ ThreadPoolExecutor::StoppedThreadQueue::try_take_for(
   while (true) {
     {
       std::lock_guard<std::mutex> guard(mutex_);
-      if (queue_.size() > 0) {
+      if (!queue_.empty()) {
         auto item = std::move(queue_.front());
         queue_.pop();
         return item;

--- a/folly/experimental/DynamicParser.cpp
+++ b/folly/experimental/DynamicParser.cpp
@@ -157,7 +157,7 @@ folly::dynamic& DynamicParser::ParserStack::errors(
 }
 
 folly::dynamic DynamicParser::ParserStack::releaseErrors() {
-  if (key_ || unmaterializedSubErrorKeys_.size() != 0 ||
+  if (key_ || !unmaterializedSubErrorKeys_.empty() ||
       subErrors_.size() != 1) {
     throw DynamicParserLogicError(
         "Do not releaseErrors() while parsing: ",

--- a/folly/experimental/crypto/Blake2xb.cpp
+++ b/folly/experimental/crypto/Blake2xb.cpp
@@ -75,7 +75,7 @@ void initStateFromParams(
       reinterpret_cast<uint8_t*>(state) + sizeof(state->h),
       0,
       sizeof(*state) - sizeof(state->h));
-  if (key.size() > 0) {
+  if (!key.empty()) {
     if (key.size() < crypto_generichash_blake2b_KEYBYTES_MIN ||
         key.size() > crypto_generichash_blake2b_KEYBYTES_MAX) {
       throw std::runtime_error("invalid key size");
@@ -129,13 +129,13 @@ void Blake2xb::init(
   param_.fanout = 1;
   param_.depth = 1;
   param_.xofLength = Endian::little(static_cast<uint32_t>(outputLength));
-  if (salt.size() > 0) {
+  if (!salt.empty()) {
     if (salt.size() != crypto_generichash_blake2b_SALTBYTES) {
       throw std::runtime_error("Invalid salt length, must be 16 bytes");
     }
     std::memcpy(param_.salt, salt.data(), sizeof(param_.salt));
   }
-  if (personalization.size() > 0) {
+  if (!personalization.empty()) {
     if (personalization.size() != crypto_generichash_blake2b_PERSONALBYTES) {
       throw std::runtime_error(
           "Invalid personalization length, must be 16 bytes");

--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -824,7 +824,7 @@ void AsyncSSLSocket::sslConn(
     sslSession_ = nullptr;
   }
 #if FOLLY_OPENSSL_HAS_SNI
-  if (tlsextHostname_.size()) {
+  if (!tlsextHostname_.empty()) {
     SSL_set_tlsext_host_name(ssl_.get(), tlsextHostname_.c_str());
   }
 #endif

--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -263,7 +263,7 @@ void AsyncServerSocket::useExistingSockets(
     eventBase_->dcheckIsInEventBaseThread();
   }
 
-  if (sockets_.size() > 0) {
+  if (!sockets_.empty()) {
     throw std::invalid_argument(
         "cannot call useExistingSocket() on a "
         "AsyncServerSocket that already has a socket");
@@ -357,7 +357,7 @@ void AsyncServerSocket::bind(const SocketAddress& address) {
   // Don't set socket_ yet, so that socket_ will remain uninitialized if an
   // error occurs.
   NetworkSocket fd;
-  if (sockets_.size() == 0) {
+  if (sockets_.empty()) {
     fd = createSocket(address.getFamily());
   } else if (sockets_.size() == 1) {
     if (address.getFamily() != sockets_[0].addressFamily_) {
@@ -389,7 +389,7 @@ void AsyncServerSocket::bind(
 
     bindSocket(fd, address, false);
   }
-  if (sockets_.size() == 0) {
+  if (sockets_.empty()) {
     throw std::runtime_error(
         "did not bind any async server socket for port and addresses");
   }
@@ -523,7 +523,7 @@ void AsyncServerSocket::bind(uint16_t port) {
     break;
   }
 
-  if (sockets_.size() == 0) {
+  if (sockets_.empty()) {
     throw std::runtime_error("did not bind any async server socket for port");
   }
 }
@@ -542,7 +542,7 @@ void AsyncServerSocket::listen(int backlog) {
 }
 
 void AsyncServerSocket::getAddress(SocketAddress* addressReturn) const {
-  CHECK(sockets_.size() >= 1);
+  CHECK(!sockets_.empty());
   VLOG_IF(2, sockets_.size() > 1)
       << "Warning: getAddress() called and multiple addresses available ("
       << sockets_.size() << "). Returning only the first one.";
@@ -551,7 +551,7 @@ void AsyncServerSocket::getAddress(SocketAddress* addressReturn) const {
 }
 
 std::vector<SocketAddress> AsyncServerSocket::getAddresses() const {
-  CHECK(sockets_.size() >= 1);
+  CHECK(!sockets_.empty());
   auto tsaVec = std::vector<SocketAddress>(sockets_.size());
   auto tsaIter = tsaVec.begin();
   for (const auto& socket : sockets_) {

--- a/folly/io/async/SSLContext.cpp
+++ b/folly/io/async/SSLContext.cpp
@@ -102,7 +102,7 @@ void SSLContext::ciphers(const std::string& ciphers) {
 
 void SSLContext::setClientECCurvesList(
     const std::vector<std::string>& ecCurves) {
-  if (ecCurves.size() == 0) {
+  if (ecCurves.empty()) {
     return;
   }
 #if OPENSSL_VERSION_NUMBER >= 0x1000200fL
@@ -472,12 +472,12 @@ bool SSLContext::setAdvertisedNextProtocols(
 bool SSLContext::setRandomizedAdvertisedNextProtocols(
     const std::list<NextProtocolsItem>& items) {
   unsetNextProtocols();
-  if (items.size() == 0) {
+  if (items.empty()) {
     return false;
   }
   int total_weight = 0;
   for (const auto& item : items) {
-    if (item.protocols.size() == 0) {
+    if (item.protocols.empty()) {
       continue;
     }
     AdvertisedNextProtocolsItem advertised_item;

--- a/folly/io/async/ScopedEventBaseThread.cpp
+++ b/folly/io/async/ScopedEventBaseThread.cpp
@@ -32,7 +32,7 @@ static void run(
     EventBase* eb,
     folly::Baton<>* stop,
     const StringPiece& name) {
-  if (name.size()) {
+  if (!name.empty()) {
     folly::setThreadName(name);
   }
 

--- a/folly/logging/LogConfigParser.cpp
+++ b/folly/logging/LogConfigParser.cpp
@@ -291,7 +291,7 @@ LogConfig::CategoryConfigMap parseCategoryConfigs(StringPiece value) {
     std::vector<StringPiece> handlerPieces;
     folly::split(":", configString, handlerPieces);
     FOLLY_SAFE_DCHECK(
-        handlerPieces.size() >= 1,
+        !handlerPieces.empty(),
         "folly::split() always returns a list of length 1");
     auto levelString = trimWhitespace(handlerPieces[0]);
 
@@ -428,7 +428,7 @@ std::pair<std::string, LogHandlerConfig> parseHandlerConfig(StringPiece value) {
     std::vector<StringPiece> pieces;
     folly::split(",", optionsStr, pieces);
     FOLLY_SAFE_DCHECK(
-        pieces.size() >= 1, "folly::split() always returns a list of length 1");
+        !pieces.empty(), "folly::split() always returns a list of length 1");
 
     for (const auto& piece : pieces) {
       StringPiece optionName;
@@ -469,7 +469,7 @@ LogConfig parseLogConfig(StringPiece value) {
   std::vector<StringPiece> pieces;
   folly::split(";", value, pieces);
   FOLLY_SAFE_DCHECK(
-      pieces.size() >= 1, "folly::split() always returns a list of length 1");
+      !pieces.empty(), "folly::split() always returns a list of length 1");
 
   auto categoryConfigs = parseCategoryConfigs(pieces[0]);
   LogConfig::HandlerConfigMap handlerConfigs;

--- a/folly/test/DeterministicSchedule.cpp
+++ b/folly/test/DeterministicSchedule.cpp
@@ -326,7 +326,7 @@ void DeterministicSchedule::beforeThreadExit() {
   }
   sems_.erase(std::find(sems_.begin(), sems_.end(), tls.sem));
   active_.erase(std::this_thread::get_id());
-  if (sems_.size() > 0) {
+  if (!sems_.empty()) {
     FOLLY_TEST_DSCHED_VLOG("exiting");
     /* Wait here so that parent thread can control when the thread
      * enters the thread local destructors. */


### PR DESCRIPTION
Found with readability-container-size-empty

Signed-off-by: Rosen Penev <rosenp@gmail.com>