### PR TITLE
Folly appears to depend on fmt, so let's make that explicit

### DIFF
--- a/folly/build/bootstrap-osx-homebrew.sh
+++ b/folly/build/bootstrap-osx-homebrew.sh
@@ -33,6 +33,7 @@ install_deps() {
         boost
         cmake
         double-conversion
+        fmt
         gflags
         glog
         jemalloc


### PR DESCRIPTION
Just tried to build folly by bootstrapping from homebrew via `bootstrap-osx-homebrew.sh`, and got some linker errors (see below). `brew install fmt` seems to fix the issue.

The error:
```
-- Configuring done
CMake Error at CMakeLists.txt:388 (add_library):
  Target "folly_test_util" links to target "fmt::fmt" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?


CMake Error at CMakeLists.txt:378 (add_library):
  Target "folly" links to target "fmt::fmt" but the target was not found.
  Perhaps a find_package() call is missing for an IMPORTED target, or an
  ALIAS target is missing?


CMake Error at folly/CMakeLists.txt:15 (add_library):
  Target "follybenchmark" links to target "fmt::fmt" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?


CMake Error at folly/logging/example/CMakeLists.txt:15 (add_executable):
  Target "logging_example" links to target "fmt::fmt" but the target was not
  found.  Perhaps a find_package() call is missing for an IMPORTED target, or
  an ALIAS target is missing?


CMake Error at folly/logging/example/CMakeLists.txt:18 (add_library):
  Target "logging_example_lib" links to target "fmt::fmt" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?


-- Generating done
CMake Generate step failed.  Build files cannot be regenerated correctly.
```