### PR TITLE
FindGlog: Add support for 'glogd' Debug library

### DIFF
--- a/build/fbcode_builder/CMake/FindGlog.cmake
+++ b/build/fbcode_builder/CMake/FindGlog.cmake
@@ -7,12 +7,17 @@
 # GLOG_LIBRARIES - link these to use Glog
 
 include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
 
-find_library(GLOG_LIBRARY glog
+find_library(GLOG_LIBRARY_RELEASE glog
+  PATHS ${GLOG_LIBRARYDIR})
+find_library(GLOG_LIBRARY_DEBUG glogd
   PATHS ${GLOG_LIBRARYDIR})
 
 find_path(GLOG_INCLUDE_DIR glog/logging.h
   PATHS ${GLOG_INCLUDEDIR})
+
+select_library_configurations(GLOG)
 
 find_package_handle_standard_args(glog DEFAULT_MSG
   GLOG_LIBRARY


### PR DESCRIPTION
Glog v0.4.0 when configured with Debug build type adds a 'd' suffix to
the library file. This results in FindGlog.cmake failing to locate it.

Update FindGlog.cmake to use check for 'glogd', and use
select_library_configurations() to set GLOG_LIBRARY to the correct
found filename.

(Note: this has no effect if a non-Debug type is used.)