### PR TITLE
Use FOLLY_LIBRARY_SANITIZE_ADDRESS for Fiber ASan checks

### DIFF
--- a/folly/fibers/Fiber.cpp
+++ b/folly/fibers/Fiber.cpp
@@ -103,7 +103,7 @@ void Fiber::init(bool recordStackUsed) {
 }
 
 Fiber::~Fiber() {
-#ifdef FOLLY_SANITIZE_ADDRESS
+#if FOLLY_LIBRARY_SANITIZE_ADDRESS
   if (asanFakeStack_ != nullptr) {
     fiberManager_.freeFakeStack(asanFakeStack_);
   }
@@ -115,7 +115,7 @@ Fiber::~Fiber() {
 void Fiber::recordStackPosition() {
   // For ASAN builds, functions may run on fake stack.
   // So we cannot get meaningful stack position.
-#ifndef FOLLY_SANITIZE_ADDRESS
+#if !FOLLY_LIBRARY_SANITIZE_ADDRESS
   int stackDummy;
   auto currentPosition = static_cast<size_t>(
       fiberStackLimit_ + fiberStackSize_ -
@@ -126,7 +126,7 @@ void Fiber::recordStackPosition() {
 }
 
 [[noreturn]] void Fiber::fiberFunc() {
-#ifdef FOLLY_SANITIZE_ADDRESS
+#if FOLLY_LIBRARY_SANITIZE_ADDRESS
   fiberManager_.registerFinishSwitchStackWithAsan(
       nullptr, &asanMainStackBase_, &asanMainStackSize_);
 #endif

--- a/folly/fibers/Fiber.h
+++ b/folly/fibers/Fiber.h
@@ -178,7 +178,7 @@ class Fiber {
   folly::IntrusiveListHook globalListHook_; /**< list hook for global list */
   std::thread::id threadId_{};
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#if FOLLY_LIBRARY_SANITIZE_ADDRESS
   void* asanFakeStack_{nullptr};
   const void* asanMainStackBase_{nullptr};
   size_t asanMainStackSize_{0};

--- a/folly/fibers/FiberManager.cpp
+++ b/folly/fibers/FiberManager.cpp
@@ -32,7 +32,7 @@
 #include <folly/portability/Unistd.h>
 #include <folly/synchronization/SanitizeThread.h>
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#if FOLLY_LIBRARY_SANITIZE_ADDRESS
 
 #include <dlfcn.h>
 
@@ -214,7 +214,7 @@ void FiberManager::FibersPoolResizer::run() {
   }
 }
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#if FOLLY_LIBRARY_SANITIZE_ADDRESS
 
 void FiberManager::registerStartSwitchStackWithAsan(
     void** saveFakeStack,
@@ -327,7 +327,7 @@ static AsanUnpoisonMemoryRegionFuncPtr getUnpoisonMemoryRegionFunc() {
   return nullptr;
 }
 
-#endif // FOLLY_SANITIZE_ADDRESS
+#endif // FOLLY_LIBRARY_SANITIZE_ADDRESS
 
 #ifndef _WIN32
 namespace {

--- a/folly/fibers/FiberManagerInternal-inl.h
+++ b/folly/fibers/FiberManagerInternal-inl.h
@@ -65,7 +65,7 @@ inline void FiberManager::ensureLoopScheduled() {
 inline void FiberManager::activateFiber(Fiber* fiber) {
   DCHECK_EQ(activeFiber_, (Fiber*)nullptr);
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#if FOLLY_LIBRARY_SANITIZE_ADDRESS
   DCHECK(!fiber->asanMainStackBase_);
   DCHECK(!fiber->asanMainStackSize_);
   auto stack = fiber->getStack();
@@ -85,7 +85,7 @@ inline void FiberManager::activateFiber(Fiber* fiber) {
 inline void FiberManager::deactivateFiber(Fiber* fiber) {
   DCHECK_EQ(activeFiber_, fiber);
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#if FOLLY_LIBRARY_SANITIZE_ADDRESS
   DCHECK(fiber->asanMainStackBase_);
   DCHECK(fiber->asanMainStackSize_);
 

--- a/folly/fibers/FiberManagerInternal.h
+++ b/folly/fibers/FiberManagerInternal.h
@@ -600,7 +600,7 @@ class FiberManager : public ::folly::Executor {
   void runReadyFiber(Fiber* fiber);
   void remoteReadyInsert(Fiber* fiber);
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#if FOLLY_LIBRARY_SANITIZE_ADDRESS
 
   // These methods notify ASAN when a fiber is entered/exited so that ASAN can
   // find the right stack extents when it needs to poison/unpoison the stack.
@@ -616,7 +616,7 @@ class FiberManager : public ::folly::Executor {
   void freeFakeStack(void* fakeStack);
   void unpoisonFiberStack(const Fiber* fiber);
 
-#endif // FOLLY_SANITIZE_ADDRESS
+#endif // FOLLY_LIBRARY_SANITIZE_ADDRESS
 
 #ifndef _WIN32
   bool alternateSignalStackRegistered_{false};


### PR DESCRIPTION
When compiling a program under ASan & linking to Folly, but where
Folly itself was _not_ compiled with ASan the following error is seen:

    include/folly/fibers/FiberManagerInternal-inl.h:75: undefined reference to `folly::fibers::FiberManager::registerFinishSwitchStackWithAsan(void*, void const**, unsigned long*)'
    /usr/bin/ld: benchmarks/executor_bench.cc.o: in function `folly::fibers::FiberManager::activateFiber(folly::fibers::Fiber*)':
    include/folly/fibers/FiberManagerInternal-inl.h:73: undefined reference to `folly::fibers::FiberManager::registerStartSwitchStackWithAsan(void**, void const*, unsigned long)'

The error is due to ASan code in FiberManagerInternal-inl.h being
guarded with FOLLY_SANITIZE_ADDRESS, however that code attempts to
call functions defined in the folly library .cpp files -
FiberManager::register..SwitchStackWithAsan from FiberManager.cpp
which is only defined if Folly was compiled with ASan.

Fix by using FOLLY_LIBRARY_SANITIZE_ADDRESS to guard such code.