### PR TITLE
[clang-tidy] Simplify boolean expressions

### DIFF
--- a/folly/IPAddressV6.cpp
+++ b/folly/IPAddressV6.cpp
@@ -282,10 +282,7 @@ bool IPAddressV6::isIPv4Mapped() const {
     }
   }
   // check if bytes 11 and 12 are 255
-  if (by[10] == 0xff && by[11] == 0xff) {
-    return true;
-  }
-  return false;
+  return by[10] == 0xff && by[11] == 0xff;
 }
 
 // public

--- a/folly/compression/Compression.cpp
+++ b/folly/compression/Compression.cpp
@@ -416,10 +416,7 @@ bool StreamCodec::uncompressStream(
     MutableByteRange& output,
     StreamCodec::FlushOp flushOp) {
   if (state_ == State::RESET && input.empty()) {
-    if (uncompressedLength().value_or(0) == 0) {
-      return true;
-    }
-    return false;
+    return uncompressedLength().value_or(0) == 0;
   }
   // Handle input state transitions
   if (state_ == State::RESET) {

--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -1009,14 +1009,16 @@ bool AsyncSSLSocket::willBlock(
     // Register for read event if not already.
     updateEventRegistration(EventHandler::READ, EventHandler::WRITE);
     return true;
-  } else if (error == SSL_ERROR_WANT_WRITE) {
+  }
+  if (error == SSL_ERROR_WANT_WRITE) {
     VLOG(3) << "AsyncSSLSocket(fd=" << fd_ << ", state=" << int(state_)
             << ", sslState=" << sslState_ << ", events=" << eventFlags_ << "): "
             << "SSL_ERROR_WANT_WRITE";
     // Register for write event if not already.
     updateEventRegistration(EventHandler::WRITE, EventHandler::READ);
     return true;
-  } else if ((false
+  }
+  if ((false
 #ifdef SSL_ERROR_WANT_ASYNC // OpenSSL 1.1.0 Async API
               || error == SSL_ERROR_WANT_ASYNC
 #endif
@@ -1953,7 +1955,7 @@ void AsyncSSLSocket::getSSLClientCiphers(
     bool convertToString) const {
   std::string ciphers;
 
-  if (parseClientHello_ == false ||
+  if (!parseClientHello_ ||
       clientHelloInfo_->clientHelloCipherSuites_.empty()) {
     clientCiphers = "";
     return;

--- a/folly/io/async/AsyncServerSocket.cpp
+++ b/folly/io/async/AsyncServerSocket.cpp
@@ -733,7 +733,7 @@ NetworkSocket AsyncServerSocket::createSocket(int family) {
  * TOS derived from the client's connect request
  */
 void AsyncServerSocket::setTosReflect(bool enable) {
-  if (!kIsLinux || enable == false) {
+  if (!kIsLinux || !enable) {
     tosReflect_ = false;
     return;
   }

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -901,7 +901,7 @@ bool AsyncSocket::setZeroCopy(bool enable) {
       ret = netops::getsockopt(fd_, SOL_SOCKET, SO_ZEROCOPY, &val, &optlen);
 
       if (!ret) {
-        enable = val ? true : false;
+        enable = val != 0;
       }
     }
 

--- a/folly/io/async/SSLContext.cpp
+++ b/folly/io/async/SSLContext.cpp
@@ -517,13 +517,10 @@ bool SSLContext::setRandomizedAdvertisedNextProtocols(
   // Client cannot really use randomized alpn
   // Note that this function reverses the typical return value convention
   // of openssl and returns 0 on success.
-  if (SSL_CTX_set_alpn_protos(
+  return SSL_CTX_set_alpn_protos(
           ctx_,
           advertisedNextProtocols_[0].protocols,
-          advertisedNextProtocols_[0].length) != 0) {
-    return false;
-  }
-  return true;
+          advertisedNextProtocols_[0].length) == 0;
 }
 
 void SSLContext::deleteNextProtocolsStrings() {

--- a/folly/io/async/test/TimeUtil.cpp
+++ b/folly/io/async/test/TimeUtil.cpp
@@ -288,11 +288,7 @@ bool checkTimeout(
   // On x86 Linux, sleep calls generally have precision only to the nearest
   // millisecond.  The tolerance parameter lets users allow a few ms of slop.
   auto overrun = effectiveElapsedTime - expected;
-  if (overrun > tolerance) {
-    return false;
-  }
-
-  return true;
+  return overrun <= tolerance;
 }
 
 } // namespace folly


### PR DESCRIPTION
Found with readability-simplify-boolean-expr

Signed-off-by: Rosen Penev <rosenp@gmail.com>