### PR TITLE
Conditionally include fmt/format.h

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -41,7 +41,9 @@
 #include <string_view> // @manual
 #endif
 
+#if __has_include(<fmt/format.h>)
 #include <fmt/format.h>
+#endif
 
 #include <folly/CpuId.h>
 #include <folly/Likely.h>


### PR DESCRIPTION
Addresses - at least partly - issue #1550 

We'd like to limit our exposure to additional libraries. Fmt is a new dependency. It doesn't look like we need it in actuality; gating the include based on whether the file exists or not makes it possible for clients (specifically React Native for Windows) to not need to fork Folly.