### PR TITLE
AsyncUDPServerSocketTest: fix issues when running on OSX

### DIFF
--- a/folly/io/async/test/AsyncUDPSocketTest.cpp
+++ b/folly/io/async/test/AsyncUDPSocketTest.cpp
@@ -692,7 +692,7 @@ class AsyncUDPSocketTest : public Test {
  public:
   void SetUp() override {
     socket_ = std::make_shared<AsyncUDPSocket>(&evb_);
-    addr_ = folly::SocketAddress("127.0.0.1", 0);
+    addr_ = folly::SocketAddress("127.0.0.1", 9999);
     socket_->bind(addr_);
   }
 

--- a/folly/io/async/test/AsyncUDPSocketTest.cpp
+++ b/folly/io/async/test/AsyncUDPSocketTest.cpp
@@ -728,6 +728,8 @@ TEST_F(AsyncUDPSocketTest, TestErrToNonExistentServer) {
       }));
 #endif // FOLLY_HAVE_MSG_ERRQUEUE
   socket_->write(addr, folly::IOBuf::copyBuffer("hey"));
+  evb_.timer().scheduleTimeoutFn([&] { evb_.terminateLoopSoon(); },
+                                 std::chrono::milliseconds(30));
   evb_.loopForever();
   EXPECT_TRUE(errRecvd);
 }
@@ -756,6 +758,8 @@ TEST_F(AsyncUDPSocketTest, CloseInErrorCallback) {
   }));
   socket_->write(addr, folly::IOBuf::copyBuffer("hey"));
   socket_->write(addr, folly::IOBuf::copyBuffer("hey"));
+  evb_.timer().scheduleTimeoutFn([&] { evb_.terminateLoopSoon(); },
+                                 std::chrono::milliseconds(30));
   evb_.loopForever();
   EXPECT_TRUE(errRecvd);
 }


### PR DESCRIPTION
When running these tests on OSX, the following failures occur:

```
  Test project /Users/matthieuhauglustaine/projects/contrib/folly/_build
        Start 1269: AsyncUDPSocketTest.AsyncSocketIntegrationTest.PingPong
   1/18 Test #1269: AsyncUDPSocketTest.AsyncSocketIntegrationTest.PingPong .................................   Passed    0.90 sec
        Start 1270: AsyncUDPSocketTest.AsyncSocketIntegrationTest.PingPongNotify
   2/18 Test #1270: AsyncUDPSocketTest.AsyncSocketIntegrationTest.PingPongNotify ...........................   Passed    0.03 sec
        Start 1271: AsyncUDPSocketTest.AsyncSocketIntegrationTest.PingPongNotifyMmsg
   3/18 Test #1271: AsyncUDPSocketTest.AsyncSocketIntegrationTest.PingPongNotifyMmsg .......................   Passed    0.02 sec
        Start 1272: AsyncUDPSocketTest.AsyncSocketIntegrationTest.ConnectedPingPong
   4/18 Test #1272: AsyncUDPSocketTest.AsyncSocketIntegrationTest.ConnectedPingPong ........................   Passed    0.03 sec
        Start 1273: AsyncUDPSocketTest.AsyncSocketIntegrationTest.ConnectedPingPongServerWrongAddress
   5/18 Test #1273: AsyncUDPSocketTest.AsyncSocketIntegrationTest.ConnectedPingPongServerWrongAddress ......   Passed    0.64 sec
        Start 1274: AsyncUDPSocketTest.AsyncSocketIntegrationTest.ConnectedPingPongClientWrongAddress
   6/18 Test #1274: AsyncUDPSocketTest.AsyncSocketIntegrationTest.ConnectedPingPongClientWrongAddress ......   Passed    0.64 sec
        Start 1275: AsyncUDPSocketTest.AsyncSocketIntegrationTest.ConnectedPingPongDifferentWriteAddress
   7/18 Test #1275: AsyncUDPSocketTest.AsyncSocketIntegrationTest.ConnectedPingPongDifferentWriteAddress ...   Passed    0.65 sec
        Start 1276: AsyncUDPSocketTest.AsyncSocketIntegrationTest.PingPongPauseResumeListening
   8/18 Test #1276: AsyncUDPSocketTest.AsyncSocketIntegrationTest.PingPongPauseResumeListening .............***Failed    1.27 sec
        Start 1277: AsyncUDPSocketTest.AsyncUDPSocketTest.TestConnect
   9/18 Test #1277: AsyncUDPSocketTest.AsyncUDPSocketTest.TestConnect ......................................***Failed    0.02 sec
        Start 1278: AsyncUDPSocketTest.AsyncUDPSocketTest.TestErrToNonExistentServer
  10/18 Test #1278: AsyncUDPSocketTest.AsyncUDPSocketTest.TestErrToNonExistentServer .......................***Timeout 120.04 sec
        Start 1279: AsyncUDPSocketTest.AsyncUDPSocketTest.TestUnsetErrCallback
  11/18 Test #1279: AsyncUDPSocketTest.AsyncUDPSocketTest.TestUnsetErrCallback .............................   Passed    0.07 sec
        Start 1280: AsyncUDPSocketTest.AsyncUDPSocketTest.CloseInErrorCallback
  12/18 Test #1280: AsyncUDPSocketTest.AsyncUDPSocketTest.CloseInErrorCallback .............................***Timeout 120.03 sec
        Start 1281: AsyncUDPSocketTest.AsyncUDPSocketTest.TestNonExistentServerNoErrCb
  13/18 Test #1281: AsyncUDPSocketTest.AsyncUDPSocketTest.TestNonExistentServerNoErrCb .....................   Passed    0.07 sec
        Start 1282: AsyncUDPSocketTest.AsyncUDPSocketTest.TestBound
  14/18 Test #1282: AsyncUDPSocketTest.AsyncUDPSocketTest.TestBound ........................................   Passed    0.03 sec
        Start 1283: AsyncUDPSocketTest.AsyncUDPSocketTest.TestBoundUnixSocket
  15/18 Test #1283: AsyncUDPSocketTest.AsyncUDPSocketTest.TestBoundUnixSocket ..............................   Passed    0.03 sec
        Start 1284: AsyncUDPSocketTest.AsyncUDPSocketTest.TestAttachAfterDetachEvbWithReadCallback
  16/18 Test #1284: AsyncUDPSocketTest.AsyncUDPSocketTest.TestAttachAfterDetachEvbWithReadCallback .........   Passed    0.02 sec
        Start 1285: AsyncUDPSocketTest.AsyncUDPSocketTest.TestAttachAfterDetachEvbNoReadCallback
  17/18 Test #1285: AsyncUDPSocketTest.AsyncUDPSocketTest.TestAttachAfterDetachEvbNoReadCallback ...........   Passed    0.02 sec
        Start 1286: AsyncUDPSocketTest.AsyncUDPSocketTest.TestDetachAttach
  18/18 Test #1286: AsyncUDPSocketTest.AsyncUDPSocketTest.TestDetachAttach .................................   Passed    0.03 sec
```

This pull request aims to address some.

## TestConnect

Commit 5af8381.

The TestConnect test fails as it tries to connect to port 0 on 127.0.0.1.

The underlying system call fails on OSX with errno set to `EADDRNOTAVAIL` (`Cannot assign requested address`).

Using a port >1024 ensures the test is green.

## TestErrToNonExistentServer & CloseInErrorCallback

Commit b4b0700.

TestErrToNonExistentServer & CloseInErrorCallback, as written, will fail on systems that do not support `IP_RECVERR`, as their err callback will never be called. In practice, these tests timeout as the event loop is never terminated.

With this PR, we ensure the event loop is closed after 30ms (similarly to other of the unit test) to avoid the timeout.

Ideally, I would simply ignore these tests on OSX but this seems not to be supported by the `folly_define_tests` CMake function.

## PingPongPauseResumeListening

I've investigated quite a bit and didn't manage to isolate the root cause. The issue appears to happen only if the client send data when the server is suspended. Upon resume, the libevent callback is properly set to execute on read events, yet the callback is never triggered. 