### PR TITLE
Windows: Fixing compile-time warning 

### DIFF
--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -212,7 +212,7 @@ FOLLY_ALWAYS_INLINE size_t to_ascii_size_clzll(uint64_t v) {
   size_t const vlog2 = 64 - static_cast<size_t>(__builtin_clzll(v));
 
   //  handle directly when Base is power-of-two
-  if (!(Base & (Base - 1))) {
+  if constexpr(!(Base & (Base - 1))) {
     constexpr auto const blog2 = constexpr_log2(Base);
     return vlog2 / blog2 + size_t(vlog2 % blog2 != 0);
   }


### PR DESCRIPTION
We are [hitting a compile-time warning](https://github.com/microsoft/react-native-windows/pull/7830) that is treated as an error in RNW CI build for x64 -- warning C4127 due to a compile-time constant being used in a conditional expression. This replaces an `if`  with an `if constexpr` in lang/ToAscii.h to avoid the warning. 