### PR TITLE
Fix compilation errors for C++20

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -1007,13 +1007,13 @@ class basic_fbstring {
   typedef T traits_type;
   typedef typename traits_type::char_type value_type;
   typedef A allocator_type;
-  typedef typename A::size_type size_type;
-  typedef typename A::difference_type difference_type;
+  typedef typename std::allocator_traits<A>::size_type size_type;
+  typedef typename std::allocator_traits<A>::difference_type difference_type;
 
-  typedef typename A::reference reference;
-  typedef typename A::const_reference const_reference;
-  typedef typename A::pointer pointer;
-  typedef typename A::const_pointer const_pointer;
+  typedef typename std::allocator_traits<A>::value_type& reference;
+  typedef typename std::allocator_traits<A>::value_type const& const_reference;
+  typedef typename std::allocator_traits<A>::pointer pointer;
+  typedef typename std::allocator_traits<A>::const_pointer const_pointer;
 
   typedef E* iterator;
   typedef const E* const_iterator;

--- a/folly/detail/Iterators.h
+++ b/folly/detail/Iterators.h
@@ -93,9 +93,10 @@ class IteratorFacade {
    * this and the `operator==(D const&) const` method above.
    */
 
-  template <class D2>
-  typename std::enable_if<std::is_convertible<D, D2>::value, bool>::type
-  operator==(D2 const& rhs) const {
+  template <class D2,
+    std::enable_if_t<!std::is_same<D, D2>::value, int> = 0,
+    std::enable_if_t<std::is_convertible<D, D2>::value, int> = 0>
+  bool operator==(D2 const& rhs) const {
     return D2(asDerivedConst()) == rhs;
   }
 


### PR DESCRIPTION
Compiling with gcc 10.0.1 and -std=gnu++2a, we have the following errors:
```
/home/docker/opensource/folly/folly/FBString.h:1013:33: error: no type named 'reference' in 'class std::allocator<char>'
 1013 |   typedef typename A::reference reference;
      |                                 ^~~~~~~~~
/home/docker/opensource/folly/folly/FBString.h:1014:39: error: no type named 'const_reference' in 'class std::allocator<char>'
 1014 |   typedef typename A::const_reference const_reference;
```
This is due to the fact many members in std::allocator have been remove in C++20: https://en.cppreference.com/w/cpp/memory/allocator

We also have this one due to the new way C++ resolves the comparison operators:
```
/home/docker/opensource/folly/folly/dynamic-inl.h:854:20: error: ambiguous overload for 'operator!=' (operand types are 'folly::dynamic::const_item_iterator' and 'folly::dynamic::const_item_iterator')
  854 |   return find(key) != items().end() ? 1u : 0u;
      |          ~~~~~~~~~ ^~ ~~~~~~~~~~~~~
      |              |                   |
      |              |                   folly::dynamic::const_item_iterator
      |              folly::dynamic::const_item_iterator
In file included from /home/docker/opensource/folly/folly/dynamic-inl.h:25,
                 from /home/docker/opensource/folly/folly/dynamic.h:796,
                 from /home/docker/opensource/folly/folly/dynamic.cpp:17:
/home/docker/opensource/folly/folly/detail/Iterators.h:80:8: note: candidate: 'bool folly::detail::IteratorFacade<D, V, Tag>::operator==(const D&) const [with D = folly::dynamic::const_item_iterator; V = const std::pair<const folly::dynamic, folly::dynamic>; Tag = std::f
orward_iterator_tag]' (reversed)
   80 |   bool operator==(D const& rhs) const {
      |        ^~~~~~~~
/home/docker/opensource/folly/folly/detail/Iterators.h:98:3: note: candidate: 'typename std::enable_if<std::is_convertible<D, D2>::value, bool>::type folly::detail::IteratorFacade<D, V, Tag>::operator==(const D2&) const [with D2 = folly::dynamic::const_item_iterator; D =
 folly::dynamic::const_item_iterator; V = const std::pair<const folly::dynamic, folly::dynamic>; Tag = std::forward_iterator_tag; typename std::enable_if<std::is_convertible<D, D2>::value, bool>::type = bool]' (reversed)
   98 |   operator==(D2 const& rhs) const {
      |   ^~~~~~~~
/home/docker/opensource/folly/folly/detail/Iterators.h:84:8: note: candidate: 'bool folly::detail::IteratorFacade<D, V, Tag>::operator!=(const D&) const [with D = folly::dynamic::const_item_iterator; V = const std::pair<const folly::dynamic, folly::dynamic>; Tag = std::f
orward_iterator_tag]'
   84 |   bool operator!=(D const& rhs) const {
      |        ^~~~~~~~
/home/docker/opensource/folly/folly/detail/Iterators.h:103:8: note: candidate: 'bool folly::detail::IteratorFacade<D, V, Tag>::operator!=(const D2&) const [with D2 = folly::dynamic::const_item_iterator; D = folly::dynamic::const_item_iterator; V = const std::pair<const f
olly::dynamic, folly::dynamic>; Tag = std::forward_iterator_tag]'
  103 |   bool operator!=(D2 const& rhs) const {
      |        ^~~~~~~~
```