### PR TITLE
fix linking of StaticTracepointTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -951,6 +951,9 @@ if (BUILD_TESTS)
       TEST unit_test SOURCES UnitTest.cpp
       TEST uri_test SOURCES UriTest.cpp
       TEST varint_test SOURCES VarintTest.cpp
+
+    DIRECTORY tracing/test/
+      TEST static_tracepoint_test SOURCES StaticTracepointTest.cpp StaticTracepointTestModule.cpp
   )
 
   if (${LIBSODIUM_FOUND})

--- a/folly/tracing/test/StaticTracepointTestModule.cpp
+++ b/folly/tracing/test/StaticTracepointTestModule.cpp
@@ -15,11 +15,10 @@
  */
 
 #include <folly/tracing/StaticTracepoint.h>
+FOLLY_SDT_DEFINE_SEMAPHORE(folly, test_semaphore_extern)
 
 namespace folly {
 namespace test {
-
-FOLLY_SDT_DEFINE_SEMAPHORE(folly, test_semaphore_extern)
 
 unsigned staticTracepointTestFunc(unsigned v) {
   unsigned res = v * v;


### PR DESCRIPTION
The placement of a macro definition inside a namespace led to errors
like

/usr/bin/ld: /usr/bin/ld: DWARF error: could not find variable specification at offset 51

The test passes once built.