### PR TITLE
Fix cache line sizing on s390x

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -107,11 +107,18 @@ constexpr bool kHasUnalignedAccess = false;
 #define FOLLY_PPC64 0
 #endif
 
+#if defined(__s390__)
+#define FOLLY_S390 1
+#else
+#define FOLLY_S390 0
+#endif
+
 namespace folly {
 constexpr bool kIsArchArm = FOLLY_ARM == 1;
 constexpr bool kIsArchAmd64 = FOLLY_X64 == 1;
 constexpr bool kIsArchAArch64 = FOLLY_AARCH64 == 1;
 constexpr bool kIsArchPPC64 = FOLLY_PPC64 == 1;
+constexpr bool kIsArchS390 = FOLLY_S390 == 1;
 } // namespace folly
 
 namespace folly {

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -107,10 +107,10 @@ constexpr bool kHasUnalignedAccess = false;
 #define FOLLY_PPC64 0
 #endif
 
-#if defined(__s390__)
-#define FOLLY_S390 1
+#if defined(__s390x__)
+#define FOLLY_S390X 1
 #else
-#define FOLLY_S390 0
+#define FOLLY_S390X 0
 #endif
 
 namespace folly {
@@ -118,7 +118,7 @@ constexpr bool kIsArchArm = FOLLY_ARM == 1;
 constexpr bool kIsArchAmd64 = FOLLY_X64 == 1;
 constexpr bool kIsArchAArch64 = FOLLY_AARCH64 == 1;
 constexpr bool kIsArchPPC64 = FOLLY_PPC64 == 1;
-constexpr bool kIsArchS390 = FOLLY_S390 == 1;
+constexpr bool kIsArchS390X = FOLLY_S390X == 1;
 } // namespace folly
 
 namespace folly {

--- a/folly/lang/Align.h
+++ b/folly/lang/Align.h
@@ -120,7 +120,7 @@ struct alignas(max_align_v) max_align_t {};
 //
 //  mimic: std::hardware_destructive_interference_size, C++17
 constexpr std::size_t hardware_destructive_interference_size =
-    (kIsArchArm || kIsArchS390) ? 64 : 128;
+    (kIsArchArm || kIsArchS390X) ? 64 : 128;
 static_assert(hardware_destructive_interference_size >= max_align_v, "math?");
 
 //  Memory locations within the same cache line are subject to constructive

--- a/folly/lang/Align.h
+++ b/folly/lang/Align.h
@@ -120,7 +120,7 @@ struct alignas(max_align_v) max_align_t {};
 //
 //  mimic: std::hardware_destructive_interference_size, C++17
 constexpr std::size_t hardware_destructive_interference_size =
-    kIsArchArm ? 64 : 128;
+    kIsArchArm | kIsArchS390 ? 64 : 128;
 static_assert(hardware_destructive_interference_size >= max_align_v, "math?");
 
 //  Memory locations within the same cache line are subject to constructive

--- a/folly/lang/Align.h
+++ b/folly/lang/Align.h
@@ -120,7 +120,7 @@ struct alignas(max_align_v) max_align_t {};
 //
 //  mimic: std::hardware_destructive_interference_size, C++17
 constexpr std::size_t hardware_destructive_interference_size =
-    kIsArchArm | kIsArchS390 ? 64 : 128;
+    (kIsArchArm || kIsArchS390) ? 64 : 128;
 static_assert(hardware_destructive_interference_size >= max_align_v, "math?");
 
 //  Memory locations within the same cache line are subject to constructive


### PR DESCRIPTION
We are using Folly inside RocksDB, and we noticed a build failure due to cache line sizing on s390x. I fixed it in our copy of Folly, and am sending you the changes upstream.

CC @pdillinger