### PR TITLE
[clang-tidy] Remove redundant static

### DIFF
--- a/folly/ClockGettimeWrappers.cpp
+++ b/folly/ClockGettimeWrappers.cpp
@@ -81,7 +81,7 @@ struct VdsoInitializer {
   void* m_handle;
 };
 
-static const VdsoInitializer vdso_initializer;
+const VdsoInitializer vdso_initializer;
 } // namespace
 
 #endif

--- a/folly/compression/Compression.cpp
+++ b/folly/compression/Compression.cpp
@@ -700,7 +700,7 @@ std::unique_ptr<Codec> LZ4Codec::create(int level, CodecType type) {
   return std::make_unique<LZ4Codec>(level, type);
 }
 
-static int lz4ConvertLevel(int level) {
+int lz4ConvertLevel(int level) {
   switch (level) {
     case 1:
     case COMPRESSION_LEVEL_FASTEST:
@@ -871,7 +871,7 @@ class LZ4FrameCodec final : public Codec {
   return std::make_unique<LZ4FrameCodec>(level, type);
 }
 
-static constexpr uint32_t kLZ4FrameMagicLE = 0x184D2204;
+constexpr uint32_t kLZ4FrameMagicLE = 0x184D2204;
 
 std::vector<std::string> LZ4FrameCodec::validPrefixes() const {
   return {prefixToStringLE(kLZ4FrameMagicLE)};
@@ -889,7 +889,7 @@ uint64_t LZ4FrameCodec::doMaxCompressedLength(
   return LZ4F_compressFrameBound(uncompressedLength, &prefs);
 }
 
-static size_t lz4FrameThrowOnError(size_t code) {
+size_t lz4FrameThrowOnError(size_t code) {
   if (LZ4F_isError(code)) {
     throw std::runtime_error(
         to<std::string>("LZ4Frame error: ", LZ4F_getErrorName(code)));
@@ -908,7 +908,7 @@ void LZ4FrameCodec::resetDCtx() {
   dirty_ = false;
 }
 
-static int lz4fConvertLevel(int level) {
+int lz4fConvertLevel(int level) {
   switch (level) {
     case COMPRESSION_LEVEL_FASTEST:
     case COMPRESSION_LEVEL_DEFAULT:
@@ -1224,8 +1224,8 @@ class LZMA2StreamCodec final : public StreamCodec {
   bool needDecodeSize_{false};
 };
 
-static constexpr uint64_t kLZMA2MagicLE = 0x005A587A37FD;
-static constexpr unsigned kLZMA2MagicBytes = 6;
+constexpr uint64_t kLZMA2MagicLE = 0x005A587A37FD;
+constexpr unsigned kLZMA2MagicBytes = 6;
 
 std::vector<std::string> LZMA2StreamCodec::validPrefixes() const {
   if (type() == CodecType::LZMA2_VARINT_SIZE) {
@@ -1331,7 +1331,7 @@ void LZMA2StreamCodec::resetDStream() {
   }
 }
 
-static lzma_ret lzmaThrowOnError(lzma_ret const rc) {
+lzma_ret lzmaThrowOnError(lzma_ret const rc) {
   switch (rc) {
     case LZMA_OK:
     case LZMA_STREAM_END:
@@ -1352,7 +1352,7 @@ static lzma_ret lzmaThrowOnError(lzma_ret const rc) {
   }
 }
 
-static lzma_action lzmaTranslateFlush(StreamCodec::FlushOp flush) {
+lzma_action lzmaTranslateFlush(StreamCodec::FlushOp flush) {
   switch (flush) {
     case StreamCodec::FlushOp::NONE:
       return LZMA_RUN;
@@ -1516,7 +1516,7 @@ bool LZMA2StreamCodec::doUncompressStream(
 
 #if FOLLY_HAVE_LIBZSTD
 
-static int zstdConvertLevel(int level) {
+int zstdConvertLevel(int level) {
   switch (level) {
     case COMPRESSION_LEVEL_FASTEST:
       return 1;
@@ -1532,7 +1532,7 @@ static int zstdConvertLevel(int level) {
   return level;
 }
 
-static int zstdFastConvertLevel(int level) {
+int zstdFastConvertLevel(int level) {
   switch (level) {
     case COMPRESSION_LEVEL_FASTEST:
       return -5;
@@ -1640,8 +1640,8 @@ Bzip2StreamCodec::Bzip2StreamCodec(int level, CodecType type)
   level_ = level;
 }
 
-static uint32_t constexpr kBzip2MagicLE = 0x685a42;
-static uint64_t constexpr kBzip2MagicBytes = 3;
+uint32_t constexpr kBzip2MagicLE = 0x685a42;
+uint64_t constexpr kBzip2MagicBytes = 3;
 
 std::vector<std::string> Bzip2StreamCodec::validPrefixes() const {
   return {prefixToStringLE(kBzip2MagicLE, kBzip2MagicBytes)};
@@ -1661,7 +1661,7 @@ uint64_t Bzip2StreamCodec::doMaxCompressedLength(
   return uncompressedLength + uncompressedLength / 100 + 600;
 }
 
-static bz_stream createBzStream() {
+bz_stream createBzStream() {
   bz_stream stream;
   stream.bzalloc = nullptr;
   stream.bzfree = nullptr;
@@ -1672,7 +1672,7 @@ static bz_stream createBzStream() {
 }
 
 // Throws on error condition, otherwise returns the code.
-static int bzCheck(int const rc) {
+int bzCheck(int const rc) {
   switch (rc) {
     case BZ_OK:
     case BZ_RUN_OK:

--- a/folly/compression/Zlib.cpp
+++ b/folly/compression/Zlib.cpp
@@ -109,7 +109,7 @@ class ZlibStreamCodec final : public StreamCodec {
   int level_;
   bool needReset_{true};
 };
-static constexpr uint16_t kGZIPMagicLE = 0x8B1F;
+constexpr uint16_t kGZIPMagicLE = 0x8B1F;
 
 std::vector<std::string> ZlibStreamCodec::validPrefixes() const {
   if (type() == CodecType::ZLIB) {
@@ -194,11 +194,11 @@ std::unique_ptr<StreamCodec> ZlibStreamCodec::createStream(
   return std::make_unique<ZlibStreamCodec>(options, level);
 }
 
-static bool inBounds(int value, int low, int high) {
+bool inBounds(int value, int low, int high) {
   return (value >= low) && (value <= high);
 }
 
-static int zlibConvertLevel(int level) {
+int zlibConvertLevel(int level) {
   switch (level) {
     case COMPRESSION_LEVEL_FASTEST:
       return 1;
@@ -310,7 +310,7 @@ void ZlibStreamCodec::resetInflateStream() {
   }
 }
 
-static int zlibTranslateFlush(StreamCodec::FlushOp flush) {
+int zlibTranslateFlush(StreamCodec::FlushOp flush) {
   switch (flush) {
     case StreamCodec::FlushOp::NONE:
       return Z_NO_FLUSH;
@@ -323,7 +323,7 @@ static int zlibTranslateFlush(StreamCodec::FlushOp flush) {
   }
 }
 
-static int zlibThrowOnError(int rc) {
+int zlibThrowOnError(int rc) {
   switch (rc) {
     case Z_OK:
     case Z_BUF_ERROR:

--- a/folly/experimental/JemallocHugePageAllocator.cpp
+++ b/folly/experimental/JemallocHugePageAllocator.cpp
@@ -63,7 +63,7 @@ bool folly::JemallocHugePageAllocator::hugePagesSupported{false};
 namespace folly {
 namespace {
 
-static void print_error(int err, const char* msg) {
+void print_error(int err, const char* msg) {
   int cur_errno = std::exchange(errno, err);
   PLOG(ERROR) << msg;
   errno = cur_errno;
@@ -108,7 +108,7 @@ class HugePageArena {
 constexpr size_t kHugePageSize = 2 * 1024 * 1024;
 
 // Singleton arena instance
-static HugePageArena arena;
+HugePageArena arena;
 
 template <typename T, typename U>
 static inline T align_up(T val, U alignment) {
@@ -118,7 +118,7 @@ static inline T align_up(T val, U alignment) {
 
 // mmap enough memory to hold the aligned huge pages, then use madvise
 // to get huge pages. This can be checked in /proc/<pid>/smaps.
-static uintptr_t map_pages(size_t nr_pages) {
+uintptr_t map_pages(size_t nr_pages) {
   // Initial mmapped area is large enough to contain the aligned huge pages
   size_t alloc_size = nr_pages * kHugePageSize;
   int mflags = MAP_PRIVATE | MAP_ANONYMOUS;

--- a/folly/experimental/symbolizer/Dwarf.cpp
+++ b/folly/experimental/symbolizer/Dwarf.cpp
@@ -87,7 +87,7 @@ namespace {
 
 // Maximum number of DIEAbbreviation to cache in a compilation unit. Used to
 // speed up inline function lookup.
-static const uint32_t kMaxAbbreviationEntries = 1000;
+const uint32_t kMaxAbbreviationEntries = 1000;
 
 // All following read* functions read from a StringPiece, advancing the
 // StringPiece, and aborting if there's not enough room.

--- a/folly/experimental/symbolizer/SignalHandler.cpp
+++ b/folly/experimental/symbolizer/SignalHandler.cpp
@@ -88,7 +88,7 @@ void FatalSignalCallbackRegistry::run() {
 
 std::atomic<FatalSignalCallbackRegistry*> gFatalSignalCallbackRegistry{};
 
-static FatalSignalCallbackRegistry* getFatalSignalCallbackRegistry() {
+FatalSignalCallbackRegistry* getFatalSignalCallbackRegistry() {
   // Leak it so we don't have to worry about destruction order
   static FatalSignalCallbackRegistry* fatalSignalCallbackRegistry =
       new FatalSignalCallbackRegistry();

--- a/folly/fibers/Fiber.cpp
+++ b/folly/fibers/Fiber.cpp
@@ -31,14 +31,14 @@ namespace folly {
 namespace fibers {
 
 namespace {
-static const uint64_t kMagic8Bytes = 0xfaceb00cfaceb00c;
+const uint64_t kMagic8Bytes = 0xfaceb00cfaceb00c;
 
 std::thread::id localThreadId() {
   return std::this_thread::get_id();
 }
 
 /* Size of the region from p + nBytes down to the last non-magic value */
-static size_t nonMagicInBytes(unsigned char* stackLimit, size_t stackSize) {
+size_t nonMagicInBytes(unsigned char* stackLimit, size_t stackSize) {
   CHECK_EQ(reinterpret_cast<intptr_t>(stackLimit) % sizeof(uint64_t), 0u);
   CHECK_EQ(stackSize % sizeof(uint64_t), 0u);
   auto begin = reinterpret_cast<uint64_t*>(stackLimit);

--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -61,8 +61,8 @@ using folly::ssl::OpenSSLUtils;
 
 // We have one single dummy SSL context so that we can implement attach
 // and detach methods in a thread safe fashion without modifying opnessl.
-static SSLContext* dummyCtx = nullptr;
-static SpinLock dummyCtxLock;
+SSLContext* dummyCtx = nullptr;
+SpinLock dummyCtxLock;
 
 // If given min write size is less than this, buffer will be allocated on
 // stack, otherwise it is allocated on heap
@@ -192,7 +192,7 @@ void setup_SSL_CTX(SSL_CTX* ctx) {
 // thing is because we will be setting this BIO_METHOD* inside BIOs owned by
 // various SSL objects which may get callbacks even during teardown. We may
 // eventually try to fix this
-static BIO_METHOD* getSSLBioMethod() {
+BIO_METHOD* getSSLBioMethod() {
   static auto const instance = OpenSSLUtils::newSocketBioMethod().release();
   return instance;
 }

--- a/folly/io/async/AsyncSocket.cpp
+++ b/folly/io/async/AsyncSocket.cpp
@@ -258,7 +258,7 @@ int AsyncSocket::SendMsgParamsCallback::getDefaultFlags(
 }
 
 namespace {
-static AsyncSocket::SendMsgParamsCallback defaultSendMsgParamsCallback;
+AsyncSocket::SendMsgParamsCallback defaultSendMsgParamsCallback;
 
 // Based on flags, signal the transparent handler to disable certain functions
 void disableTransparentFunctions(

--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -63,7 +63,7 @@ class EventBaseBackend : public folly::EventBaseBackendBase {
 // event_init() should only ever be called once.  Subsequent calls
 // should be made to event_base_new().  We can recognise that
 // event_init() has already been called by simply inspecting current_base.
-static std::mutex libevent_mutex_;
+std::mutex libevent_mutex_;
 
 EventBaseBackend::EventBaseBackend() {
   struct event ev;


### PR DESCRIPTION
Found with readability-static-definition-in-anonymous-namespace

Signed-off-by: Rosen Penev <rosenp@gmail.com>