### PR TITLE
Creating hooks for enabling kTLS from the user application side

### DIFF
--- a/folly/io/async/AsyncSSLSocket.cpp
+++ b/folly/io/async/AsyncSSLSocket.cpp
@@ -1716,7 +1716,8 @@ int AsyncSSLSocket::eorAwareSSLWrite(
     minEorRawByteNo_ = getRawBytesWritten() + n;
   }
 
-  n = sslWriteImpl(ssl.get(), buf, n);
+  n = ktlsEnabled_ ? send(fd_.toFd(), buf, n, 0) :
+                     sslWriteImpl(ssl.get(), buf, n);
   if (n > 0) {
     appBytesWritten_ += n;
     if (appEorByteNo_) {

--- a/folly/io/async/AsyncSSLSocket.h
+++ b/folly/io/async/AsyncSSLSocket.h
@@ -811,6 +811,10 @@ class AsyncSSLSocket : public virtual AsyncSocket {
     asyncOperationFinishCallback_ = std::move(cb);
   }
 
+  void enableKTLS(bool enabled) {
+    ktlsEnabled_ = enabled;
+  }
+
  private:
   /**
    * Handle the return from invoking SSL_accept
@@ -943,6 +947,8 @@ class AsyncSSLSocket : public virtual AsyncSocket {
   Timeout handshakeTimeout_;
   Timeout connectionTimeout_;
 
+  // Enable if kTLS support is needed
+  bool ktlsEnabled_{false};
   // The app byte num that we are tracking for EOR.
   //
   // Only one app EOR byte can be tracked.


### PR DESCRIPTION
Summary:
kTLS is a way to offload ssl encrypt/decrypt etc. crypto operations to
the kernel's TLS module. The application which is invoking AsyncSSLSocket
lib will setup the kTLS path by doing appropriate setsockopt() calls and
will subsequently set ktlsEnabled_ flag. This will invoke send() system
call instead of SSL_write to write the data. This makes all the data to
go through kTLS module and hence gets offloaded to it.