### PR TITLE
Direct initialize semaphoreWaiter

### DIFF
--- a/folly/fibers/SemaphoreBase.cpp
+++ b/folly/fibers/SemaphoreBase.cpp
@@ -167,8 +167,7 @@ namespace {
 
 class FutureWaiter final : public fibers::Baton::Waiter {
  public:
-  explicit FutureWaiter(int64_t tokens)
-      : semaphoreWaiter(SemaphoreBase::Waiter(tokens)) {
+  explicit FutureWaiter(int64_t tokens) : semaphoreWaiter(tokens) {
     semaphoreWaiter.baton.setWaiter(*this);
   }
 


### PR DESCRIPTION
Before this patch, it relies on the c++17 guaranteed copy elision, since `SemaphoreBase::Waiter` is NOT copy constructible due to `std::atomic<intptr_t>`.

This patch makes it compile even using `-std=c++14`.