### PR TITLE
Benchmark.ccp: Define "__STDC_FORMAT_MACROS" for using PRId64 in C++

### DIFF
--- a/folly/Benchmark.cpp
+++ b/folly/Benchmark.cpp
@@ -16,9 +16,14 @@
 
 // @author Andrei Alexandrescu (andrei.alexandrescu@fb.com)
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS 1
+#endif
+
 #include <folly/Benchmark.h>
 
 #include <algorithm>
+#include <cinttypes>
 #include <cmath>
 #include <cstring>
 #include <iostream>


### PR DESCRIPTION
Under some environments __STDC_FORMAT_MACROS needs to be defined to
define PRId64 and friends in C++.

Fixes https://github.com/facebook/folly/issues/1435