### PR TITLE
Remove sysfs cachelocality when compiling for WIN32

### DIFF
--- a/folly/concurrency/CacheLocality.cpp
+++ b/folly/concurrency/CacheLocality.cpp
@@ -105,6 +105,7 @@ static size_t parseLeadingNumber(const std::string& line) {
   return val;
 }
 
+#ifndef _WIN32
 CacheLocality CacheLocality::readFromSysfsTree(
     const std::function<std::string(std::string)>& mapping) {
   // number of equivalence classes per level
@@ -198,6 +199,7 @@ CacheLocality CacheLocality::readFromSysfs() {
     return rv;
   });
 }
+#endif // !_WIN32
 
 static bool procCpuinfoLineRelevant(std::string const& line) {
   return line.size() > 4 && (line[0] == 'p' || line[0] == 'c');

--- a/folly/concurrency/CacheLocality.h
+++ b/folly/concurrency/CacheLocality.h
@@ -100,6 +100,7 @@ struct CacheLocality {
   template <template <typename> class Atom = std::atomic>
   static const CacheLocality& system();
 
+#ifndef _WIN32
   /// Reads CacheLocality information from a tree structured like
   /// the sysfs filesystem.  The provided function will be evaluated
   /// for each sysfs file that needs to be queried.  The function
@@ -114,6 +115,7 @@ struct CacheLocality {
   /// Reads CacheLocality information from the real sysfs filesystem.
   /// Throws an exception if no cache information can be loaded.
   static CacheLocality readFromSysfs();
+#endif // !_WIN32
 
   /// readFromProcCpuinfo(), except input is taken from memory rather
   /// than the file system.


### PR DESCRIPTION
sysfs doesn't exist on windows, so these functions do not make sense.  

This was hit while bringing in a bunch of the fabric code from react-native into react-native-windows.