### PR TITLE
Fix openNoInt building error after android ndk r21

### DIFF
--- a/folly/FileUtil.cpp
+++ b/folly/FileUtil.cpp
@@ -35,7 +35,26 @@ namespace folly {
 using namespace fileutil_detail;
 
 int openNoInt(const char* name, int flags, mode_t mode) {
+#if defined(__ANDROID__)
+  // NDK bionic with FORTIFY has this definition:
+  // https://android.googlesource.com/platform/bionic/+/9349b9e51b/libc/include/bits/fortify/fcntl.h
+  // ```
+  // __BIONIC_ERROR_FUNCTION_VISIBILITY
+  // int open(const char* pathname, int flags, mode_t modes, ...) __overloadable
+  //         __errorattr(__open_too_many_args_error);
+  // ```
+  // This is originally to prevent open() with incorrect parameters.
+  //
+  // However, combined with folly wrapNotInt, template deduction will fail.
+  // In this case, we create a custom Open lambda to bypass the error.
+  // The solution is referenced from
+  // https://github.com/llvm/llvm-project/commit/0a0e411204a2baa520fd73a8d69b664f98b428ba
+  //
+  auto Open = [&]() { return open(name, flags, mode); };
+  return int(wrapNoInt(Open));
+#else
   return int(wrapNoInt(open, name, flags, mode));
+#endif
 }
 
 static int filterCloseReturn(int r) {


### PR DESCRIPTION
Android NDK bionic with FORTIFY will override original `open()` definition and making folly `wrapNoInt` template failed to deduct.
The issue may happen only after NDK r21 because [this commit landed after r21](https://android.googlesource.com/platform/bionic/+/9349b9e51b41d12fd054b925802b626ca2db0afb%5E%21/#F0)

References:
https://github.com/android/ndk/issues/1328
https://github.com/llvm/llvm-project/commit/0a0e411204a2baa520fd73a8d69b664f98b428ba 