### PR TITLE
Fix several C++ warnings

### DIFF
--- a/folly/dynamic.cpp
+++ b/folly/dynamic.cpp
@@ -297,7 +297,7 @@ std::size_t dynamic::hash() const {
           [&](auto acc, auto const& item) { return acc + h(item); });
     }
     case ARRAY:
-      return folly::hash::hash_range(begin(), end());
+      return static_cast<std::size_t>(folly::hash::hash_range(begin(), end()));
     case INT64:
       return std::hash<int64_t>()(getInt());
     case DOUBLE:

--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -56,17 +56,23 @@ using to_ascii_alphabet_upper = to_ascii_alphabet<true>;
 
 namespace detail {
 
+#if defined(_M_IX86)
+FOLLY_ERASE auto to_ascii_port_clzll(uint64_t v) {
+  return __builtin_clzll(v);
+}
+#else
 FOLLY_ERASE auto to_ascii_port_clzll(uint64_t v) {
 #if _MSC_VER
 #if FOLLY_X64
   return __lzcnt64(v);
 #else
-  return __assume(0), 0;
+  __assume(0), 0;
 #endif
 #else
   return __builtin_clzll(v);
 #endif
 }
+#endif
 
 template <uint64_t Base, typename Alphabet>
 struct to_ascii_array {

--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -59,7 +59,7 @@ namespace detail {
 FOLLY_ERASE auto to_ascii_port_clzll(uint64_t v) {
 #if _MSC_VER
 #if FOLLY_X64
-  return __lzcnt64(v);
+  return static_cast<int>(__lzcnt64(v));
 #else
   return __assume(0), 0;
 #endif
@@ -75,7 +75,7 @@ struct to_ascii_array {
     data_type_ result{};
     Alphabet alpha;
     for (size_t i = 0; i < Base; ++i) {
-      result.data[i] = alpha(i);
+      result.data[i] = alpha(static_cast<uint8_t>(i));
     }
     return result;
   }

--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -59,7 +59,7 @@ namespace detail {
 FOLLY_ERASE auto to_ascii_port_clzll(uint64_t v) {
 #if _MSC_VER
 #if FOLLY_X64
-  return static_cast<int>(__lzcnt64(v));
+  return __lzcnt64(v);
 #else
   return __assume(0), 0;
 #endif

--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -56,23 +56,17 @@ using to_ascii_alphabet_upper = to_ascii_alphabet<true>;
 
 namespace detail {
 
-#if defined(_M_IX86)
-FOLLY_ERASE auto to_ascii_port_clzll(uint64_t v) {
-  return __builtin_clzll(v);
-}
-#else
 FOLLY_ERASE auto to_ascii_port_clzll(uint64_t v) {
 #if _MSC_VER
 #if FOLLY_X64
   return __lzcnt64(v);
 #else
-  __assume(0), 0;
+  return __assume(0), 0;
 #endif
 #else
   return __builtin_clzll(v);
 #endif
 }
-#endif
 
 template <uint64_t Base, typename Alphabet>
 struct to_ascii_array {

--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -224,7 +224,7 @@ FOLLY_ALWAYS_INLINE size_t to_ascii_size_clzll(uint64_t v) {
   }
 
   //  log2 is approx log<2>(v)
-  size_t const vlog2 = 64 - to_ascii_port_clzll(v);
+  size_t const vlog2 = 64 - static_cast<int>(to_ascii_port_clzll(v));
 
   //  handle directly when Base is power-of-two
   if (!(Base & (Base - 1))) {

--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -224,7 +224,7 @@ FOLLY_ALWAYS_INLINE size_t to_ascii_size_clzll(uint64_t v) {
   }
 
   //  log2 is approx log<2>(v)
-  size_t const vlog2 = 64 - static_cast<int>(to_ascii_port_clzll(v));
+  size_t const vlog2 = 64 - static_cast<size_t>(to_ascii_port_clzll(v));
 
   //  handle directly when Base is power-of-two
   if (!(Base & (Base - 1))) {


### PR DESCRIPTION
Fixes warnings about implicit type truncation. By making the conversions explicit, react-native-windows will be able to remove suppressions for several warnings required per SDL. 