### PR TITLE
folly: fixes to renable cmake tests

### DIFF
--- a/CMake/FollyFunctions.cmake
+++ b/CMake/FollyFunctions.cmake
@@ -266,17 +266,19 @@ function(folly_define_tests)
 
   set(cur_test 0)
   while (cur_test LESS test_count)
-    if (
-      1
-      # TODO: Use IN_LIST after cmake 3.3
-      AND (test_${cur_test}_tag MATCHES "\\bBROKEN\\b" OR BUILD_BROKEN_TESTS)
-      AND (test_${cur_test}_tag MATCHES "\\bSLOW\\b" OR BUILD_SLOW_TESTS)
-      AND (test_${cur_test}_tag MATCHES "\\bHANGING\\b" OR BUILD_HANGING_TESTS)
-      AND (test_${cur_test}_tag MATCHES "\\bWINDOWS_DISABLED\\b" OR NOT WIN32)
-      AND (test_${cur_test}_tag MATCHES "\\bAPPLE_DISABLED\\b" OR NOT APPLE)
-    )
-      set(cur_test_name ${test_${cur_test}_name})
-      set(cur_dir_name ${directory_${test_${cur_test}_directory}_name})
+    set(cur_test_name ${test_${cur_test}_name})
+    set(cur_dir_name ${directory_${test_${cur_test}_directory}_name})
+    if ("BROKEN" IN_LIST test_${cur_test}_tag AND NOT BUILD_BROKEN_TESTS)
+      message("Skipping broken test ${cur_dir_name}${cur_test_name}, enable with BUILD_BROKEN_TESTS")
+    elseif ("SLOW" IN_LIST test_${cur_test}_tag AND NOT BUILD_SLOW_TESTS)
+      message("Skipping slow test ${cur_dir_name}${cur_test_name}, enable with BUILD_SLOW_TESTS")
+    elseif ("HANGING" IN_LIST test_${cur_test}_tag AND NOT BUILD_HANGING_TESTS)
+      message("Skipping hanging test ${cur_dir_name}${cur_test_name}, enable with BUILD_HANGING_TESTS")
+    elseif ("WINDOWS_DISABLED" IN_LIST test_${cur_test}_tag AND WIN32)
+      message("Skipping windows disabled test ${cur_dir_name}${cur_test_name}, enable with WINDOWS_DISABLED")
+    elseif ("APPLE_DISABLED" IN_LIST test_${cur_test}_tag AND APPLE)
+      message("Skipping apple disabled test ${cur_dir_name}${cur_test_name}, enable with APPLE_DISABLED")
+    else()
       add_executable(${cur_test_name}
         ${test_${cur_test}_headers}
         ${test_${cur_test}_sources}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -886,7 +886,6 @@ if (BUILD_TESTS)
       TEST json_patch_test SOURCES json_patch_test.cpp
       TEST json_other_test SOURCES JsonOtherTest.cpp
       TEST lazy_test SOURCES LazyTest.cpp
-      TEST lock_traits_test SOURCES LockTraitsTest.cpp
       TEST locks_test SOURCES SpinLockTest.cpp
       TEST math_test SOURCES MathTest.cpp
       TEST map_util_test SOURCES MapUtilTest.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,7 +579,8 @@ if (BUILD_TESTS)
       TEST fiber_io_executor_test SOURCES FiberIOExecutorTest.cpp
       TEST global_executor_test SOURCES GlobalExecutorTest.cpp
       TEST serial_executor_test SOURCES SerialExecutorTest.cpp
-      TEST thread_pool_executor_test WINDOWS_DISABLED
+      # Fails in ThreadPoolExecutorTest.RequestContext:719 data2 != nullptr
+      TEST thread_pool_executor_test BROKEN WINDOWS_DISABLED
         SOURCES ThreadPoolExecutorTest.cpp
       TEST threaded_executor_test SOURCES ThreadedExecutorTest.cpp
       TEST timed_drivable_executor_test SOURCES TimedDrivableExecutorTest.cpp
@@ -645,7 +646,8 @@ if (BUILD_TESTS)
           XlogTest.cpp
 
     DIRECTORY fibers/test/
-      TEST fibers_test SOURCES FibersTest.cpp
+      # FiberManager swapWithException fails with segfault
+      TEST fibers_test BROKEN SOURCES FibersTest.cpp
 
     DIRECTORY functional/test/
       TEST apply_tuple_test WINDOWS_DISABLED
@@ -743,7 +745,8 @@ if (BUILD_TESTS)
       TEST DelayedDestructionTest SOURCES DelayedDestructionTest.cpp
       TEST DelayedDestructionBaseTest SOURCES DelayedDestructionBaseTest.cpp
       TEST DestructorCheckTest SOURCES DestructorCheckTest.cpp
-      TEST EventBaseTest SOURCES EventBaseTest.cpp
+      # Fails with gtest macro error
+      TEST EventBaseTest BROKEN SOURCES EventBaseTest.cpp
       TEST EventBaseLocalTest SOURCES EventBaseLocalTest.cpp
       TEST HHWheelTimerTest SOURCES HHWheelTimerTest.cpp
       TEST HHWheelTimerSlowTests SLOW
@@ -889,7 +892,8 @@ if (BUILD_TESTS)
       TEST locks_test SOURCES SpinLockTest.cpp
       TEST math_test SOURCES MathTest.cpp
       TEST map_util_test SOURCES MapUtilTest.cpp
-      TEST memcpy_test SOURCES MemcpyTest.cpp
+      # Fails with link error on __folly_memcpy
+      TEST memcpy_test BROKEN SOURCES MemcpyTest.cpp
       TEST memory_idler_test SOURCES MemoryIdlerTest.cpp
       TEST memory_test WINDOWS_DISABLED
         SOURCES MemoryTest.cpp

--- a/folly/executors/test/ThreadPoolExecutorTest.cpp
+++ b/folly/executors/test/ThreadPoolExecutorTest.cpp
@@ -353,8 +353,8 @@ TEST(ThreadPoolExecutorTest, EDFTaskStats) {
   taskStats<EDFThreadPoolExecutor>();
 }
 
-#ifdef __linux__
 TEST(ThreadPoolExecutorTest, GetUsedCpuTime) {
+#ifdef __linux__
   CPUThreadPoolExecutor e(4);
   ASSERT_EQ(e.numActiveThreads(), 0);
   ASSERT_EQ(e.getUsedCpuTime(), nanoseconds(0));
@@ -399,9 +399,7 @@ TEST(ThreadPoolExecutorTest, GetUsedCpuTime) {
   baton.wait();
   auto elapsed3 = e.getUsedCpuTime();
   ASSERT_NEAR_NS(elapsed3, elapsed2 + 500ms, 100ms);
-}
 #else
-TEST(ThreadPoolExecutorTest, GetUsedCpuTime) {
   CPUThreadPoolExecutor e(1);
   // Just make sure 0 is returned
   ASSERT_EQ(e.getUsedCpuTime(), nanoseconds(0));
@@ -414,8 +412,8 @@ TEST(ThreadPoolExecutorTest, GetUsedCpuTime) {
   });
   baton.wait();
   ASSERT_EQ(e.getUsedCpuTime(), nanoseconds(0));
-}
 #endif
+}
 
 template <class TPE>
 static void expiration() {


### PR DESCRIPTION
Having the tests is useful to be able to test the OSS builds. A few were failing for me locally so I've tagged them BROKEN in CMakeLists.txt which folly's cmake config filters out