### PR TITLE
Fix issue #1238 make cmake find libatomic

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -172,6 +172,7 @@ check_cxx_source_compiles("
 if(NOT FOLLY_CPP_ATOMIC_BUILTIN)
   list(APPEND CMAKE_REQUIRED_LIBRARIES atomic)
   list(APPEND FOLLY_LINK_LIBRARIES atomic)
+  set(ATOMIC_LIBRARY "atomic")
   check_cxx_source_compiles("
     #include <atomic>
     int main(int argc, char** argv) {


### PR DESCRIPTION
this fixes cmake not finding libatomic at least on clearlinux 33470 
