### PR TITLE
Add 0-RTT read early data OpenSSL solution

### DIFF
--- a/folly/io/async/AsyncSSLSocket.h
+++ b/folly/io/async/AsyncSSLSocket.h
@@ -838,6 +838,9 @@ class AsyncSSLSocket : public virtual AsyncSocket {
   void handleWrite() noexcept override;
   void handleAccept() noexcept;
   void handleConnect() noexcept override;
+#if FOLLY_OPENSSL_HAS_TLS13
+  int handleReadEarlyData() noexcept;
+#endif
 
   void invalidState(HandshakeCB* callback);
   bool
@@ -928,6 +931,9 @@ class AsyncSSLSocket : public virtual AsyncSocket {
   // to disable client-initiated renegotiation.
   bool handshakeComplete_{false};
   bool renegotiateAttempted_{false};
+#if FOLLY_OPENSSL_HAS_TLS13
+  bool earlyDataPhaseComplete_{false};
+#endif
   SSLStateEnum sslState_{STATE_UNINIT};
   std::shared_ptr<folly::SSLContext> ctx_;
   // Callback for SSL_accept() or SSL_connect()

--- a/folly/io/async/SSLContext.h
+++ b/folly/io/async/SSLContext.h
@@ -574,6 +574,15 @@ class SSLContext {
 
   [[deprecated("Use folly::ssl::init")]] static void initializeOpenSSL();
 
+#if FOLLY_OPENSSL_HAS_TLS13
+  /**
+   * Callback to parse 0-RTT early data.
+   */
+  std::function<bool(
+      const unsigned char *buf,
+      size_t bufSize)> parseEarlyDataCb_;
+#endif
+
  protected:
   SSL_CTX* ctx_;
 


### PR DESCRIPTION
Summary:
In TLS 1.3 handshake, early data comes as an extension of clientHello.
It is read using SSL_read_early_data() OpenSSL api and corresponding
cases based on its state machine are handled. A callback
(parseEarlyDataCb_) is added to verify the read early data. This
callback can be used to reject the early data if not found suitable.