### PR TITLE
Ensure builtins.h is being exercised in msvc builds

### DIFF
--- a/folly/test/PortabilityTest.cpp
+++ b/folly/test/PortabilityTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <folly/Portability.h>
+#include <folly/Portability/Builtins.h>
 
 #if FOLLY_HAS_STRING_VIEW
 #include <string_view> // @manual

--- a/folly/test/PortabilityTest.cpp
+++ b/folly/test/PortabilityTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <folly/Portability.h>
-#include <folly/Portability/Builtins.h>
+#include <folly/portability/Builtins.h>
 
 #if FOLLY_HAS_STRING_VIEW
 #include <string_view> // @manual


### PR DESCRIPTION
portability_test doesn't actually #include "builtins.h" so it's got a blind spot in terms of compiler support for intrinsics