### PR TITLE
`lint-ignore` processing for `clang-tidy` (fbcode addons)

### DIFF
--- a/folly/test/TryTest.cpp
+++ b/folly/test/TryTest.cpp
@@ -224,7 +224,7 @@ TEST(Try, tryEmplaceWithThrowingConstructor) {
   struct NonInheritingException {};
   struct ThrowingConstructor {
     [[noreturn]] ThrowingConstructor() noexcept(false) {
-      // @lint-ignore HOWTOEVEN
+      // @lint-ignore HOWTOEVEN CLANGTIDY
       throw NonInheritingException{};
     }
 


### PR DESCRIPTION
Summary: Disable CLANGTIDY checks for several places at the code where HOWTOEVEN checks are disabled.

Differential Revision: D24197524

