### PR TITLE
experimental enable jemalloc API for FreeBSD too.

### DIFF
--- a/CMake/FollyConfigChecks.cmake
+++ b/CMake/FollyConfigChecks.cmake
@@ -20,7 +20,11 @@ include(CheckSymbolExists)
 include(CheckTypeSize)
 include(CheckCXXCompilerFlag)
 
-CHECK_INCLUDE_FILE_CXX(jemalloc/jemalloc.h FOLLY_USE_JEMALLOC)
+if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  CHECK_INCLUDE_FILE_CXX(malloc_np.h FOLLY_USE_JEMALLOC)
+else()
+  CHECK_INCLUDE_FILE_CXX(jemalloc/jemalloc.h FOLLY_USE_JEMALLOC)
+endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
   # clang only rejects unknown warning flags if -Werror=unknown-warning-option

--- a/folly/experimental/JemallocHugePageAllocator.cpp
+++ b/folly/experimental/JemallocHugePageAllocator.cpp
@@ -22,13 +22,13 @@
 
 #include <sstream>
 
-#if defined(MADV_HUGEPAGE) && defined(FOLLY_USE_JEMALLOC) && !FOLLY_SANITIZE
-#if (JEMALLOC_VERSION_MAJOR >= 5)
+#if (defined(MADV_HUGEPAGE) || defined(MAP_ALIGNED_SUPER)) && defined(FOLLY_USE_JEMALLOC) && !FOLLY_SANITIZE
+#if defined(__FreeBSD__) || (JEMALLOC_VERSION_MAJOR >= 5)
 #define FOLLY_JEMALLOC_HUGE_PAGE_ALLOCATOR_SUPPORTED 1
 bool folly::JemallocHugePageAllocator::hugePagesSupported{true};
 #endif
 
-#endif // MADV_HUGEPAGE && defined(FOLLY_USE_JEMALLOC) && !FOLLY_SANITIZE
+#endif // MADV_HUGEPAGE || MAP_ALIGNED_SUPER && defined(FOLLY_USE_JEMALLOC) && !FOLLY_SANITIZE
 
 #ifndef FOLLY_JEMALLOC_HUGE_PAGE_ALLOCATOR_SUPPORTED
 // Some mocks when jemalloc.h is not included or version too old
@@ -119,11 +119,15 @@ static inline T align_up(T val, U alignment) {
 static uintptr_t map_pages(size_t nr_pages) {
   // Initial mmapped area is large enough to contain the aligned huge pages
   size_t alloc_size = nr_pages * kHugePageSize;
+  int mflags = MAP_PRIVATE | MAP_ANONYMOUS;
+#if defined(__FreeBSD__)
+  mflags |= MAP_ALIGNED_SUPER;
+#endif
   void* p = mmap(
       nullptr,
       alloc_size + kHugePageSize,
       PROT_READ | PROT_WRITE,
-      MAP_PRIVATE | MAP_ANONYMOUS,
+      mflags,
       -1,
       0);
 
@@ -134,6 +138,7 @@ static uintptr_t map_pages(size_t nr_pages) {
   // Aligned start address
   uintptr_t first_page = align_up((uintptr_t)p, kHugePageSize);
 
+#if !defined(__FreeBSD__)
   // Unmap left-over 4k pages
   munmap(p, first_page - (uintptr_t)p);
   munmap(
@@ -158,6 +163,7 @@ static uintptr_t map_pages(size_t nr_pages) {
        ptr += kHugePageSize) {
     memset((void*)ptr, 0, 1);
   }
+#endif
 
   return first_page;
 }

--- a/folly/memory/detail/MallocImpl.h
+++ b/folly/memory/detail/MallocImpl.h
@@ -23,6 +23,7 @@
 extern "C" {
 
 #if FOLLY_HAVE_WEAK_SYMBOLS
+#if !defined(__FreeBSD__)
 void* mallocx(size_t, int) __attribute__((__nothrow__, __weak__));
 void* rallocx(void*, size_t, int) __attribute__((__nothrow__, __weak__));
 size_t xallocx(void*, size_t, size_t, int)
@@ -37,6 +38,7 @@ int mallctlnametomib(const char*, size_t*, size_t*)
     __attribute__((__nothrow__, __weak__));
 int mallctlbymib(const size_t*, size_t, void*, size_t*, void*, size_t)
     __attribute__((__nothrow__, __weak__));
+#endif
 #else
 extern void* (*mallocx)(size_t, int);
 extern void* (*rallocx)(void*, size_t, int);

--- a/folly/portability/Malloc.h
+++ b/folly/portability/Malloc.h
@@ -28,7 +28,11 @@
 #endif
 // JEMalloc provides it's own implementation of
 // malloc_usable_size, and that's what we should be using.
+#if defined(__FreeBSD__)
+#include <malloc_np.h>
+#else
 #include <jemalloc/jemalloc.h> // @manual
+#endif
 #else
 #if !defined(__FreeBSD__)
 #if __has_include(<malloc.h>)


### PR DESCRIPTION
Contrary to other systems, jemalloc is part of the FreeBSD's libc.
As such APIs are directly exposed. Enabling super pages
as well, supporting same page size.