### PR TITLE
Properly set working directory for shell builder generator

### DIFF
--- a/build/fbcode_builder/shell_builder.py
+++ b/build/fbcode_builder/shell_builder.py
@@ -99,9 +99,8 @@ if __name__ == '__main__':
     temp = persistent_temp_dir(repo_root)
 
     config = read_fbcode_builder_config('fbcode_builder_config.py')
-    builder = ShellFBCodeBuilder()
+    builder = ShellFBCodeBuilder(projects_dir=temp)
 
-    builder.add_option('projects_dir', temp)
     if distutils.spawn.find_executable('ccache'):
         builder.add_option('ccache_dir',
             os.environ.get('CCACHE_DIR', os.path.join(temp, '.ccache')))


### PR DESCRIPTION
cf. https://github.com/facebook/folly/blob/9d715f1f0f683baa25706ed0c442aababf59275d/build/fbcode_builder/fbcode_builder.py#L93

`FBCodeBuilder` constructor fixes `_github_dir`, which implies that the shell builder should initialize this value at construction time.