### PR TITLE
Adding ECN support to folly

### DIFF
--- a/folly/io/async/AsyncUDPServerSocket.h
+++ b/folly/io/async/AsyncUDPServerSocket.h
@@ -123,6 +123,8 @@ class AsyncUDPServerSocket : private AsyncUDPSocket::ReadCallback,
     socket_ = std::make_shared<AsyncUDPSocket>(evb_);
     socket_->setReusePort(reusePort_);
     socket_->setReuseAddr(reuseAddr_);
+    socket_->setTos(tos_);
+    socket_->setRecvTosHeader(recvTosHeader_);
     socket_->applyOptions(
         validateSocketOptions(
             options, addy.getFamily(), SocketOptionKey::ApplyPos::PRE_BIND),
@@ -141,6 +143,10 @@ class AsyncUDPServerSocket : private AsyncUDPSocket::ReadCallback,
   void setReusePort(bool reusePort) { reusePort_ = reusePort; }
 
   void setReuseAddr(bool reuseAddr) { reuseAddr_ = reuseAddr; }
+
+  void setRecvTosHeader(bool recvTos) { recvTosHeader_ = recvTos; }
+
+  void setTos(uint8_t tos) { tos_ = tos; }
 
   folly::SocketAddress address() const {
     CHECK(socket_);
@@ -350,8 +356,10 @@ class AsyncUDPServerSocket : private AsyncUDPSocket::ReadCallback,
   // Temporary buffer for data
   folly::IOBufQueue buf_;
 
+  bool recvTosHeader_{false};
   bool reusePort_{false};
   bool reuseAddr_{false};
+  uint8_t tos_{0};
 
   EventRecvmsgCallback* eventCb_{nullptr};
 };

--- a/folly/net/NetOps.h
+++ b/folly/net/NetOps.h
@@ -195,7 +195,15 @@ struct sock_txtime {
 #endif
 
 #ifndef SOL_UDP
-#define SOL_UDP 17
+#define SOL_UDP IPPROTO_UDP
+#endif
+
+#ifndef SOL_IP
+#define SOL_IP IPPROTO_IP
+#endif
+
+#ifndef SOL_IPV6
+#define SOL_IPV6 IPPROTO_IPV6
 #endif
 
 #ifndef ETH_MAX_MTU
@@ -232,11 +240,42 @@ struct mmsghdr {
 #ifndef IP_BIND_ADDRESS_NO_PORT
 #define IP_BIND_ADDRESS_NO_PORT 24
 #endif
-
 #endif
 
 namespace folly {
 namespace netops {
+// ECN (Explicit Congestion Notification) codepoints in RFC3168
+// mapped to the lower 2 bits of the TOS field.
+enum iptos_ecn : int {
+#ifdef IPTOS_ECN_MASK
+  kIptosEcnMask = IPTOS_ECN_MASK,
+#else
+  kIptosEcnMask = 0x03,
+#endif
+
+#ifdef IPTOS_ECN_NOT_ECT
+  kIptosEcnNotEct = IPTOS_ECN_NOT_ECT,
+#else
+  kIptosEcnNotEct = 0x00,
+#endif
+
+#ifdef IPTOS_ECN_ECT1
+  kIptosEcnEct1 = IPTOS_ECN_ECT1,
+#else
+  kIptosEcnEct1 = 0x01,
+#endif
+#ifdef IPTOS_ECN_ECT0
+  kIptosEcnEct0 = IPTOS_ECN_ECT0,
+#else
+  kIptosEcnEct0 = 0x02,
+#endif
+#ifdef IPTOS_ECN_CE
+  kIptosEcnCe = IPTOS_ECN_CE,
+#else
+  kIptosEcnCe = 0x03,
+#endif
+};
+
 // Poll descriptor is intended to be byte-for-byte identical to pollfd,
 // except that it is typed as containing a NetworkSocket for sane interactions.
 struct PollDescriptor {


### PR DESCRIPTION
Summary:
Added ECN support to folly/io/async/AsyncUDPSocket.

The support consists:
1. Configuring TOC (for IPv4) and TCLASS (for IPv6) fields for sending UDP packets
2. Parsing and passing TOC/TCLASS header as part of AsyncUDPSocket::ReadCallback::OnDataAvailableParams

Notes:
- The implementation always use `msghdr` parsing, This required to properly extract `TOS/TCLASS` IP header
- The `AsyncUDPSocket` already has `setTraficClass` function that somewhat similar to `setTos`. The difference: `setTraficClass` works after socket creation and only for IPv6. `setTos` executes during socket initialization (e.g. binding) and works both for IPv4 and IPv6.

Differential Revision: D27573238

