### PR TITLE
Update RateLimiter.cpp

### DIFF
--- a/folly/logging/RateLimiter.cpp
+++ b/folly/logging/RateLimiter.cpp
@@ -20,13 +20,13 @@ namespace folly {
 namespace logging {
 
 bool IntervalRateLimiter::checkSlow() {
-  auto ts = timestamp_.load();
+  auto ts = timestamp_.load(std::memory_order_relaxed);
   auto now = clock::now().time_since_epoch().count();
   if (now < (ts + interval_.count())) {
     return false;
   }
 
-  if (!timestamp_.compare_exchange_strong(ts, now)) {
+  if (!timestamp_.compare_exchange_strong(ts, now, std::memory_order_release, std::memory_order_relaxed)) {
     // We raced with another thread that reset the timestamp.
     // We treat this as if we fell into the previous interval, and so we
     // rate-limit ourself.


### PR DESCRIPTION
Side effects after L23 is not necessary to be observed in other threads, hence the `std::memory_order_relaxed` for `load` operation.

When comparison failed, `std::memory_order_relaxed` is enough for loading `timestamp_` into `ts`. Otherwise, `std::memory_order_release` is required.