### PR TITLE
FutureSplitter should not loose interruptHandlers

### DIFF
--- a/folly/futures/FutureSplitter.h
+++ b/folly/futures/FutureSplitter.h
@@ -52,6 +52,7 @@ class FutureSplitter {
   explicit FutureSplitter(Future<T>&& future)
       : promise_(std::make_shared<SharedPromise<T>>()),
         e_(getExecutorFrom(future)) {
+    promise_->setInterruptHandler(future.getCore().getInterruptHandler());
     std::move(future).thenTry([promise = promise_](Try<T>&& theTry) {
       promise->setTry(std::move(theTry));
     });


### PR DESCRIPTION
Corresponding gtest:
```
#include <folly/futures/FutureSplitter.h>
TEST(FutureHelpers, cancelablesplit)
{
  auto executor = std::make_shared<folly::ManualExecutor>();
  {
    auto[p, f] = folly::makePromiseContract<folly::Unit>(executor.get());
    std::atomic<bool> flag = false;
    p.setInterruptHandler([&](const folly::exception_wrapper &) {
        flag = true;
    });

    auto ff = folly::FutureSplitter(std::move(f));
    ff.getFuture().cancel();
    ASSERT_TRUE(flag);
  }
}
```