### PR TITLE
fix: typedef redefinition

### DIFF
--- a/folly/portability/Time.h
+++ b/folly/portability/Time.h
@@ -49,7 +49,6 @@
 #define CLOCK_PROCESS_CPUTIME_ID 2
 #define CLOCK_THREAD_CPUTIME_ID 3
 
-typedef uint8_t clockid_t;
 extern "C" int clock_gettime(clockid_t clk_id, struct timespec* ts);
 extern "C" int clock_getres(clockid_t clk_id, struct timespec* ts);
 #endif


### PR DESCRIPTION
Solves #1658 .
Typedef redefinition error prevents apps using latest folly version from building