### PR TITLE
<bit> produces warnings when building with C++17/13/11/...

### DIFF
--- a/folly/lang/Bits.h
+++ b/folly/lang/Bits.h
@@ -67,7 +67,7 @@
 #include <folly/lang/Assume.h>
 #include <folly/portability/Builtins.h>
 
-#if __has_include(<bit>)
+#if __has_include(<bit>) && __cplusplus >= 202002L
 #include <bit>
 #endif
 


### PR DESCRIPTION
Constant from: http://eel.is/c++draft/cpp.predefined#1.1

Fixes #1454 