### PR TITLE
[clang-tidy] Fix inconsistent declarations

### DIFF
--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -187,7 +187,7 @@ class ConversionError : public ConversionErrorBase {
  *   return YourConversionError(messageString);
  * }
  ******************************************************************************/
-ConversionError makeConversionError(ConversionCode code, StringPiece sp);
+ConversionError makeConversionError(ConversionCode code, StringPiece input);
 
 namespace detail {
 /**

--- a/folly/Demangle.h
+++ b/folly/Demangle.h
@@ -54,7 +54,7 @@ inline fbstring demangle(const std::type_info& type) {
  * libiberty), so it is possible for the fbstring version to work, while this
  * version returns the original, mangled name.
  */
-size_t demangle(const char* name, char* buf, size_t bufSize);
+size_t demangle(const char* name, char* out, size_t outSize);
 inline size_t demangle(const std::type_info& type, char* buf, size_t bufSize) {
   return demangle(type.name(), buf, bufSize);
 }

--- a/folly/FileUtil.h
+++ b/folly/FileUtil.h
@@ -51,13 +51,13 @@ int truncateNoInt(const char* path, off_t len);
 int flockNoInt(int fd, int operation);
 int shutdownNoInt(NetworkSocket fd, int how);
 
-ssize_t readNoInt(int fd, void* buf, size_t n);
-ssize_t preadNoInt(int fd, void* buf, size_t n, off_t offset);
+ssize_t readNoInt(int fd, void* buf, size_t count);
+ssize_t preadNoInt(int fd, void* buf, size_t count, off_t offset);
 ssize_t readvNoInt(int fd, const iovec* iov, int count);
 ssize_t preadvNoInt(int fd, const iovec* iov, int count, off_t offset);
 
-ssize_t writeNoInt(int fd, const void* buf, size_t n);
-ssize_t pwriteNoInt(int fd, const void* buf, size_t n, off_t offset);
+ssize_t writeNoInt(int fd, const void* buf, size_t count);
+ssize_t pwriteNoInt(int fd, const void* buf, size_t count, off_t offset);
 ssize_t writevNoInt(int fd, const iovec* iov, int count);
 ssize_t pwritevNoInt(int fd, const iovec* iov, int count, off_t offset);
 
@@ -83,8 +83,8 @@ ssize_t pwritevNoInt(int fd, const iovec* iov, int count, off_t offset);
  * readv and preadv.  The contents of iov after these functions return
  * is unspecified.
  */
-FOLLY_NODISCARD ssize_t readFull(int fd, void* buf, size_t n);
-FOLLY_NODISCARD ssize_t preadFull(int fd, void* buf, size_t n, off_t offset);
+FOLLY_NODISCARD ssize_t readFull(int fd, void* buf, size_t count);
+FOLLY_NODISCARD ssize_t preadFull(int fd, void* buf, size_t count, off_t offset);
 FOLLY_NODISCARD ssize_t readvFull(int fd, iovec* iov, int count);
 FOLLY_NODISCARD ssize_t preadvFull(int fd, iovec* iov, int count, off_t offset);
 
@@ -105,8 +105,8 @@ FOLLY_NODISCARD ssize_t preadvFull(int fd, iovec* iov, int count, off_t offset);
  * These functions return -1 on error, or the total number of bytes written
  * (which is always the same as the number of requested bytes) on success.
  */
-ssize_t writeFull(int fd, const void* buf, size_t n);
-ssize_t pwriteFull(int fd, const void* buf, size_t n, off_t offset);
+ssize_t writeFull(int fd, const void* buf, size_t count);
+ssize_t pwriteFull(int fd, const void* buf, size_t count, off_t offset);
 ssize_t writevFull(int fd, iovec* iov, int count);
 ssize_t pwritevFull(int fd, iovec* iov, int count, off_t offset);
 

--- a/folly/IPAddress.h
+++ b/folly/IPAddress.h
@@ -234,7 +234,7 @@ class IPAddress {
    *
    * @throws IPAddressFormatException
    */
-  explicit IPAddress(StringPiece ip);
+  explicit IPAddress(StringPiece str);
 
   /**
    * Create an IPAddress from a sockaddr.
@@ -251,10 +251,10 @@ class IPAddress {
   /* implicit */ IPAddress(const in6_addr& addr) noexcept;
 
   // Assign from V4 address
-  IPAddress& operator=(const IPAddressV4& ipV4Addr) noexcept;
+  IPAddress& operator=(const IPAddressV4& ipv4_addr) noexcept;
 
   // Assign from V6 address
-  IPAddress& operator=(const IPAddressV6& ipV6Addr) noexcept;
+  IPAddress& operator=(const IPAddressV6& ipv6_addr) noexcept;
 
   /**
    * Converts an IPAddress to an IPAddressV4 instance.
@@ -330,7 +330,7 @@ class IPAddress {
    * @throws IPAddressFormatException if no /mask
    * @return true if address is part of specified subnet with cidr
    */
-  bool inSubnet(StringPiece ipSlashCidr) const;
+  bool inSubnet(StringPiece cidrNetwork) const;
 
   /**
    * Check if an IPAddress belongs to a subnet.

--- a/folly/IPAddressV4.h
+++ b/folly/IPAddressV4.h
@@ -122,7 +122,7 @@ class IPAddressV4 {
 
   // Create an IPAddressV4 from a string
   // @throws IPAddressFormatException
-  explicit IPAddressV4(StringPiece ip);
+  explicit IPAddressV4(StringPiece addr);
 
   // ByteArray4 constructor
   explicit IPAddressV4(const ByteArray4& src) noexcept;

--- a/folly/IPAddressV6.h
+++ b/folly/IPAddressV6.h
@@ -140,7 +140,7 @@ class IPAddressV6 {
   // Create an IPAddressV6 from a string
   // @throws IPAddressFormatException
   //
-  explicit IPAddressV6(StringPiece ip);
+  explicit IPAddressV6(StringPiece addr);
 
   // ByteArray16 constructor
   explicit IPAddressV6(const ByteArray16& src) noexcept;

--- a/folly/Random.h
+++ b/folly/Random.h
@@ -100,7 +100,7 @@ class Random {
   /**
    * Get secure random bytes. (On Linux and OSX, this means /dev/urandom).
    */
-  static void secureRandom(void* data, size_t len);
+  static void secureRandom(void* data, size_t size);
 
   /**
    * Shortcut to get a secure random value of integral type.

--- a/folly/SocketAddress.h
+++ b/folly/SocketAddress.h
@@ -581,8 +581,8 @@ class SocketAddress {
 
   struct addrinfo* getAddrInfo(const char* host, uint16_t port, int flags);
   struct addrinfo* getAddrInfo(const char* host, const char* port, int flags);
-  void setFromAddrInfo(const struct addrinfo* results);
-  void setFromLocalAddr(const struct addrinfo* results);
+  void setFromAddrInfo(const struct addrinfo* info);
+  void setFromLocalAddr(const struct addrinfo* info);
   void setFromSocket(
       NetworkSocket socket,
       int (*fn)(NetworkSocket, struct sockaddr*, socklen_t*));

--- a/folly/String.h
+++ b/folly/String.h
@@ -171,7 +171,7 @@ std::string stringPrintf(FOLLY_PRINTF_FORMAT const char* format, ...)
     FOLLY_PRINTF_FORMAT_ATTR(1, 2);
 
 /* Similar to stringPrintf, with different signature. */
-void stringPrintf(std::string* out, FOLLY_PRINTF_FORMAT const char* fmt, ...)
+void stringPrintf(std::string* out, FOLLY_PRINTF_FORMAT const char* format, ...)
     FOLLY_PRINTF_FORMAT_ATTR(2, 3);
 
 std::string& stringAppendf(

--- a/folly/Subprocess.h
+++ b/folly/Subprocess.h
@@ -212,7 +212,7 @@ class ProcessReturnCode {
    * Helper function to enforce a precondition based on this.
    * Throws std::logic_error if in an unexpected state.
    */
-  void enforce(State state) const;
+  void enforce(State expected) const;
 
  private:
   explicit ProcessReturnCode(int rv) : rawStatus_(rv) {}

--- a/folly/TimeoutQueue.h
+++ b/folly/TimeoutQueue.h
@@ -97,7 +97,7 @@ class TimeoutQueue {
   int64_t nextExpiration() const;
 
  private:
-  int64_t runInternal(int64_t now, bool runOnce);
+  int64_t runInternal(int64_t now, bool onceOnly);
   TimeoutQueue(const TimeoutQueue&) = delete;
   TimeoutQueue& operator=(const TimeoutQueue&) = delete;
 

--- a/folly/executors/QueuedImmediateExecutor.h
+++ b/folly/executors/QueuedImmediateExecutor.h
@@ -32,7 +32,7 @@ class QueuedImmediateExecutor : public Executor {
  public:
   static QueuedImmediateExecutor& instance();
 
-  void add(Func func) override;
+  void add(Func callback) override;
 
  private:
   folly::ThreadLocal<std::queue<Func>> q_;

--- a/folly/experimental/exception_tracer/ExceptionCounterLib.h
+++ b/folly/experimental/exception_tracer/ExceptionCounterLib.h
@@ -37,7 +37,7 @@ struct ExceptionStats {
  */
 std::vector<ExceptionStats> getExceptionStatistics();
 
-std::ostream& operator<<(std::ostream& out, const ExceptionStats& data);
+std::ostream& operator<<(std::ostream& out, const ExceptionStats& stats);
 
 } // namespace exception_tracer
 } // namespace folly

--- a/folly/experimental/io/AsyncBase.h
+++ b/folly/experimental/io/AsyncBase.h
@@ -140,8 +140,8 @@ class AsyncBaseOp {
   void* userData_{nullptr};
 };
 
-std::ostream& operator<<(std::ostream& stream, const AsyncBaseOp& op);
-std::ostream& operator<<(std::ostream& stream, AsyncBaseOp::State state);
+std::ostream& operator<<(std::ostream& os, const AsyncBaseOp& op);
+std::ostream& operator<<(std::ostream& os, AsyncBaseOp::State state);
 
 /**
  * Generic C++ interface around Linux IO(io_submit, io_uring)

--- a/folly/experimental/io/AsyncIO.h
+++ b/folly/experimental/io/AsyncIO.h
@@ -24,7 +24,7 @@ namespace folly {
 
 class AsyncIOOp : public AsyncBaseOp {
   friend class AsyncIO;
-  friend std::ostream& operator<<(std::ostream& stream, const AsyncIOOp& o);
+  friend std::ostream& operator<<(std::ostream& os, const AsyncIOOp& o);
 
  public:
   explicit AsyncIOOp(NotificationCallback cb = NotificationCallback());
@@ -60,7 +60,7 @@ class AsyncIOOp : public AsyncBaseOp {
   iocb iocb_;
 };
 
-std::ostream& operator<<(std::ostream& stream, const AsyncIOOp& op);
+std::ostream& operator<<(std::ostream& os, const AsyncIOOp& op);
 
 /**
  * C++ interface around Linux Async IO.

--- a/folly/experimental/symbolizer/Dwarf.h
+++ b/folly/experimental/symbolizer/Dwarf.h
@@ -115,7 +115,7 @@ class Dwarf {
   bool findLocation(
       uintptr_t address,
       const LocationInfoMode mode,
-      detail::CompilationUnit& unit,
+      detail::CompilationUnit& cu,
       LocationInfo& info,
       folly::Range<SymbolizedFrame*> inlineFrames = {}) const;
 
@@ -213,7 +213,7 @@ class Dwarf::LineNumberVM {
       folly::StringPiece data,
       folly::StringPiece compilationDirectory);
 
-  bool findAddress(uintptr_t address, Path& file, uint64_t& line);
+  bool findAddress(uintptr_t target, Path& file, uint64_t& line);
 
   /** Gets full file name at given index including directory. */
   Path getFullFileName(uint64_t index) const {
@@ -243,7 +243,7 @@ class Dwarf::LineNumberVM {
   };
 
   /** Read one FileName object, advance sp */
-  static bool readFileName(folly::StringPiece& sp, FileName& fn);
+  static bool readFileName(folly::StringPiece& program, FileName& fn);
 
   /**
    * Get file name at given index; may be in the initial table

--- a/folly/experimental/symbolizer/SignalHandler.h
+++ b/folly/experimental/symbolizer/SignalHandler.h
@@ -41,7 +41,7 @@ void installFatalSignalHandler();
  * installFatalSignalCallbacks(), below.
  */
 typedef void (*SignalCallback)();
-void addFatalSignalCallback(SignalCallback callback);
+void addFatalSignalCallback(SignalCallback cb);
 
 /**
  * Install the fatal signal callbacks; fatal signals will call these

--- a/folly/io/async/AsyncPipe.h
+++ b/folly/io/async/AsyncPipe.h
@@ -115,8 +115,8 @@ class AsyncPipeWriter : public EventHandler,
    * on success/error.
    */
   void write(
-      std::unique_ptr<folly::IOBuf> iob,
-      AsyncWriter::WriteCallback* wcb = nullptr);
+      std::unique_ptr<folly::IOBuf> buf,
+      AsyncWriter::WriteCallback* callback = nullptr);
 
   /**
    * Set a special hook to close the socket (otherwise, will call close())

--- a/folly/io/async/AsyncSSLSocket.h
+++ b/folly/io/async/AsyncSSLSocket.h
@@ -699,9 +699,9 @@ class AsyncSSLSocket : public virtual AsyncSocket {
   static int bioRead(BIO* b, char* out, int outl);
   void resetClientHelloParsing(SSL* ssl);
   static void clientHelloParsingCallback(
-      int write_p,
+      int written,
       int version,
-      int content_type,
+      int contentType,
       const void* buf,
       size_t len,
       SSL* ssl,
@@ -875,7 +875,7 @@ class AsyncSSLSocket : public virtual AsyncSocket {
 
   void startSSLConnect();
 
-  static void sslInfoCallback(const SSL* ssl, int type, int val);
+  static void sslInfoCallback(const SSL* ssl, int where, int ret);
 
   // Whether the current write to the socket should use MSG_MORE.
   bool corkCurrentWrite_{false};

--- a/folly/io/async/AsyncServerSocket.h
+++ b/folly/io/async/AsyncServerSocket.h
@@ -773,7 +773,7 @@ class AsyncServerSocket : public DelayedDestruction, public AsyncSocketBase {
     void start(EventBase* eventBase, uint32_t maxAtOnce, uint32_t maxInQueue);
     void stop(EventBase* eventBase, AcceptCallback* callback);
 
-    void messageAvailable(QueueMessage&& message) noexcept override;
+    void messageAvailable(QueueMessage&& msg) noexcept override;
 
     NotificationQueue<QueueMessage>* getQueue() {
       return &queue_;
@@ -804,7 +804,7 @@ class AsyncServerSocket : public DelayedDestruction, public AsyncSocketBase {
 
   virtual void handlerReady(
       uint16_t events,
-      NetworkSocket socket,
+      NetworkSocket fd,
       sa_family_t family) noexcept;
 
   NetworkSocket createSocket(int family);

--- a/folly/io/async/AsyncUDPSocket.h
+++ b/folly/io/async/AsyncUDPSocket.h
@@ -165,7 +165,7 @@ class AsyncUDPSocket : public EventHandler {
   virtual int writem(
       const folly::SocketAddress& address,
       const std::unique_ptr<folly::IOBuf>* bufs,
-      size_t num);
+      size_t count);
 
   /**
    * Send the data in buffer to destination. Returns the return code from
@@ -187,13 +187,13 @@ class AsyncUDPSocket : public EventHandler {
   virtual ssize_t writev(
       const folly::SocketAddress& address,
       const struct iovec* vec,
-      size_t veclen,
+      size_t iovec_len,
       int gso);
 
   virtual ssize_t writev(
       const folly::SocketAddress& address,
       const struct iovec* vec,
-      size_t veclen);
+      size_t iovec_len);
 
   virtual ssize_t recvmsg(struct msghdr* msg, int flags);
 

--- a/folly/io/async/HHWheelTimer.h
+++ b/folly/io/async/HHWheelTimer.h
@@ -170,7 +170,7 @@ class HHWheelTimerBase : private folly::AsyncTimeout,
    */
   static int DEFAULT_TICK_INTERVAL;
   explicit HHWheelTimerBase(
-      folly::TimeoutManager* timeoutManager,
+      folly::TimeoutManager* timeoutMananger,
       Duration intervalDuration = Duration(DEFAULT_TICK_INTERVAL),
       AsyncTimeout::InternalEnum internal = AsyncTimeout::InternalEnum::NORMAL,
       Duration defaultTimeoutDuration = Duration(-1));

--- a/folly/io/async/Request.h
+++ b/folly/io/async/Request.h
@@ -209,22 +209,22 @@ class RequestContext {
   }
 
   // Remove the RequestData instance with string identifier "val", if it exists.
-  void clearContextData(const RequestToken& token);
+  void clearContextData(const RequestToken& val);
   void clearContextData(const std::string& val) {
     clearContextData(RequestToken(val));
   }
 
   // Returns true if and only if the RequestData instance with string identifier
   // "val" exists in this RequestContext instnace.
-  bool hasContextData(const RequestToken& token) const;
+  bool hasContextData(const RequestToken& val) const;
   bool hasContextData(const std::string& val) const {
     return hasContextData(RequestToken(val));
   }
 
   // Get (constant) raw pointer of the RequestData instance with string
   // identifier "val" if it exists, otherwise returns null pointer.
-  RequestData* getContextData(const RequestToken& token);
-  const RequestData* getContextData(const RequestToken& token) const;
+  RequestData* getContextData(const RequestToken& val);
+  const RequestData* getContextData(const RequestToken& val) const;
   RequestData* getContextData(const std::string& val) {
     return getContextData(RequestToken(val));
   }
@@ -253,7 +253,7 @@ class RequestContext {
   static std::shared_ptr<RequestContext> setContext(
       std::shared_ptr<RequestContext> const& ctx);
   static std::shared_ptr<RequestContext> setContext(
-      std::shared_ptr<RequestContext>&& ctx);
+      std::shared_ptr<RequestContext>&& newCtx_);
 
   static std::shared_ptr<RequestContext> saveContext() {
     return getStaticContext().first;
@@ -376,7 +376,7 @@ class RequestContext {
 
     Combined* combined() const;
     Combined* ensureCombined(); // Lazy allocation if needed
-    void setCombined(Combined* combined);
+    void setCombined(Combined* p);
     Combined* expand(Combined* combined);
 
     bool doSetContextData(
@@ -404,12 +404,12 @@ class RequestContext {
         DoSetBehaviour behaviour,
         bool safe);
     Combined* eraseOldData(
-        Combined* combined,
+        Combined* cur,
         const RequestToken& token,
         RequestData* oldData,
         bool safe);
     Combined* insertNewData(
-        Combined* combined,
+        Combined* cur,
         const RequestToken& token,
         std::unique_ptr<RequestData>& data,
         bool found);

--- a/folly/logging/CustomLogFormatter.h
+++ b/folly/logging/CustomLogFormatter.h
@@ -56,7 +56,7 @@ class CustomLogFormatter : public LogFormatter {
       const LogCategory* handlerCategory) override;
 
  private:
-  void parseFormatString(StringPiece format);
+  void parseFormatString(StringPiece input);
 
   std::string logFormat_;
   std::string singleLineLogFormat_;

--- a/folly/logging/LogCategory.h
+++ b/folly/logging/LogCategory.h
@@ -149,7 +149,7 @@ class LogCategory {
    * choice if you've attached a Handler to this category and you don't want
    * any of these logs to also appear in the parent's Handler.
    */
-  void setPropagateLevelMessagesToParent(LogLevel propagate);
+  void setPropagateLevelMessagesToParent(LogLevel level);
 
   /**
    * Get which messages processed by this category will be processed by the

--- a/folly/logging/LogHandlerConfig.h
+++ b/folly/logging/LogHandlerConfig.h
@@ -34,8 +34,8 @@ class LogHandlerConfig {
   LogHandlerConfig();
   explicit LogHandlerConfig(StringPiece type);
   explicit LogHandlerConfig(Optional<StringPiece> type);
-  LogHandlerConfig(StringPiece type, Options options);
-  LogHandlerConfig(Optional<StringPiece> type, Options options);
+  LogHandlerConfig(StringPiece type, Options opts);
+  LogHandlerConfig(Optional<StringPiece> type, Options opts);
 
   /**
    * Update this LogHandlerConfig object by merging in settings from another

--- a/folly/logging/LogName.h
+++ b/folly/logging/LogName.h
@@ -36,7 +36,7 @@ class LogName {
    * '.' characters are removed, and all sequences of consecutive '.'
    * characters are replaced with a single '.'
    */
-  static std::string canonicalize(folly::StringPiece name);
+  static std::string canonicalize(folly::StringPiece input);
 
   /**
    * Hash a log name.

--- a/folly/system/MemoryMapping.h
+++ b/folly/system/MemoryMapping.h
@@ -278,7 +278,7 @@ void swap(MemoryMapping&, MemoryMapping&) noexcept;
  * Useful when copying from/to memory mappings after hintLinearScan();
  * copying backwards renders any prefetching useless (even harmful).
  */
-void alignedForwardMemcpy(void* dest, const void* src, size_t size);
+void alignedForwardMemcpy(void* dst, const void* src, size_t size);
 
 /**
  * Copy a file using mmap(). Overwrites dest.


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>