### PR TITLE
Fix compile error on Arch Linux with GCC 9.2.

### DIFF
--- a/folly/logging/BridgeFromGoogleLogging.cpp
+++ b/folly/logging/BridgeFromGoogleLogging.cpp
@@ -18,6 +18,7 @@
 
 #include <folly/logging/Logger.h>
 #include <folly/logging/xlog.h>
+#include <gflags/gflags.h>
 
 namespace folly {
 namespace logging {


### PR DESCRIPTION
I received the following error when trying to compile folly on Arch Linux with gcc 9.2.1 20200130 and gflags 2.2.2 installed
![image](https://user-images.githubusercontent.com/13181907/75714341-89362480-5c99-11ea-914e-f6a64a4b596e.png)
