### PR TITLE
CMake: Handle generator expressions requiring a target for pkg-config

### DIFF
--- a/CMake/GenPkgConfig.cmake
+++ b/CMake/GenPkgConfig.cmake
@@ -92,7 +92,14 @@ function(gen_pkgconfig_vars)
 
   # Set the output variables
   string(REPLACE ";" " " cflags "${cflags}")
-  set("${var_prefix}_CFLAGS" "${cflags}" PARENT_SCOPE)
   string(REPLACE ";" " " private_libs "${private_libs}")
+
+  # Since CMake 3.18 FindThreads may include a generator expression requiring a target, which gets propagated to us through INTERFACE_COMPILE_OPTIONS.
+	# Before CMake 3.19 there's no way to solve this in a general way, so we work around the specific case. See #1414 and CMake bug #21074.
+  if(CMAKE_VERSION VERSION_LESS 3.19)
+    string(REPLACE "<COMPILE_LANG_AND_ID:CUDA,NVIDIA>" "<COMPILE_LANGUAGE:CUDA>" cflags "${cflags}")
+  endif()
+
+  set("${var_prefix}_CFLAGS" "${cflags}" PARENT_SCOPE)
   set("${var_prefix}_PRIVATE_LIBS" "${private_libs}" PARENT_SCOPE)
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,10 +436,17 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc.gen
   @ONLY
 )
+
+# Specify target to allow resolving generator expressions requiring a target for CMake >=3.19. See #1414.
+if(CMAKE_VERSION VERSION_GREATER 3.18)
+  set(target_arg TARGET folly_deps)
+endif()
+
 file(
   GENERATE
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc
   INPUT ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc.gen
+  ${target_arg}
 )
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/libfolly.pc


### PR DESCRIPTION
CMake's find modules may have target-based generator expressions, which get propagated to us when generating the pkg-config file.
CMake 3.19 introduces the TARGET argument to file(GENERATE), which allows resolving such generator expressions and will avoid future issues.
A workaround proposed by @adriaandegroot is added for CMake 3.18.

Additionally changed list->string conversion to use list(JOIN) instead of string replacement.

Fixes #1414.