### PR TITLE
Mark StaticMata as FOLLY_EXPORT

### DIFF
--- a/folly/detail/ThreadLocalDetail.h
+++ b/folly/detail/ThreadLocalDetail.h
@@ -393,7 +393,7 @@ struct StaticMetaBase {
 // for threads that use ThreadLocalPtr objects collide on a lock inside
 // StaticMeta; you can specify multiple Tag types to break that lock.
 template <class Tag, class AccessMode>
-struct StaticMeta final : StaticMetaBase {
+struct FOLLY_EXPORT StaticMeta final : StaticMetaBase {
   StaticMeta()
       : StaticMetaBase(
             &StaticMeta::getThreadEntrySlow,


### PR DESCRIPTION
When using folly::ThreadLocal<> to create thread-local variables, if a thread-local is set from two different libraries which are compiled with -fvisibility=hidden and using libc++, then a nullptr dereference is seen when attempting to set the thread-local from the second DLL.

This is due to StaticMetaBase (which should be a singleton) getting created twice. This results in the thread local metadata getting corrupted and hence attempting to dereference a nullptr.

Fix by marking StaticMeta as FOLLY_EXPORT, so only a single instance exists at runtime.

Fixes #1431