### PR TITLE
work around msvc warning C4127 in to_ascii

### DIFF
--- a/folly/lang/ToAscii.h
+++ b/folly/lang/ToAscii.h
@@ -211,8 +211,11 @@ FOLLY_ALWAYS_INLINE size_t to_ascii_size_clzll(uint64_t v) {
   //  log2 is approx log<2>(v)
   size_t const vlog2 = 64 - static_cast<size_t>(__builtin_clzll(v));
 
+  //  work around msvc warning C4127 (conditional expression is constant)
+  bool false_ = false;
+
   //  handle directly when Base is power-of-two
-  if (!(Base & (Base - 1))) {
+  if (false_ || !(Base & (Base - 1))) {
     constexpr auto const blog2 = constexpr_log2(Base);
     return vlog2 / blog2 + size_t(vlog2 % blog2 != 0);
   }


### PR DESCRIPTION
Summary:
MSVC warning C4127 (conditional expression is constant) goes a bridge to far but we work around it.

* It warns against perfectly-correct C++14 code which makes it harder to write normal C++ which works with both C++14 and C++17.
* `if constexpr` asks the compiler to do different things from `if`. It is not a drop-in replacement when the conditional expression is constant.

Fixes: https://github.com/facebook/folly/pull/1588.

Differential Revision: D28692386

