### PR TITLE
Fix table size for android

### DIFF
--- a/folly/Subprocess.cpp
+++ b/folly/Subprocess.cpp
@@ -560,8 +560,13 @@ int Subprocess::prepareChild(
   // If requested, close all other file descriptors.  Don't close
   // any fds in options.fdActions_, and don't touch stdin, stdout, stderr.
   // Ignore errors.
+  #ifdef __ANDROID__
+  int tableSize = sysconf(_SC_OPEN_MAX);
+  #else
+  int tableSize = getdtablesize();
+  #endif
   if (options.closeOtherFds_) {
-    for (int fd = getdtablesize() - 1; fd >= 3; --fd) {
+    for (int fd = tableSize - 1; fd >= 3; --fd) {
       if (options.fdActions_.count(fd) == 0) {
         ::close(fd);
       }


### PR DESCRIPTION
## Description

Hi!
I wanted to fix a build of folly on Android.

Trying to use folly's `MPMCQueue` on Android triggers the following error:
```
{xxx}/rnfbjni/android/app/build/third-party-ndk/folly/folly/Subprocess.cpp:542:19: error: use of undeclared identifier 'getdtablesize'; did you mean 'getpagesize'?
```
where `{xxx}` is a local path on my machine.

[Here](https://github.com/karol-bisztyga/rnfbjni/tree/patch-folly-repro) is a branch of my project that reproduces the problem(I've already fixed it by patching `folly` so you can see what patch has to be removed in order to make it fail [here](https://github.com/karol-bisztyga/rnfbjni/commit/e6d8059e55efda5f88d5edbc1e932b94223b052c)).

From [the man page for `getdtablesize`](https://linux.die.net/man/2/getdtablesize):

> SVr4, 4.4BSD (the getdtablesize() function first appeared in 4.2BSD). It is not specified in POSIX.1-2001; portable applications should employ sysconf(_SC_OPEN_MAX) instead of this call.


### Related issues:
https://github.com/facebook/folly/issues/1279
https://github.com/facebook/folly/issues/918 - probably, I cannot see bug details.


