### PR TITLE
Fix mode_t to match Linux and be overridable

### DIFF
--- a/folly/portability/SysTypes.h
+++ b/folly/portability/SysTypes.h
@@ -21,8 +21,6 @@
 #ifdef _WIN32
 #include <basetsd.h> // @manual
 
-#define HAVE_MODE_T 1
-
 // This is a massive pain to have be an `int` due to the pthread implementation
 // we support, but it's far more compatible with the rest of the windows world
 // as an `int` than it would be as a `void*`
@@ -31,7 +29,12 @@ using pid_t = int;
 // appropriate place without defining a portability header for stdint.h
 // with just this single typedef.
 using ssize_t = SSIZE_T;
+
+#ifndef HAVE_MODE_T
+#define HAVE_MODE_T 1
 // The Windows headers don't define this anywhere, nor do any of the libs
 // that Folly depends on, so define it here.
-using mode_t = unsigned short;
+using mode_t = unsigned int;
+#endif
+
 #endif


### PR DESCRIPTION
`unsigned int` is a more typical definition of the mode_t type on Linux systems, which is what this is trying to emulate.

Also guard by checking that HAVE_MODE_T isn't already define to allow clients to suppress its definition in cases where other client-used libraries (e.g. wxWindows) have their own definition which may conflict.