### PR TITLE
increase the alt stack size threshold for alternate symbolization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,6 @@ auto_sources(hfiles "*.h" "RECURSE" "${FOLLY_DIR}")
 REMOVE_MATCHES_FROM_LISTS(files hfiles
   MATCHES
     "^${FOLLY_DIR}/build/"
-    "^${FOLLY_DIR}/experimental/exception_tracer/"
     "^${FOLLY_DIR}/futures/exercises/"
     "^${FOLLY_DIR}/logging/example/"
     "^${FOLLY_DIR}/(.*/)?test/"

--- a/folly/container/detail/F14Policy.h
+++ b/folly/container/detail/F14Policy.h
@@ -469,11 +469,13 @@ class ValueContainerIterator : public ValueContainerIteratorBase<ValuePtr> {
     return cur;
   }
 
-  bool operator==(ValueContainerIterator<ValueConstPtr> const& rhs) const {
-    return underlying_ == rhs.underlying_;
+  friend bool operator==(ValueContainerIterator const& lhs,
+                         ValueContainerIterator const& rhs) {
+    return lhs.underlying_ == rhs.underlying_;
   }
-  bool operator!=(ValueContainerIterator<ValueConstPtr> const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator!=(ValueContainerIterator const& lhs,
+                         ValueContainerIterator const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:
@@ -698,11 +700,13 @@ class NodeContainerIterator : public BaseIter<ValuePtr, NonConstPtr<ValuePtr>> {
     return cur;
   }
 
-  bool operator==(NodeContainerIterator<ValueConstPtr> const& rhs) const {
-    return underlying_ == rhs.underlying_;
+  friend bool operator==(NodeContainerIterator const& lhs,
+                         NodeContainerIterator const& rhs) {
+    return lhs.underlying_ == rhs.underlying_;
   }
-  bool operator!=(NodeContainerIterator<ValueConstPtr> const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator!=(NodeContainerIterator const& lhs,
+                         NodeContainerIterator const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:
@@ -936,11 +940,13 @@ class VectorContainerIterator : public BaseIter<ValuePtr, uint32_t> {
     return cur;
   }
 
-  bool operator==(VectorContainerIterator<ValueConstPtr> const& rhs) const {
-    return current_ == rhs.current_;
+  friend bool operator==(VectorContainerIterator const& lhs,
+                         VectorContainerIterator const& rhs) {
+    return lhs.current_ == rhs.current_;
   }
-  bool operator!=(VectorContainerIterator<ValueConstPtr> const& rhs) const {
-    return !(*this == rhs);
+  friend bool operator!=(VectorContainerIterator const& lhs,
+                         VectorContainerIterator const& rhs) {
+    return !(lhs == rhs);
   }
 
  private:

--- a/folly/experimental/symbolizer/SignalHandler.cpp
+++ b/folly/experimental/symbolizer/SignalHandler.cpp
@@ -478,10 +478,11 @@ void signalHandler(int signum, siginfo_t* info, void* uctx) {
 
 #endif // FOLLY_USE_SYMBOLIZER
 
-// Small sigaltstack size threshold.
-// 8931 is known to cause the signal handler to stack overflow during
-// symbolization even for a simple one-liner "kill(getpid(), SIGTERM)".
-constexpr size_t kSmallSigAltStackSize = 8931;
+// Small sigaltstack size threshold. If the alternate stack is too small we
+// must use UnsafeSelfAllocateStackTracePrinter() to avoid stack overflow
+// during symbolization of a signal. 48K has been observed to have stack
+// overflow, and 56K has been observed to work.
+constexpr size_t kSmallSigAltStackSize = 65536;
 
 FOLLY_MAYBE_UNUSED bool isSmallSigAltStackEnabled() {
   stack_t ss;

--- a/folly/fibers/Fiber.cpp
+++ b/folly/fibers/Fiber.cpp
@@ -79,7 +79,7 @@ Fiber::Fiber(FiberManager& fiberManager)
 void Fiber::init(bool recordStackUsed) {
 // It is necessary to disable the logic for ASAN because we change
 // the fiber's stack.
-#ifndef FOLLY_SANITIZE_ADDRESS
+#ifndef FOLLY_LIBRARY_SANITIZE_ADDRESS
   recordStackUsed_ = recordStackUsed;
   if (UNLIKELY(recordStackUsed_ && !stackFilledWithMagic_)) {
     CHECK_EQ(
@@ -103,7 +103,7 @@ void Fiber::init(bool recordStackUsed) {
 }
 
 Fiber::~Fiber() {
-#ifdef FOLLY_SANITIZE_ADDRESS
+#ifdef FOLLY_LIBRARY_SANITIZE_ADDRESS
   if (asanFakeStack_ != nullptr) {
     fiberManager_.freeFakeStack(asanFakeStack_);
   }
@@ -115,7 +115,7 @@ Fiber::~Fiber() {
 void Fiber::recordStackPosition() {
   // For ASAN builds, functions may run on fake stack.
   // So we cannot get meaningful stack position.
-#ifndef FOLLY_SANITIZE_ADDRESS
+#ifndef FOLLY_LIBRARY_SANITIZE_ADDRESS
   int stackDummy;
   auto currentPosition = static_cast<size_t>(
       fiberStackLimit_ + fiberStackSize_ -
@@ -126,7 +126,7 @@ void Fiber::recordStackPosition() {
 }
 
 [[noreturn]] void Fiber::fiberFunc() {
-#ifdef FOLLY_SANITIZE_ADDRESS
+#ifdef FOLLY_LIBRARY_SANITIZE_ADDRESS
   fiberManager_.registerFinishSwitchStackWithAsan(
       nullptr, &asanMainStackBase_, &asanMainStackSize_);
 #endif

--- a/folly/fibers/Fiber.h
+++ b/folly/fibers/Fiber.h
@@ -193,7 +193,7 @@ class Fiber {
   folly::IntrusiveListHook globalListHook_; /**< list hook for global list */
   std::thread::id threadId_{};
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#ifdef FOLLY_LIBRARY_SANITIZE_ADDRESS
   void* asanFakeStack_{nullptr};
   const void* asanMainStackBase_{nullptr};
   size_t asanMainStackSize_{0};

--- a/folly/fibers/FiberManager.cpp
+++ b/folly/fibers/FiberManager.cpp
@@ -33,7 +33,7 @@
 #include <folly/portability/Unistd.h>
 #include <folly/synchronization/SanitizeThread.h>
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#ifdef FOLLY_LIBRARY_SANITIZE_ADDRESS
 
 #ifndef _WIN32
 #include <dlfcn.h>
@@ -217,7 +217,7 @@ void FiberManager::FibersPoolResizer::run() {
   }
 }
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#ifdef FOLLY_LIBRARY_SANITIZE_ADDRESS
 
 void FiberManager::registerStartSwitchStackWithAsan(
     void** saveFakeStack,
@@ -336,7 +336,7 @@ static AsanUnpoisonMemoryRegionFuncPtr getUnpoisonMemoryRegionFunc() {
   return nullptr;
 }
 
-#endif // FOLLY_SANITIZE_ADDRESS
+#endif // FOLLY_LIBRARY_SANITIZE_ADDRESS
 
 // TVOS and WatchOS platforms have SIGSTKSZ but not sigaltstack
 #if defined(SIGSTKSZ) && !FOLLY_APPLE_TVOS && !FOLLY_APPLE_WATCHOS

--- a/folly/fibers/FiberManagerInternal-inl.h
+++ b/folly/fibers/FiberManagerInternal-inl.h
@@ -66,7 +66,7 @@ inline void FiberManager::ensureLoopScheduled() {
 inline void FiberManager::activateFiber(Fiber* fiber) {
   DCHECK_EQ(activeFiber_, (Fiber*)nullptr);
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#ifdef FOLLY_LIBRARY_SANITIZE_ADDRESS
   DCHECK(!fiber->asanMainStackBase_);
   DCHECK(!fiber->asanMainStackSize_);
   auto stack = fiber->getStack();
@@ -86,7 +86,7 @@ inline void FiberManager::activateFiber(Fiber* fiber) {
 inline void FiberManager::deactivateFiber(Fiber* fiber) {
   DCHECK_EQ(activeFiber_, fiber);
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#ifdef FOLLY_LIBRARY_SANITIZE_ADDRESS
   DCHECK(fiber->asanMainStackBase_);
   DCHECK(fiber->asanMainStackSize_);
 

--- a/folly/fibers/FiberManagerInternal.h
+++ b/folly/fibers/FiberManagerInternal.h
@@ -601,7 +601,7 @@ class FiberManager : public ::folly::Executor {
   void runReadyFiber(Fiber* fiber);
   void remoteReadyInsert(Fiber* fiber);
 
-#ifdef FOLLY_SANITIZE_ADDRESS
+#ifdef FOLLY_LIBRARY_SANITIZE_ADDRESS
 
   // These methods notify ASAN when a fiber is entered/exited so that ASAN can
   // find the right stack extents when it needs to poison/unpoison the stack.
@@ -617,7 +617,7 @@ class FiberManager : public ::folly::Executor {
   void freeFakeStack(void* fakeStack);
   void unpoisonFiberStack(const Fiber* fiber);
 
-#endif // FOLLY_SANITIZE_ADDRESS
+#endif // FOLLY_LIBRARY_SANITIZE_ADDRESS
 
   bool alternateSignalStackRegistered_{false};
 


### PR DESCRIPTION
If sigaltstack is in use, the alternate stack may be too small to run the normal SafeStackTracePrinter. In that case we must fall back to UnsafeSelfAllocateStackTracePrinter. Logic to enable this fallback already exists, but the threshold of 8931 bytes is not sufficient to run the current symbolizer code--the actual stack size needed by SafeStackTracePrinter is greater than 48K.

GCC sanitizers use a sigaltstack of 4*SIGSTKSZ = 32K. `Dwarf::findLocation` makes space for locals with `sub $0xa198,%rsp`, which is 41368 bytes. Adjusting the alternate stack size on x86_64, I observed a failure at 48K and a success at 56K.