### PR TITLE
[clang-tidy] pass by value

### DIFF
--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -24,6 +24,7 @@
 #include <cerrno>
 #include <chrono>
 #include <memory>
+#include <utility>
 
 #include <folly/Format.h>
 #include <folly/Indestructible.h>
@@ -220,11 +221,11 @@ namespace folly {
  * Create a client AsyncSSLSocket
  */
 AsyncSSLSocket::AsyncSSLSocket(
-    const shared_ptr<SSLContext>& ctx,
+    shared_ptr<SSLContext>  ctx,
     EventBase* evb,
     bool deferSecurityNegotiation)
     : AsyncSocket(evb),
-      ctx_(ctx),
+      ctx_(std::move(ctx)),
       handshakeTimeout_(this, evb),
       connectionTimeout_(this, evb) {
   init();
@@ -237,14 +238,14 @@ AsyncSSLSocket::AsyncSSLSocket(
  * Create a server/client AsyncSSLSocket
  */
 AsyncSSLSocket::AsyncSSLSocket(
-    const shared_ptr<SSLContext>& ctx,
+    shared_ptr<SSLContext>  ctx,
     EventBase* evb,
     NetworkSocket fd,
     bool server,
     bool deferSecurityNegotiation)
     : AsyncSocket(evb, fd),
       server_(server),
-      ctx_(ctx),
+      ctx_(std::move(ctx)),
       handshakeTimeout_(this, evb),
       connectionTimeout_(this, evb) {
   noTransparentTls_ = true;
@@ -259,13 +260,13 @@ AsyncSSLSocket::AsyncSSLSocket(
 }
 
 AsyncSSLSocket::AsyncSSLSocket(
-    const shared_ptr<SSLContext>& ctx,
+    shared_ptr<SSLContext>  ctx,
     AsyncSocket::UniquePtr oldAsyncSocket,
     bool server,
     bool deferSecurityNegotiation)
     : AsyncSocket(std::move(oldAsyncSocket)),
       server_(server),
-      ctx_(ctx),
+      ctx_(std::move(ctx)),
       handshakeTimeout_(this, AsyncSocket::getEventBase()),
       connectionTimeout_(this, AsyncSocket::getEventBase()) {
   noTransparentTls_ = true;

--- a/folly/io/async/AsyncSSLSocket.h
+++ b/folly/io/async/AsyncSSLSocket.h
@@ -195,7 +195,7 @@ class AsyncSSLSocket : public virtual AsyncSocket {
    * Create a client AsyncSSLSocket
    */
   AsyncSSLSocket(
-      const std::shared_ptr<folly::SSLContext>& ctx,
+      std::shared_ptr<folly::SSLContext>  ctx,
       EventBase* evb,
       bool deferSecurityNegotiation = false);
 
@@ -217,7 +217,7 @@ class AsyncSSLSocket : public virtual AsyncSocket {
    *          unencrypted data can be sent before sslConn/Accept
    */
   AsyncSSLSocket(
-      const std::shared_ptr<folly::SSLContext>& ctx,
+      std::shared_ptr<folly::SSLContext>  ctx,
       EventBase* evb,
       NetworkSocket fd,
       bool server = true,
@@ -228,7 +228,7 @@ class AsyncSSLSocket : public virtual AsyncSocket {
    * AsyncSocket.
    */
   AsyncSSLSocket(
-      const std::shared_ptr<folly::SSLContext>& ctx,
+      std::shared_ptr<folly::SSLContext>  ctx,
       AsyncSocket::UniquePtr oldAsyncSocket,
       bool server = true,
       bool deferSecurityNegotiation = false);

--- a/folly/logging/StandardLogHandler.cpp
+++ b/folly/logging/StandardLogHandler.cpp
@@ -20,6 +20,8 @@
 #include <folly/logging/LogMessage.h>
 #include <folly/logging/LogWriter.h>
 
+#include <utility>
+
 namespace folly {
 
 StandardLogHandler::StandardLogHandler(
@@ -30,7 +32,7 @@ StandardLogHandler::StandardLogHandler(
     : syncLevel_(syncLevel),
       formatter_{std::move(formatter)},
       writer_{std::move(writer)},
-      config_{config} {}
+      config_{std::move(config)} {}
 
 StandardLogHandler::~StandardLogHandler() = default;
 

--- a/folly/test/DeterministicSchedule.cpp
+++ b/folly/test/DeterministicSchedule.cpp
@@ -117,8 +117,8 @@ void ThreadSyncVar::acq_rel() {
 }
 
 DeterministicSchedule::DeterministicSchedule(
-    const std::function<size_t(size_t)>& scheduler)
-    : scheduler_(scheduler), nextThreadId_(0), step_(0) {
+    std::function<size_t(size_t)>  scheduler)
+    : scheduler_(std::move(scheduler)), nextThreadId_(0), step_(0) {
   auto& tls = TLState::get();
   assert(tls.sem == nullptr);
   assert(tls.sched == nullptr);

--- a/folly/test/DeterministicSchedule.h
+++ b/folly/test/DeterministicSchedule.h
@@ -154,7 +154,7 @@ class DeterministicSchedule {
    * schedule) to participate in a deterministic schedule.
    */
   explicit DeterministicSchedule(
-      const std::function<size_t(size_t)>& scheduler);
+      std::function<size_t(size_t)>  scheduler);
 
   DeterministicSchedule(const DeterministicSchedule&) = delete;
   DeterministicSchedule& operator=(const DeterministicSchedule&) = delete;


### PR DESCRIPTION
Found with modernize-pass-by-value

Signed-off-by: Rosen Penev <rosenp@gmail.com>