### PR TITLE
Replace std::is_pod<> which is deprecated in C++20

### DIFF
--- a/folly/PackedSyncPtr.h
+++ b/folly/PackedSyncPtr.h
@@ -137,7 +137,8 @@ class PackedSyncPtr {
 } FOLLY_PACK_ATTR;
 
 static_assert(
-    std::is_pod<PackedSyncPtr<void>>::value,
+    std::is_standard_layout<PackedSyncPtr<void>>::value &&
+        std::is_trivial<PackedSyncPtr<void>>::value,
     "PackedSyncPtr must be kept a POD type.");
 static_assert(
     sizeof(PackedSyncPtr<void>) == 8,

--- a/folly/SingletonThreadLocal.h
+++ b/folly/SingletonThreadLocal.h
@@ -77,7 +77,10 @@ class SingletonThreadLocal {
   struct LocalCache {
     Wrapper* cache;
   };
-  static_assert(std::is_pod<LocalCache>::value, "non-pod");
+  static_assert(
+      std::is_standard_layout<LocalCache>::value &&
+          std::is_trivial<LocalCache>::value,
+      "non-pod");
 
   struct LocalLifetime;
 

--- a/folly/experimental/symbolizer/Dwarf.cpp
+++ b/folly/experimental/symbolizer/Dwarf.cpp
@@ -118,8 +118,10 @@ const uint32_t kMaxAbbreviationEntries = 1000;
 
 // Read (bitwise) one object of type T
 template <class T>
-typename std::enable_if<std::is_pod<T>::value, T>::type read(
-    folly::StringPiece& sp) {
+typename std::enable_if<
+    std::is_standard_layout<T>::value && std::is_trivial<T>::value,
+    T>::type
+read(folly::StringPiece& sp) {
   FOLLY_SAFE_CHECK(sp.size() >= sizeof(T), "underflow");
   T x;
   memcpy(&x, sp.data(), sizeof(T));

--- a/folly/experimental/symbolizer/Elf.h
+++ b/folly/experimental/symbolizer/Elf.h
@@ -273,7 +273,9 @@ class ElfFile {
 
   template <class T>
   const T& at(ElfOff offset) const noexcept {
-    static_assert(std::is_pod<T>::value, "non-pod");
+    static_assert(
+        std::is_standard_layout<T>::value && std::is_trivial<T>::value,
+        "non-pod");
     FOLLY_SAFE_CHECK(
         offset + sizeof(T) <= length_,
         "Offset (",

--- a/folly/lang/Bits.h
+++ b/folly/lang/Bits.h
@@ -332,7 +332,10 @@ FOLLY_PUSH_WARNING
 FOLLY_CLANG_DISABLE_WARNING("-Wpacked")
 FOLLY_PACK_PUSH
 template <class T>
-struct Unaligned<T, typename std::enable_if<std::is_pod<T>::value>::type> {
+struct Unaligned<
+    T,
+    typename std::enable_if<
+        std::is_standard_layout<T>::value && std::is_trivial<T>::value>::type> {
   Unaligned() = default; // uninitialized
   /* implicit */ Unaligned(T v) : value(v) {}
   T value;

--- a/folly/net/TcpInfo.h
+++ b/folly/net/TcpInfo.h
@@ -232,7 +232,7 @@ struct TcpInfo {
    */
   template <typename T1, typename T2>
   static size_t constexpr getFieldOffset(T1 T2::*field) {
-    static_assert(std::is_pod<T1>());
+    static_assert(std::is_standard_layout<T1>() && std::is_trivial<T1>());
     constexpr T2 dummy{};
     return size_t(&(dummy.*field)) - size_t(&dummy);
   }

--- a/folly/synchronization/MicroSpinLock.h
+++ b/folly/synchronization/MicroSpinLock.h
@@ -113,7 +113,8 @@ struct MicroSpinLock {
   }
 };
 static_assert(
-    std::is_pod<MicroSpinLock>::value,
+    std::is_standard_layout<MicroSpinLock>::value &&
+        std::is_trivial<MicroSpinLock>::value,
     "MicroSpinLock must be kept a POD type.");
 
 //////////////////////////////////////////////////////////////////////

--- a/folly/test/TraitsTest.cpp
+++ b/folly/test/TraitsTest.cpp
@@ -352,7 +352,6 @@ TEST(Traits, aligned_storage_for_t) {
   EXPECT_EQ(2, alignof(storage));
   EXPECT_TRUE(std::is_trivial<storage>::value);
   EXPECT_TRUE(std::is_standard_layout<storage>::value);
-  EXPECT_TRUE(std::is_pod<storage>::value); // pod = trivial + standard-layout
 }
 
 TEST(Traits, remove_cvref) {


### PR DESCRIPTION
Warnings are triggered by `is_pod<>` with both Clang and GCC when
using `-std=c++20`.

This change replaces all instances of `is_pod<T>::value` with
`(is_standard_layout<T>::value && is_trivial<T>::value)`, which
is equivalent and even suggested by both compilers.