### PR TITLE
GH actions: fixup boost windows environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,9 @@ jobs:
     runs-on: windows-2016
     steps:
     - uses: actions/checkout@v1
+    - name: Export boost environment
+      run: "echo ::set-env name=BOOST_ROOT::%BOOST_ROOT_1_69_0%"
+      shell: cmd
     - name: Fix Git config
       run: git config --system core.longpaths true
     - name: Fetch boost

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -705,6 +705,18 @@ jobs:
         out.write("    - uses: actions/checkout@v1\n")
 
         if build_opts.is_windows():
+            # cmake relies on BOOST_ROOT but GH deliberately don't set it in order
+            # to avoid versioning issues:
+            # https://github.com/actions/virtual-environments/issues/319
+            # Instead, set the version we think we need; this is effectively
+            # coupled with the boost manifest
+            # This is the unusual syntax for setting an env var for the rest of
+            # the steps in a workflow:
+            # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+            out.write("    - name: Export boost environment\n");
+            out.write("      run: \"echo ::set-env name=BOOST_ROOT::%BOOST_ROOT_1_69_0%\"\n");
+            out.write("      shell: cmd\n");
+
             # The git installation may not like long filenames, so tell it
             # that we want it to use them!
             out.write("    - name: Fix Git config\n")


### PR DESCRIPTION
The environment changed since I tested  D20740410 and now it appears
that we'll need to re-export a versioned variable in order for cmake
to detect boost on the GH actions hosts.

Test Plan: the GH actions status of this diff.

The workflow was updated via:

```
python3 build/fbcode_builder/getdeps.py generate-github-actions folly --output-file .github/workflows/main.yml
```