### PR TITLE
Fix for compilation errors on a build without precompiled headers

### DIFF
--- a/folly/experimental/io/test/IoTestTempFileUtil.h
+++ b/folly/experimental/io/test/IoTestTempFileUtil.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include <glog/logging.h>
 
 #include <folly/experimental/TestUtil.h>


### PR DESCRIPTION
Summary: The file `folly/experimental/io/test/IoTestTempFileUtil.h` does not have `pragma once` and can be included several times. It produces compilation errors.

Reviewed By: Orvid

Differential Revision: D23496733

