### PR TITLE
Fix Range.h to compile in c++20

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -474,7 +474,7 @@ class Range {
   template <typename ValueType>
   struct StringViewType
       : std::conditional<
-            std::is_pod<std::remove_const_t<ValueType>>::value,
+            std::is_trivially_copyable<std::remove_const_t<ValueType>>::value,
             std::basic_string_view<std::remove_const_t<ValueType>>,
             NotStringView> {};
 

--- a/folly/Range.h
+++ b/folly/Range.h
@@ -474,7 +474,7 @@ class Range {
   template <typename ValueType>
   struct StringViewType
       : std::conditional<
-            std::is_trivially_copyable<std::remove_const_t<ValueType>>::value,
+            folly::is_trivially_copyable<std::remove_const_t<ValueType>>::value,
             std::basic_string_view<std::remove_const_t<ValueType>>,
             NotStringView> {};
 

--- a/folly/Range.h
+++ b/folly/Range.h
@@ -474,7 +474,7 @@ class Range {
   template <typename ValueType>
   struct StringViewType
       : std::conditional<
-            folly::is_trivially_copyable<std::remove_const_t<ValueType>>::value,
+            std::is_trivial<std::remove_const_t<ValueType>>::value,
             std::basic_string_view<std::remove_const_t<ValueType>>,
             NotStringView> {};
 


### PR DESCRIPTION
`std::is_pod` is deprecated in c++20, using `is_trivially_copyable` instead