### PR TITLE
remove extern "C"

### DIFF
--- a/folly/experimental/io/IoUring.h
+++ b/folly/experimental/io/IoUring.h
@@ -16,9 +16,7 @@
 
 #pragma once
 
-extern "C" {
 #include <liburing.h>
-}
 
 #include <folly/SharedMutex.h>
 #include <folly/experimental/io/AsyncBase.h>

--- a/folly/experimental/io/IoUringBackend.h
+++ b/folly/experimental/io/IoUringBackend.h
@@ -16,9 +16,7 @@
 
 #pragma once
 
-extern "C" {
 #include <liburing.h>
-}
 
 #include <folly/Function.h>
 #include <folly/Range.h>


### PR DESCRIPTION
The upstream [liburing](https://git.kernel.dk/cgit/liburing/tree/src/include/liburing.h) has changed to use ```extern "C" ```, we must remove the duplicated `extern "C"`.