### PR TITLE
Mark SharedMutexImpl with FOLLY_EXPORT (#1558)

### DIFF
--- a/folly/SharedMutex.h
+++ b/folly/SharedMutex.h
@@ -328,7 +328,7 @@ template <
     bool BlockImmediately = false,
     bool AnnotateForThreadSanitizer = kIsSanitizeThread && !ReaderPriority,
     bool TrackThreadId = false>
-class SharedMutexImpl : std::conditional_t<
+class FOLLY_EXPORT SharedMutexImpl : std::conditional_t<
                             TrackThreadId,
                             shared_mutex_detail::ThreadIdOwnershipTracker,
                             shared_mutex_detail::NopOwnershipTracker> {


### PR DESCRIPTION
When accessing a folly::SharedMutex instance from multiple DSOs and
program and folly compiled with -fvisibility=hidden, a deadlock is
seen when at least one thread is attempting to acquire a write
lock.

Backtraces suggest that the writer is waiting for some outstanding
reader to unlock; but no such reader appears to have the lock
acquired. In actual fact there's multiple copies of the (supposedly
singleton) deferredReaders array, one per DSO, it has hidden (local)
visibility.  This essentially corrupts the details of which readers
are outstanding.

Fix by flagging SharedMutexImpl as FOLLY_EXPORT - meaning it has weak
linkage and hence only a single instance will be present in memory at
runtime.

Fixes: https://github.com/facebook/folly/issues/1558