### PR TITLE
Make folly compile on Debian systems

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -745,7 +745,7 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
 
     def run_project_cmd(self, args, loader, manifest):
         platforms = [
-            HostType("linux", "ubuntu", "18"),
+            HostType("linux", None, None),
             HostType("darwin", None, None),
             HostType("windows", None, None),
         ]

--- a/folly/portability/Time.cpp
+++ b/folly/portability/Time.cpp
@@ -275,7 +275,9 @@ extern "C" int clock_gettime(clockid_t clock_id, struct timespec* tp) {
   }
 }
 #else
+#if !__linux__
 #error No clock_gettime(3) compatibility wrapper available for this platform.
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
The attached patches make Folly compile on Debian systems without affecting the build on Ubuntu 18.04.   They fix the error message

> folly/folly/portability/Time.cpp:278:2: error: No clock_gettime(3) compatibility wrapper available for this platform.
> #error No clock_gettime(3) compatibility wrapper available for this platform.

which suggested, apparently erroneously, that a compatibility wrapper is needed for Linux systems other than Ubuntu 18.04.   clock_gettime() is a Linux system call.