### PR TITLE
include <bit> if we're going to use std::bit_cast

### DIFF
--- a/folly/lang/Bits.h
+++ b/folly/lang/Bits.h
@@ -64,11 +64,16 @@
 #include <folly/lang/Assume.h>
 #include <folly/portability/Builtins.h>
 
+#ifdef __has_include
+#if __has_include(<bit>)
+#include <bit>
+#endif
+#endif
+
 namespace folly {
 
 #if __cpp_lib_bit_cast
 
-#include <bit>
 using std::bit_cast;
 
 #else

--- a/folly/lang/Bits.h
+++ b/folly/lang/Bits.h
@@ -68,6 +68,7 @@ namespace folly {
 
 #if __cpp_lib_bit_cast
 
+#include <bit>
 using std::bit_cast;
 
 #else


### PR DESCRIPTION
This fixes #1333 and makes folly work with the most recent version of microsoft/STL (we just added bit_cast)

Note: I've not tested this locally so I am relying on CI to make sure things work.