### PR TITLE
[clang-tidy] Remove redundant const

### DIFF
--- a/folly/IPAddressV4.cpp
+++ b/folly/IPAddressV4.cpp
@@ -279,7 +279,7 @@ uint8_t IPAddressV4::getNthMSByte(size_t byteIndex) const {
   return bytes()[byteIndex];
 }
 // protected
-const ByteArray4 IPAddressV4::fetchMask(size_t numBits) {
+ByteArray4 IPAddressV4::fetchMask(size_t numBits) {
   static const size_t bits = bitCount();
   if (numBits > bits) {
     throw IPAddressFormatException("IPv4 addresses are 32 bits");

--- a/folly/IPAddressV4.h
+++ b/folly/IPAddressV4.h
@@ -251,7 +251,7 @@ class IPAddressV4 {
    * @throws abort if numBits == 0 or numBits > bitCount()
    * @return mask associated with numBits
    */
-  static const ByteArray4 fetchMask(size_t numBits);
+  static ByteArray4 fetchMask(size_t numBits);
 
   // Given 2 IPAddressV4, mask pairs extract the longest common IPAddress,
   // mask pair

--- a/folly/IPAddressV6.cpp
+++ b/folly/IPAddressV6.cpp
@@ -498,7 +498,7 @@ uint8_t IPAddressV6::getNthMSByte(size_t byteIndex) const {
 }
 
 // protected
-const ByteArray16 IPAddressV6::fetchMask(size_t numBits) {
+ByteArray16 IPAddressV6::fetchMask(size_t numBits) {
   static const size_t bits = bitCount();
   if (numBits > bits) {
     throw IPAddressFormatException("IPv6 addresses are 128 bits.");

--- a/folly/IPAddressV6.h
+++ b/folly/IPAddressV6.h
@@ -338,7 +338,7 @@ class IPAddressV6 {
    * @throws abort if numBits == 0 or numBits > bitCount()
    * @return mask associated with numBits
    */
-  static const ByteArray16 fetchMask(size_t numBits);
+  static ByteArray16 fetchMask(size_t numBits);
   // Given 2 IPAddressV6,mask pairs extract the longest common IPAddress,
   // mask pair
   static CIDRNetworkV6 longestCommonPrefix(

--- a/folly/io/async/ssl/SSLErrors.cpp
+++ b/folly/io/async/ssl/SSLErrors.cpp
@@ -45,7 +45,7 @@ std::string decodeOpenSSLError(
   }
 }
 
-const StringPiece getSSLErrorString(SSLError error) {
+StringPiece getSSLErrorString(SSLError error) {
   StringPiece ret;
   switch (error) {
     case SSLError::CLIENT_RENEGOTIATION:


### PR DESCRIPTION
Found with readability-const-return-typ

Signed-off-by: Rosen Penev <rosenp@gmail.com>