### PR TITLE
[clang-tidy] Change several for ranges to const reference

### DIFF
--- a/folly/executors/IOThreadPoolExecutor.cpp
+++ b/folly/executors/IOThreadPoolExecutor.cpp
@@ -217,7 +217,7 @@ void IOThreadPoolExecutor::stopThreads(size_t n) {
       ioThread->eventBase->terminateLoopSoon();
     }
   }
-  for (auto thread : stoppedThreads) {
+  for (const auto& thread : stoppedThreads) {
     stoppedThreads_.add(thread);
     threadList_.remove(thread);
   }

--- a/folly/executors/ThreadPoolExecutor.cpp
+++ b/folly/executors/ThreadPoolExecutor.cpp
@@ -270,7 +270,7 @@ ThreadPoolExecutor::PoolStats ThreadPoolExecutor::getPoolStats() const {
   ThreadPoolExecutor::PoolStats stats;
   size_t activeTasks = 0;
   size_t idleAlive = 0;
-  for (auto thread : threadList_.get()) {
+  for (const auto& thread : threadList_.get()) {
     if (thread->idle) {
       const std::chrono::nanoseconds idleTime = now - thread->lastActiveTime;
       stats.maxIdleTime = std::max(stats.maxIdleTime, idleTime);


### PR DESCRIPTION
Found with performance-for-range-copy

Signed-off-by: Rosen Penev <rosenp@gmail.com>