### PR TITLE
[folly/logging] Fix mixed MSVC/clang-cl build

### DIFF
--- a/folly/logging/LogStreamProcessor.cpp
+++ b/folly/logging/LogStreamProcessor.cpp
@@ -111,7 +111,6 @@ LogStreamProcessor::LogStreamProcessor(
       message_{std::move(msg)},
       stream_{this} {}
 
-#ifdef __INCLUDE_LEVEL__
 namespace {
 LogCategory* getXlogCategory(XlogFileScopeInfo* fileScopeInfo) {
   // By the time a LogStreamProcessor is created, the XlogFileScopeInfo object
@@ -165,7 +164,6 @@ LogStreamProcessor::LogStreamProcessor(
           functionName,
           INTERNAL,
           std::string()) {}
-#endif
 
 /*
  * We intentionally define the LogStreamProcessor destructor in

--- a/folly/logging/LogStreamProcessor.h
+++ b/folly/logging/LogStreamProcessor.h
@@ -186,7 +186,6 @@ class LogStreamProcessor {
             INTERNAL,
             formatLogString(fmt, std::forward<Args>(args)...)) {}
 
-#ifdef __INCLUDE_LEVEL__
   /*
    * Versions of the above constructors to use in XLOG() macros that appear in
    * .cpp files.  These are only used if the compiler supports the
@@ -254,7 +253,6 @@ class LogStreamProcessor {
             functionName,
             INTERNAL,
             formatLogString(fmt, std::forward<Args>(args)...)) {}
-#endif
 
   ~LogStreamProcessor() noexcept;
 

--- a/folly/logging/xlog.cpp
+++ b/folly/logging/xlog.cpp
@@ -123,7 +123,6 @@ LogCategory* XlogCategoryInfo<IsInHeaderFile>::init(
       &isInitialized_);
 }
 
-#ifdef __INCLUDE_LEVEL__
 LogLevel XlogLevelInfo<false>::loadLevelFull(
     folly::StringPiece categoryName,
     bool isOverridden,
@@ -137,12 +136,12 @@ LogLevel XlogLevelInfo<false>::loadLevelFull(
   }
   return currentLevel;
 }
-#endif
+
 
 // Explicitly instantiations of XlogLevelInfo and XlogCategoryInfo
-// If __INCLUDE_LEVEL__ is not available only the "true" variants ever get
-// used, because we cannot determine if we are ever in the .cpp file being
-// compiled or not.
 template class XlogLevelInfo<true>;
 template class XlogCategoryInfo<true>;
+template class XlogLevelInfo<false>;
+template class XlogCategoryInfo<false>;
+
 } // namespace folly

--- a/folly/logging/xlog.h
+++ b/folly/logging/xlog.h
@@ -575,10 +575,8 @@ namespace folly {
 
 class XlogFileScopeInfo {
  public:
-#ifdef __INCLUDE_LEVEL__
   std::atomic<::folly::LogLevel> level;
   ::folly::LogCategory* category;
-#endif
 };
 
 /**
@@ -651,7 +649,6 @@ class XlogCategoryInfo {
   LogCategory* category_;
 };
 
-#ifdef __INCLUDE_LEVEL__
 /**
  * Specialization of XlogLevelInfo for XLOG() statements in the .cpp file being
  * compiled.  In this case we only define a single file-static LogLevel object
@@ -704,7 +701,6 @@ class XlogCategoryInfo<false> {
     return fileScopeInfo;
   }
 };
-#endif
 
 /**
  * Get the default XLOG() category name for the given filename.


### PR DESCRIPTION
An executable built by clang-cl that is linked against folly/logging
from vcpkg will fail to link due to a few missing symbols.  folly/logging
has a number of functions that are only defined when __INCLUDE_LEVEL__ is defined.
vcpkg always uses MSVC, MSVC does not support this macro while clang-cl does,
resulting in mismatch between what is defined, used, and declared.

These ifdefs mostly came from fc507b26548882a8492de57abf0a8923ecf7709a.

The (minor IMO) negative consequence of this diff is that
XlogFileScopeInfo will be unnecessarily larger (a pointer and an uint32)
 on compilers that don't support __INCLUDE_LEVEL__ (e.g MSVC).

The actual condition of whether to make use of __INCLUDE__LEVEL__ remains, via the XLOG_IS_IN_HEADER_FILE macro.