### PR TITLE
Allow folly to build on systems not having the config-fmt.cmake

### DIFF
--- a/CMake/FindFmt.cmake
+++ b/CMake/FindFmt.cmake
@@ -1,0 +1,35 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_path(LIBFMT_INCLUDE_DIR fmt/core.h)
+mark_as_advanced(LIBFMT_INCLUDE_DIR)
+
+find_library(LIBFMT_LIBRARY NAMES fmt fmtd)
+mark_as_advanced(LIBFMT_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+    LIBFMT
+    DEFAULT_MSG
+    LIBFMT_LIBRARY LIBFMT_INCLUDE_DIR)
+
+if(LIBFMT_FOUND)
+    set(LIBFMT_LIBRARIES ${LIBFMT_LIBRARY})
+    set(LIBFMT_INCLUDE_DIRS ${LIBFMT_INCLUDE_DIR})
+    message(STATUS "Found {fmt}: ${LIBFMT_LIBRARY}")
+    add_library(fmt::fmt UNKNOWN IMPORTED)
+    set_target_properties(fmt::fmt PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBFMT_INCLUDE_DIR}")
+    set_target_properties(fmt::fmt PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C" IMPORTED_LOCATION "${LIBFMT_LIBRARY}")
+endif()
+

--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -204,6 +204,14 @@ if (FOLLY_LIBRARY_SANITIZE_ADDRESS)
 endif()
 
 add_library(folly_deps INTERFACE)
+
+find_package(fmt CONFIG)
+if (NOT DEFINED fmt_CONFIG)
+    # Fallback on a normal search on the current system
+    find_package(fmt MODULE REQUIRED)
+endif()
+target_link_libraries(folly_deps INTERFACE fmt::fmt)
+
 list(REMOVE_DUPLICATES FOLLY_INCLUDE_DIRECTORIES)
 target_include_directories(folly_deps INTERFACE ${FOLLY_INCLUDE_DIRECTORIES})
 target_link_libraries(folly_deps INTERFACE
@@ -212,5 +220,3 @@ target_link_libraries(folly_deps INTERFACE
   ${FOLLY_ASAN_FLAGS}
 )
 
-find_package(fmt CONFIG REQUIRED)
-target_link_libraries(folly_deps INTERFACE fmt::fmt)


### PR DESCRIPTION
As written in the documentation, {fmt} should be built alongside folly. This is not possible in my case. My usecase is to provide some kind of small distribution of shared libraries that can be installed on any systems. Hence I really need to have libfmt treated as a normal shared lib.

Moreover, libfmt can be consumed on our side as a normal library outside on cmake. We do not provide the cmake config file which are strongly dependent on the system on which libfmt is installed.

My proposal is to first look for the fmt-config.cmake as it is now but in case of cmake support is not provided by system, we fall back to a normal library lookup.