### PR TITLE
Adding x86 support for to_ascii_port_clzll() 

### DIFF
--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -60,6 +60,8 @@ FOLLY_ERASE auto to_ascii_port_clzll(uint64_t v) {
 #if _MSC_VER
 #if FOLLY_X64
   return __lzcnt64(v);
+#elif defined(_M_IX86)
+  return __builtin_clzll(v);
 #else
   return __assume(0), 0;
 #endif

--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -24,6 +24,7 @@
 #include <folly/Utility.h>
 #include <folly/lang/Align.h>
 #include <folly/lang/CArray.h>
+#include <folly/portability/builtins.h>
 
 #if _MSC_VER
 #include <intrin.h>

--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -56,20 +56,6 @@ using to_ascii_alphabet_upper = to_ascii_alphabet<true>;
 
 namespace detail {
 
-FOLLY_ERASE auto to_ascii_port_clzll(uint64_t v) {
-#if _MSC_VER
-#if FOLLY_X64
-  return __lzcnt64(v);
-#elif defined(_M_IX86)
-  return __builtin_clzll(v);
-#else
-  return __assume(0), 0;
-#endif
-#else
-  return __builtin_clzll(v);
-#endif
-}
-
 template <uint64_t Base, typename Alphabet>
 struct to_ascii_array {
   using data_type_ = c_array<uint8_t, Base>;
@@ -226,7 +212,7 @@ FOLLY_ALWAYS_INLINE size_t to_ascii_size_clzll(uint64_t v) {
   }
 
   //  log2 is approx log<2>(v)
-  size_t const vlog2 = 64 - static_cast<size_t>(to_ascii_port_clzll(v));
+  size_t const vlog2 = 64 - static_cast<size_t>(__builtin_clzll(v));
 
   //  handle directly when Base is power-of-two
   if (!(Base & (Base - 1))) {


### PR DESCRIPTION
Currently to_ascii_port_clzll() in ToAscii.h always returns 0 in x86. This adds a check for x86 and a call to __builtin_clzll() instead. 

Closes #1566.

@yfeldblum @Orvid 