### PR TITLE
[folly/container/F14] avoid operator!= ambiguity in c++20

### DIFF
--- a/folly/container/detail/F14Policy.h
+++ b/folly/container/detail/F14Policy.h
@@ -469,11 +469,13 @@ class ValueContainerIterator : public ValueContainerIteratorBase<ValuePtr> {
     return cur;
   }
 
-  bool operator==(ValueContainerIterator<ValueConstPtr> const& rhs) const {
-    return underlying_ == rhs.underlying_;
+  friend bool operator==(ValueContainerIterator const& lhs,
+                         ValueContainerIterator const& rhs) {
+    return lhs.underlying_ == rhs.underlying_;
   }
-  bool operator!=(ValueContainerIterator<ValueConstPtr> const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator!=(ValueContainerIterator const& lhs,
+                         ValueContainerIterator const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:
@@ -698,11 +700,13 @@ class NodeContainerIterator : public BaseIter<ValuePtr, NonConstPtr<ValuePtr>> {
     return cur;
   }
 
-  bool operator==(NodeContainerIterator<ValueConstPtr> const& rhs) const {
-    return underlying_ == rhs.underlying_;
+  friend bool operator==(NodeContainerIterator const& lhs,
+                         NodeContainerIterator const& rhs) {
+    return lhs.underlying_ == rhs.underlying_;
   }
-  bool operator!=(NodeContainerIterator<ValueConstPtr> const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator!=(NodeContainerIterator const& lhs,
+                         NodeContainerIterator const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:
@@ -936,11 +940,13 @@ class VectorContainerIterator : public BaseIter<ValuePtr, uint32_t> {
     return cur;
   }
 
-  bool operator==(VectorContainerIterator<ValueConstPtr> const& rhs) const {
-    return current_ == rhs.current_;
+  friend bool operator==(VectorContainerIterator const& lhs,
+                         VectorContainerIterator const& rhs) {
+    return lhs.current_ == rhs.current_;
   }
-  bool operator!=(VectorContainerIterator<ValueConstPtr> const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator!=(VectorContainerIterator const& lhs,
+                         VectorContainerIterator const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:


### PR DESCRIPTION
Summary:
F14 map `iterator` doesn't define `operator==` or `operator!=` to itself.
Those member functions take `const_iterator` as the right-hand side,
relying on the ability to convert implicitly from `iterator` to
`const_iterator`. This interacts poorly with c++20's default equality
operators, triggering clang's `-Wambiguous-reversed-operator`.

This diff replaces the equality member functions with friends that use
the same left-hand and right-hand types.  iterator != const_iterator
will now compile by implicitly converting the left-hand-side and then
calling `operator!=(const_iterator const&, const_iterator const&)`,
rather than calling `iterator::operator!=(const_iterator const&)`.
This resolves the ambiguity in c++20, and should work fine on earlier
versions, although I have not tested it on anything except c++17.

Test Plan:
does it build?