### PR TITLE
Linux: fix clock_gettime and recvmmsg build problems

### DIFF
--- a/CMake/FollyConfigChecks.cmake
+++ b/CMake/FollyConfigChecks.cmake
@@ -85,12 +85,12 @@ string(REGEX REPLACE
 
 check_symbol_exists(pthread_atfork pthread.h FOLLY_HAVE_PTHREAD_ATFORK)
 
-check_symbol_exists(accept4 sys/socket.h FOLLY_HAVE_ACCEPT4)
+check_symbol_exists(accept4 "sys/socket.h;linux/socket.h" FOLLY_HAVE_ACCEPT4)
 check_symbol_exists(getrandom sys/random.h FOLLY_HAVE_GETRANDOM)
 check_symbol_exists(preadv sys/uio.h FOLLY_HAVE_PREADV)
-check_symbol_exists(pwritev sys/uio.h FOLLY_HAVE_PWRITEV)
-check_symbol_exists(clock_gettime time.h FOLLY_HAVE_CLOCK_GETTIME)
-check_symbol_exists(pipe2 unistd.h FOLLY_HAVE_PIPE2)
+check_symbol_exists(pwritev sys/uio. FOLLY_HAVE_PWRITEV)
+check_symbol_exists(clock_gettime "time.h;linux/time.h" FOLLY_HAVE_CLOCK_GETTIME)
+check_symbol_exists(pipe2 "unistd.h;linux/unistd.h" FOLLY_HAVE_PIPE2)
 check_symbol_exists(sendmmsg sys/socket.h FOLLY_HAVE_SENDMMSG)
 check_symbol_exists(recvmmsg sys/socket.h FOLLY_HAVE_RECVMMSG)
 

--- a/folly/net/NetOps.cpp
+++ b/folly/net/NetOps.cpp
@@ -33,7 +33,9 @@
 #endif
 
 #if !FOLLY_HAVE_RECVMMSG
-#if FOLLY_HAVE_WEAK_SYMBOLS
+#if defined(__linux__)
+#include <linux/socket.h>
+#elif FOLLY_HAVE_WEAK_SYMBOLS
 extern "C" FOLLY_ATTR_WEAK int recvmmsg(
     int sockfd,
     struct mmsghdr* msgvec,

--- a/folly/portability/Time.cpp
+++ b/folly/portability/Time.cpp
@@ -274,6 +274,8 @@ extern "C" int clock_gettime(clockid_t clock_id, struct timespec* tp) {
       return -1;
   }
 }
+#elif defined(__linux__)
+#include <time.h>
 #else
 #error No clock_gettime(3) compatibility wrapper available for this platform.
 #endif


### PR DESCRIPTION
Replaces https://github.com/facebook/folly/pull/1514.  This more minimal change makes folly compile successfully by showing where clock_gettime() is found on Linux and solving the problem created by ee1e6c7b7219a545093e07b785efb5f396fac1ef when recvmmsg is not found.   Further changes to code in //folly/portability would be needed in order to allow Ninja (for example) to find these Linux syscalls at compile time.   Nonetheless, clock_gettime_wrappers_test passes.