### PR TITLE
Fix data race/UB in RCU documentation example

### DIFF
--- a/folly/synchronization/Rcu.h
+++ b/folly/synchronization/Rcu.h
@@ -67,9 +67,10 @@
 // void writer() {
 //   while (true) {
 //     std::this_thread::sleep_for(std::chrono::seconds(60));
-//     ConfigData* oldConfigData = globalConfigData;
+//     ConfigData* oldConfigData;
 //     ConfigData* newConfigData = loadConfigDataFromRemoteServer();
 //     sm.lock();
+//     oldConfigData = globalConfigData;
 //     globalConfigData = newConfigData;
 //     sm.unlock();
 //     delete oldConfigData;


### PR DESCRIPTION
The read of globalConfigData outside of sm.lock() races with any other writer that is modifying
globalConfigData inside of sm.lock(). This is a documentation only change.