### PR TITLE
Fix compilation issues on Apple platforms.

### DIFF
--- a/folly/experimental/coro/AsyncPipe.h
+++ b/folly/experimental/coro/AsyncPipe.h
@@ -96,7 +96,7 @@ class AsyncPipe {
     if (onClosed != nullptr) {
       cancellationSource.emplace();
       onClosedCallback = std::make_unique<OnClosedCallback>(
-          cancellationSource.value(), std::move(onClosed));
+          *cancellationSource, std::move(onClosed));
     }
     auto guard =
         folly::makeGuard([cancellationSource = std::move(cancellationSource)] {


### PR DESCRIPTION
Summary: There's a bug in C++ SDK shipped on Apple platforms that marks `std::optional`'s `value()` as unavailable. To resolve that we should use `operator*` instead.

Differential Revision: D30755147

