### PR TITLE
Explicitly name hazptr thread pool

### DIFF
--- a/folly/synchronization/HazptrThreadPoolExecutor.cpp
+++ b/folly/synchronization/HazptrThreadPoolExecutor.cpp
@@ -23,7 +23,9 @@ namespace {
 
 struct HazptrTPETag {};
 folly::Singleton<folly::CPUThreadPoolExecutor, HazptrTPETag> hazptr_tpe_([] {
-  return new folly::CPUThreadPoolExecutor(1);
+  return new folly::CPUThreadPoolExecutor(
+      std::make_pair(1, 1),
+      std::make_shared<folly::NamedThreadFactory>("hazptr-tpe-"));
 });
 
 folly::Executor* get_hazptr_tpe() {


### PR DESCRIPTION
Summary:
Hazptr library creates its own CPU executor which name interfere with default executor name. We want to avoid this.
Also insure that the thread is permanent, otherwise folly runtime may destroy and recreate it periodically.

Reviewed By: magedm

Differential Revision: D25708252

