### PR TITLE
Handle multiple async pauses which maybe returned by crypto engine

### DIFF
--- a/folly/io/async/AsyncPipe.cpp
+++ b/folly/io/async/AsyncPipe.cpp
@@ -73,7 +73,7 @@ void AsyncPipeReader::handlerReady(uint16_t events) noexcept {
   VLOG(5) << "AsyncPipeReader::handlerReady() this=" << this << ", fd=" << fd_;
   assert(readCallback_ != nullptr);
 
-  while (readCallback_) {
+  if (readCallback_) {
     // - What API does callback support?
     const auto movable = readCallback_->isBufferMovable(); // noexcept
 

--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -1065,17 +1065,17 @@ bool AsyncSSLSocket::willBlock(
       // Our NetworkSocket::native_handle_type is type SOCKET on
       // win32, which means that we need to explicitly construct
       // a native handle type to pass to the constructor.
-      auto native_handle = NetworkSocket::native_handle_type(ofd);
-
-      auto asyncPipeReader =
-          AsyncPipeReader::newReader(eventBase_, NetworkSocket(native_handle));
-      auto asyncPipeReaderPtr = asyncPipeReader.get();
       if (!asyncOperationFinishCallback_) {
-        asyncOperationFinishCallback_.reset(
-            new DefaultOpenSSLAsyncFinishCallback(
-                std::move(asyncPipeReader), this, DestructorGuard(this)));
+          auto native_handle = NetworkSocket::native_handle_type(ofd);
+
+          auto asyncPipeReader =
+              AsyncPipeReader::newReader(eventBase_, NetworkSocket(native_handle));
+          auto asyncPipeReaderPtr = asyncPipeReader.get();
+          asyncOperationFinishCallback_.reset(
+                  new DefaultOpenSSLAsyncFinishCallback(
+                      std::move(asyncPipeReader), this, DestructorGuard(this)));
+          asyncPipeReaderPtr->setReadCB(asyncOperationFinishCallback_.get());
       }
-      asyncPipeReaderPtr->setReadCB(asyncOperationFinishCallback_.get());
     }
 #endif
 

--- a/folly/io/async/AsyncSSLSocket.h
+++ b/folly/io/async/AsyncSSLSocket.h
@@ -173,8 +173,11 @@ class AsyncSSLSocket : public virtual AsyncSocket {
     void readDataAvailable(size_t len) noexcept override {
       CHECK_EQ(len, 1);
       sslSocket_->restartSSLAccept();
-      pipeReader_->setReadCB(nullptr);
-      sslSocket_->setAsyncOperationFinishCallback(nullptr);
+      SSL *s = sslSocket_->ssl_.get();
+      if(SSL_get_state(s) == TLS_ST_SW_SRVR_DONE) {
+        pipeReader_->setReadCB(nullptr);
+        sslSocket_->setAsyncOperationFinishCallback(nullptr);
+      }
     }
 
     void getReadBuffer(void** bufReturn, size_t* lenReturn) noexcept override {


### PR DESCRIPTION
At present, after handling fist async pause handler is being reset, as such to handle cases where crypto engines may return multiple pauses, delaying resetting callback until SSL_accept completes.