### PR TITLE
Handle multiple SSL_ERROR_WANT_ASYNC which is returned by ASYNC engine

### DIFF
--- a/folly/io/async/AsyncPipe.cpp
+++ b/folly/io/async/AsyncPipe.cpp
@@ -48,8 +48,6 @@ void AsyncPipeReader::close() {
 
     if (closeCb_) {
       closeCb_(fd_);
-    } else {
-      netops::close(fd_);
     }
     fd_ = NetworkSocket();
   }

--- a/folly/io/async/AsyncSSLSocket.h
+++ b/folly/io/async/AsyncSSLSocket.h
@@ -175,9 +175,9 @@ class AsyncSSLSocket : public AsyncSocket {
 
     void readDataAvailable(size_t len) noexcept override {
       CHECK_EQ(len, 1);
-      sslSocket_->restartSSLAccept();
       pipeReader_->setReadCB(nullptr);
       sslSocket_->setAsyncOperationFinishCallback(nullptr);
+      sslSocket_->restartSSLAccept();
     }
 
     void getReadBuffer(void** bufReturn, size_t* lenReturn) noexcept override {


### PR DESCRIPTION
@afrind , Please review the updated changes as per your comments. 

The changes are required to handle cases where multiple SSL_ERROR_WANT_ASYNC is returned by the async engine.

Also I have removed the code which closes the async fd as this is my crypto driver handle and should not be closed by upper layers as I require it further in my SSL connection


