### PR TITLE
Fix clang10 warnings

### DIFF
--- a/folly/ConcurrentSkipList-inl.h
+++ b/folly/ConcurrentSkipList-inl.h
@@ -236,7 +236,7 @@ class SkipListRandomHeight {
       p *= kProb;
       sizeLimit *= kProbInv;
       lookupTable_[i] = lookupTable_[i - 1] + p;
-      sizeLimitTable_[i] = sizeLimit > kMaxSizeLimit
+      sizeLimitTable_[i] = sizeLimit > static_cast<double>(kMaxSizeLimit)
           ? kMaxSizeLimit
           : static_cast<size_t>(sizeLimit);
     }

--- a/folly/chrono/Conv.h
+++ b/folly/chrono/Conv.h
@@ -74,7 +74,7 @@ struct is_chrono_conversion {
  */
 template <typename Src>
 Expected<time_t, ConversionCode> chronoRangeCheck(Src value) {
-  if (value > std::numeric_limits<time_t>::max()) {
+  if (value > static_cast<Src>(std::numeric_limits<time_t>::max())) {
     return makeUnexpected(ConversionCode::POSITIVE_OVERFLOW);
   }
   if (std::is_signed<Src>::value) {

--- a/folly/fibers/ExecutorLoopController.h
+++ b/folly/fibers/ExecutorLoopController.h
@@ -31,8 +31,6 @@ class ExecutorTimeoutManager : public TimeoutManager {
   explicit ExecutorTimeoutManager(folly::Executor* executor)
       : executor_(executor) {}
 
-  ExecutorTimeoutManager(ExecutorTimeoutManager&&) = default;
-  ExecutorTimeoutManager& operator=(ExecutorTimeoutManager&&) = default;
   ExecutorTimeoutManager(const ExecutorTimeoutManager&) = delete;
   ExecutorTimeoutManager& operator=(const ExecutorTimeoutManager&) = delete;
 

--- a/folly/futures/Retrying.h
+++ b/folly/futures/Retrying.h
@@ -181,7 +181,7 @@ Duration retryingJitteredExponentialBackoffDur(
   auto dist = std::normal_distribution<double>(0.0, jitter_param);
   auto jitter = std::exp(dist(rng));
   auto backoff_rep = jitter * backoff_min.count() * std::pow(2, n - 1);
-  if (UNLIKELY(backoff_rep >= std::numeric_limits<Duration::rep>::max())) {
+  if (UNLIKELY(backoff_rep >= static_cast<decltype(backoff_rep)>(std::numeric_limits<Duration::rep>::max()))) {
     return std::max(backoff_min, backoff_max);
   }
   auto backoff = Duration(Duration::rep(backoff_rep));

--- a/folly/test/ConvTest.cpp
+++ b/folly/test/ConvTest.cpp
@@ -318,7 +318,7 @@ void testString2Integral() {
         (Uint)4147483648U,
         (Uint)4000000000U,
     };
-    FOR_EACH_RANGE (i, 0, sizeof(uStrings2) / sizeof(uStrings2)) {
+    FOR_EACH_RANGE (i, 0, sizeof(uStrings2) / sizeof(*uStrings2)) {
       EXPECT_EQ(to<Uint>(uStrings2[i]), uValues2[i]);
       if (sizeof(Int) == 4) {
         EXPECT_THROW(to<Sint>(uStrings2[i]), std::range_error);


### PR DESCRIPTION
Summary:
- Clang 10 has a new warning: "-Wimplicit-int-float-conversion" which
  flags some code. Fix these up by explicitly casting where appropriate.
- Clang 10 has a new warning: "-Wsizeof-array-div" which flags some
  code. Fix these up by inserting parenthesis.
- Clang 10 uses "-Wdefaulted-function-deleted" which warns about
  `ExecutorTimeoutManager` special member functions being implicitly
  deleted due to the base class of `TimeoutManager` having a deleted move
  constructor. Instead of defaulting them when they will be deleted,
  just remove them.