### PR TITLE
Do not attempt to use __rdtsc on non-x64/x86 MSVC targets

### DIFF
--- a/folly/chrono/Hardware.h
+++ b/folly/chrono/Hardware.h
@@ -21,7 +21,7 @@
 #include <chrono>
 #include <cstdint>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 extern "C" std::uint64_t __rdtsc();
 #pragma intrinsic(__rdtsc)
 #endif
@@ -29,7 +29,7 @@ extern "C" std::uint64_t __rdtsc();
 namespace folly {
 
 inline std::uint64_t hardware_timestamp() {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
   return __rdtsc();
 #elif defined(__GNUC__) && (defined(__i386__) || FOLLY_X64)
   return __builtin_ia32_rdtsc();


### PR DESCRIPTION
Currently, Hardware.h assumes the `__rdtsc` intrinsic is always available when building with MSVC. However, this is not the case when building for Windows for ARM64.

This blocks successful compilation of https://github.com/facebook/rocksdb on Windows for ARM64, since that library embeds Folly and includes this specific header.

Instead, use a condition similar to the check in `asm_volatile_pause` in Asm.h. This results in successful compilation and a fallback to `steady_clock::now()` on Windows for ARM64 targets.

