### PR TITLE
CMake: Fix version comparison for target argument

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -439,7 +439,8 @@ configure_file(
 
 # Specify target to allow resolving generator expressions requiring
 # a target for CMake >=3.19. See #1414.
-if(CMAKE_VERSION VERSION_GREATER 3.18)
+# VERSION_GREATER_EQUAL isn't available before CMake 3.7.
+if(NOT CMAKE_VERSION VERSION_LESS 3.19)
   set(target_arg TARGET folly_deps)
 endif()
 


### PR DESCRIPTION
VERSION_GREATER 3.18 also matches 3.18.2, which is wrong as the target argument was only added in 3.19.
After noticing that folly requires an ancient CMake version I converted over from VERSION_GREATER_EQUAL and introduced the comparison error.

Issue reported [here](https://github.com/facebook/folly/pull/1433#discussion_r484278801).