### PR TITLE
Handle MSVC defining __SANITIZE_ADDRESS__

### DIFF
--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -95,6 +95,9 @@
 #elif defined(__GNUC__)
 #define FOLLY_DISABLE_ADDRESS_SANITIZER \
   __attribute__((__no_address_safety_analysis__, __noinline__))
+#elif defined(_MSC_VER)
+#define FOLLY_DISABLE_ADDRESS_SANITIZER \
+  __declspec(no_sanitize_address)
 #endif
 #endif
 #ifndef FOLLY_DISABLE_ADDRESS_SANITIZER
@@ -145,8 +148,11 @@
 #endif
 
 #if FOLLY_SANITIZE
+// We need to specifically check for __clang__ as clang-cl defines _MSC_VER
+#if defined(__clang__) || !defined(_MSC_VER)
 #define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER(...) \
   __attribute__((no_sanitize(__VA_ARGS__)))
+#endif
 #else
 #define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER(...)
 #endif // FOLLY_SANITIZE


### PR DESCRIPTION
The MSVC compiler now defines `__SANITIZE_ADDRESS__` when passed `/fsanitize=address` so we need to correctly define `FOLLY_DISABLE_ADDRESS_SANITIZER` and `FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER`