### PR TITLE
Support of Arch Linux in `getdeps.py`

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -347,7 +347,7 @@ class InstallSysDepsCmd(ProjectCmdBase):
         )
         parser.add_argument(
             "--package-type",
-            choices=["rpm", "deb"],
+            choices=["rpm", "deb", "pacman-package"],
             default=None,
             help="Allow overriding the package type so can see deb from centos",
         )
@@ -381,6 +381,10 @@ class InstallSysDepsCmd(ProjectCmdBase):
             packages = sorted(list(set(all_packages["deb"])))
             if packages:
                 cmd_args = ["apt", "install", "-y"] + packages
+        elif manager == "pacman-package":
+            packages = sorted(list(set(all_packages["pacman-package"])))
+            if packages:
+                cmd_args = ["pacman", "-S"] + packages
         else:
             host_tuple = loader.build_opts.host_type.as_tuple_string()
             print(

--- a/build/fbcode_builder/getdeps/manifest.py
+++ b/build/fbcode_builder/getdeps/manifest.py
@@ -85,6 +85,7 @@ SCHEMA = {
     "autoconf.envcmd.LDFLAGS": {"optional_section": True},
     "rpms": {"optional_section": True},
     "debs": {"optional_section": True},
+    "pacman-packages": {"optional_section": True},
     "preinstalled.env": {"optional_section": True},
     "b2.args": {"optional_section": True},
     "make.build_args": {"optional_section": True},
@@ -112,6 +113,7 @@ ALLOWED_EXPR_SECTIONS = [
     "install.files",
     "rpms",
     "debs",
+    "pacman-packages",
 ]
 
 
@@ -358,6 +360,7 @@ class ManifestParser(object):
         return {
             "rpm": self.get_section_as_args("rpms", ctx),
             "deb": self.get_section_as_args("debs", ctx),
+            "pacman-package": self.get_section_as_args("pacman-packages", ctx),
         }
 
     def _is_satisfied_by_preinstalled_environment(self, ctx):

--- a/build/fbcode_builder/getdeps/platform.py
+++ b/build/fbcode_builder/getdeps/platform.py
@@ -103,6 +103,8 @@ class HostType(object):
             return "rpm"
         if self.distro.startswith(("debian", "ubuntu")):
             return "deb"
+        if self.distro == "arch":
+            return "pacman-package"
         return None
 
     @staticmethod

--- a/build/fbcode_builder/manifests/autoconf
+++ b/build/fbcode_builder/manifests/autoconf
@@ -7,6 +7,9 @@ autoconf
 [debs]
 autoconf
 
+[pacman-packages]
+autoconf
+
 [download]
 url = http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
 sha256 = 954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969

--- a/build/fbcode_builder/manifests/automake
+++ b/build/fbcode_builder/manifests/automake
@@ -7,6 +7,9 @@ automake
 [debs]
 automake
 
+[pacman-packages]
+automake
+
 [download]
 url = http://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.gz
 sha256 = 608a97523f97db32f1f5d5615c98ca69326ced2054c9f82e65bade7fc4c9dea8

--- a/build/fbcode_builder/manifests/bison
+++ b/build/fbcode_builder/manifests/bison
@@ -7,6 +7,9 @@ bison
 [debs]
 bison
 
+[pacman-packages]
+bison
+
 [download.not(os=windows)]
 url = https://mirrors.kernel.org/gnu/bison/bison-3.3.tar.gz
 sha256 = fdeafb7fffade05604a61e66b8c040af4b2b5cbb1021dcfe498ed657ac970efd

--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -15,6 +15,9 @@ BOOST_ROOT_1_69_0
 [debs]
 libboost-all-dev
 
+[pacman-packages]
+boost
+
 [rpms.all(distro=centos_stream,distro_vers=8)]
 boost169
 boost169-math

--- a/build/fbcode_builder/manifests/cmake
+++ b/build/fbcode_builder/manifests/cmake
@@ -4,6 +4,9 @@ name = cmake
 [rpms]
 cmake
 
+[pacman-packages]
+cmake
+
 [dependencies]
 ninja
 openssl

--- a/build/fbcode_builder/manifests/double-conversion
+++ b/build/fbcode_builder/manifests/double-conversion
@@ -9,6 +9,9 @@ sha256 = 95004b65e43fefc6100f337a25da27bb99b9ef8d4071a36a33b5e83eb1f82021
 double-conversion
 double-conversion-devel
 
+[pacman-packages]
+double-conversion
+
 [build]
 builder = cmake
 subdir = double-conversion-3.1.4

--- a/build/fbcode_builder/manifests/flex
+++ b/build/fbcode_builder/manifests/flex
@@ -7,6 +7,9 @@ flex
 [debs]
 flex
 
+[pacman-packages]
+flex
+
 [download.not(os=windows)]
 url = https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
 sha256 = e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995

--- a/build/fbcode_builder/manifests/jq
+++ b/build/fbcode_builder/manifests/jq
@@ -7,6 +7,9 @@ jq
 [debs]
 jq
 
+[pacman-packages]
+jq
+
 [download.not(os=windows)]
 url = https://github.com/stedolan/jq/releases/download/jq-1.5/jq-1.5.tar.gz
 sha256 = c4d2bfec6436341113419debf479d833692cc5cdab7eb0326b5a4d4fbe9f493c

--- a/build/fbcode_builder/manifests/libcurl
+++ b/build/fbcode_builder/manifests/libcurl
@@ -8,6 +8,9 @@ libcurl
 [debs]
 libcurl4-openssl-dev
 
+[pacman-packages]
+libcurl-gnutls
+
 [download]
 url = https://curl.haxx.se/download/curl-7.65.1.tar.gz
 sha256 = 821aeb78421375f70e55381c9ad2474bf279fc454b791b7e95fc83562951c690

--- a/build/fbcode_builder/manifests/libelf
+++ b/build/fbcode_builder/manifests/libelf
@@ -7,6 +7,9 @@ elfutils-libelf-devel-static
 [debs]
 libelf-dev
 
+[pacman-packages]
+libelf
+
 [download]
 url = https://ftp.osuosl.org/pub/blfs/conglomeration/libelf/libelf-0.8.13.tar.gz
 sha256 = 591a9b4ec81c1f2042a97aa60564e0cb79d041c52faa7416acb38bc95bd2c76d

--- a/build/fbcode_builder/manifests/libevent
+++ b/build/fbcode_builder/manifests/libevent
@@ -7,6 +7,9 @@ libevent-devel
 [debs]
 libevent-dev
 
+[pacman-packages]
+libevent
+
 # Note that the CMakeLists.txt file is present only in
 # git repo and not in the release tarball, so take care
 # to use the github generated source tarball rather than

--- a/build/fbcode_builder/manifests/libffi
+++ b/build/fbcode_builder/manifests/libffi
@@ -8,6 +8,9 @@ libffi
 [debs]
 libffi-dev
 
+[pacman-packages]
+libffi
+
 [download]
 url = https://github.com/libffi/libffi/releases/download/v3.4.2/libffi-3.4.2.tar.gz
 sha256 = 540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620

--- a/build/fbcode_builder/manifests/libgit2
+++ b/build/fbcode_builder/manifests/libgit2
@@ -4,6 +4,9 @@ name = libgit2
 [rpms]
 libgit2-devel
 
+[pacman-packages]
+libgit2
+
 # Ubuntu 18.04 libgit2 has clash with libcurl4-openssl-dev as it depends on
 # libcurl4-gnutls-dev.  Should be ok from 20.04 again
 # There is a description at https://github.com/r-hub/sysreqsdb/issues/77

--- a/build/fbcode_builder/manifests/libicu
+++ b/build/fbcode_builder/manifests/libicu
@@ -7,6 +7,9 @@ libicu-devel
 [debs]
 libicu-dev
 
+[pacman-packages]
+icu
+
 [download]
 url = https://github.com/unicode-org/icu/releases/download/release-68-2/icu4c-68_2-src.tgz
 sha256 = c79193dee3907a2199b8296a93b52c5cb74332c26f3d167269487680d479d625

--- a/build/fbcode_builder/manifests/libmnl
+++ b/build/fbcode_builder/manifests/libmnl
@@ -8,6 +8,9 @@ libmnl-static
 [debs]
 libmnl-dev
 
+[pacman-packages]
+libmnl
+
 [download]
 url = http://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
 sha256 = 171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81

--- a/build/fbcode_builder/manifests/libnl
+++ b/build/fbcode_builder/manifests/libnl
@@ -8,6 +8,9 @@ libnl3
 [debs]
 libnl-3-dev
 
+[pacman-packages]
+libnl
+
 [download]
 url = https://www.infradead.org/~tgr/libnl/files/libnl-3.2.25.tar.gz
 sha256 = 8beb7590674957b931de6b7f81c530b85dc7c1ad8fbda015398bc1e8d1ce8ec5

--- a/build/fbcode_builder/manifests/libsodium
+++ b/build/fbcode_builder/manifests/libsodium
@@ -8,6 +8,9 @@ libsodium-static
 [debs]
 libsodium-dev
 
+[pacman-packages]
+libsodium
+
 [download.not(os=windows)]
 url = https://github.com/jedisct1/libsodium/releases/download/1.0.17/libsodium-1.0.17.tar.gz
 sha256 = 0cc3dae33e642cc187b5ceb467e0ad0e1b51dcba577de1190e9ffa17766ac2b1

--- a/build/fbcode_builder/manifests/libtool
+++ b/build/fbcode_builder/manifests/libtool
@@ -7,6 +7,9 @@ libtool
 [debs]
 libtool
 
+[pacman-packages]
+libtool
+
 [download]
 url = http://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz
 sha256 = e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3

--- a/build/fbcode_builder/manifests/libusb
+++ b/build/fbcode_builder/manifests/libusb
@@ -8,6 +8,9 @@ libusb
 [debs]
 libusb-1.0-0-dev
 
+[pacman-packages]
+libusb
+
 [download]
 url = https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.tar.bz2
 sha256 = 75aeb9d59a4fdb800d329a545c2e6799f732362193b465ea198f2aa275518157

--- a/build/fbcode_builder/manifests/libzmq
+++ b/build/fbcode_builder/manifests/libzmq
@@ -8,6 +8,9 @@ zeromq
 [debs]
 libzmq3-dev
 
+[pacman-packages]
+zeromq
+
 [download]
 url = https://github.com/zeromq/libzmq/releases/download/v4.3.1/zeromq-4.3.1.tar.gz
 sha256 = bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb

--- a/build/fbcode_builder/manifests/lz4
+++ b/build/fbcode_builder/manifests/lz4
@@ -8,6 +8,9 @@ lz4-static
 [debs]
 liblz4-dev
 
+[pacman-packages]
+lz4
+
 [download]
 url = https://github.com/lz4/lz4/archive/v1.8.3.tar.gz
 sha256 = 33af5936ac06536805f9745e0b6d61da606a1f8b4cc5c04dd3cbaca3b9b4fc43

--- a/build/fbcode_builder/manifests/lzo
+++ b/build/fbcode_builder/manifests/lzo
@@ -7,6 +7,9 @@ lzo-devel
 [debs]
 liblzo2-dev
 
+[pacman-packages]
+lzo
+
 [download]
 url = http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz 
 sha256 = c0f892943208266f9b6543b3ae308fab6284c5c90e627931446fb49b4221a072

--- a/build/fbcode_builder/manifests/nghttp2
+++ b/build/fbcode_builder/manifests/nghttp2
@@ -8,6 +8,9 @@ libnghttp2
 [debs]
 libnghttp2-dev
 
+[pacman-packages]
+libnghttp2
+
 [download]
 url = https://github.com/nghttp2/nghttp2/releases/download/v1.39.2/nghttp2-1.39.2.tar.gz
 sha256 = fc820a305e2f410fade1a3260f09229f15c0494fc089b0100312cd64a33a38c0

--- a/build/fbcode_builder/manifests/ninja
+++ b/build/fbcode_builder/manifests/ninja
@@ -7,6 +7,9 @@ ninja-build
 [debs]
 ninja-build
 
+[pacman-packages]
+ninja
+
 [download.os=windows]
 url = https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip
 sha256 = bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f

--- a/build/fbcode_builder/manifests/nmap
+++ b/build/fbcode_builder/manifests/nmap
@@ -7,6 +7,9 @@ nmap
 [debs]
 nmap
 
+[pacman-packages]
+nmap
+
 [download.not(os=windows)]
 url = https://api.github.com/repos/nmap/nmap/tarball/ef8213a36c2e89233c806753a57b5cd473605408
 sha256 = eda39e5a8ef4964fac7db16abf91cc11ff568eac0fa2d680b0bfa33b0ed71f4a

--- a/build/fbcode_builder/manifests/openssl
+++ b/build/fbcode_builder/manifests/openssl
@@ -9,6 +9,9 @@ openssl-libs
 [debs]
 libssl-dev
 
+[pacman-packages]
+openssl
+
 [download]
 url = https://www.openssl.org/source/openssl-1.1.1l.tar.gz
 sha256 = 0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1

--- a/build/fbcode_builder/manifests/patchelf
+++ b/build/fbcode_builder/manifests/patchelf
@@ -7,6 +7,9 @@ patchelf
 [debs]
 patchelf
 
+[pacman-packages]
+patchelf
+
 [download]
 url = https://github.com/NixOS/patchelf/archive/0.10.tar.gz
 sha256 = b3cb6bdedcef5607ce34a350cf0b182eb979f8f7bc31eae55a93a70a3f020d13

--- a/build/fbcode_builder/manifests/protobuf
+++ b/build/fbcode_builder/manifests/protobuf
@@ -7,6 +7,9 @@ protobuf-devel
 [debs]
 libprotobuf-dev
 
+[pacman-packages]
+protobuf
+
 [git]
 repo_url = https://github.com/protocolbuffers/protobuf.git
 rev = master

--- a/build/fbcode_builder/manifests/python
+++ b/build/fbcode_builder/manifests/python
@@ -8,6 +8,9 @@ python3-devel
 [debs]
 python3-all-dev
 
+[pacman-packages]
+python3
+
 [download]
 url = https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tgz
 sha256 = 316aa33f3b7707d041e73f246efedb297a70898c4b91f127f66dc8d80c596f1a

--- a/build/fbcode_builder/manifests/python_3_7
+++ b/build/fbcode_builder/manifests/python_3_7
@@ -8,6 +8,9 @@ python3-devel
 [debs]
 python3-all-dev
 
+[pacman-packages]
+python3
+
 [download.os=linux]
 url = https://www.python.org/ftp/python/3.7.6/Python-3.7.6.tgz
 sha256 = aeee681c235ad336af116f08ab6563361a0c81c537072c1b309d6e4050aa2114

--- a/build/fbcode_builder/manifests/re2
+++ b/build/fbcode_builder/manifests/re2
@@ -8,6 +8,9 @@ re2-devel
 [debs]
 libre2-dev
 
+[pacman-packages]
+re2
+
 [download]
 url = https://github.com/google/re2/archive/2019-06-01.tar.gz
 sha256 = 02b7d73126bd18e9fbfe5d6375a8bb13fadaf8e99e48cbb062e4500fc18e8e2e

--- a/build/fbcode_builder/manifests/snappy
+++ b/build/fbcode_builder/manifests/snappy
@@ -4,6 +4,9 @@ name = snappy
 [debs]
 libsnappy-dev
 
+[pacman-packages]
+snappy
+
 [download]
 url = https://github.com/google/snappy/archive/1.1.7.tar.gz
 sha256 = 3dfa02e873ff51a11ee02b9ca391807f0c8ea0529a4924afa645fbf97163f9d4

--- a/build/fbcode_builder/manifests/sqlite3
+++ b/build/fbcode_builder/manifests/sqlite3
@@ -8,6 +8,9 @@ sqlite-libs
 [debs]
 libsqlite3-dev
 
+[pacman-packages]
+sqlite3
+
 [download]
 url = https://sqlite.org/2019/sqlite-amalgamation-3280000.zip
 sha256 = d02fc4e95cfef672b45052e221617a050b7f2e20103661cda88387349a9b1327

--- a/build/fbcode_builder/manifests/sqlite3-bin
+++ b/build/fbcode_builder/manifests/sqlite3-bin
@@ -7,6 +7,9 @@ sqlite
 [debs]
 sqlite3
 
+[pacman-packages]
+sqlite
+
 [download.os=linux]
 url = https://github.com/sqlite/sqlite/archive/version-3.33.0.tar.gz
 sha256 = 48e5f989eefe9af0ac758096f82ead0f3c7b58118ac17cc5810495bd5084a331

--- a/build/fbcode_builder/manifests/tcl
+++ b/build/fbcode_builder/manifests/tcl
@@ -7,6 +7,9 @@ tcl
 [debs]
 tcl
 
+[pacman-packages]
+tcl
+
 [download]
 url = https://github.com/tcltk/tcl/archive/core-8-7a3.tar.gz
 sha256 = 22d748f0c9652f3ecc195fed3f24a1b6eea8d449003085e6651197951528982e

--- a/build/fbcode_builder/manifests/tree
+++ b/build/fbcode_builder/manifests/tree
@@ -7,6 +7,9 @@ tree
 [debs]
 tree
 
+[pacman-packages]
+tree
+
 [download.os=linux]
 url = https://salsa.debian.org/debian/tree-packaging/-/archive/debian/1.8.0-1/tree-packaging-debian-1.8.0-1.tar.gz
 sha256 = a841eee1d52bfd64a48f54caab9937b9bd92935055c48885c4ab1ae4dab7fae5

--- a/build/fbcode_builder/manifests/zlib
+++ b/build/fbcode_builder/manifests/zlib
@@ -8,6 +8,9 @@ zlib-static
 [debs]
 zlib1g-dev
 
+[pacman-packages]
+zlib
+
 [download]
 url = http://www.zlib.net/zlib-1.2.11.tar.gz
 sha256 = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1

--- a/build/fbcode_builder/manifests/zstd
+++ b/build/fbcode_builder/manifests/zstd
@@ -5,6 +5,9 @@ name = zstd
 libzstd-devel
 libzstd
 
+[pacman-packages]
+zstd
+
 [download]
 url = https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.5.tar.gz
 sha256 = 98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e


### PR DESCRIPTION
I don't sure that I make all in accordance with the your contribution pipeline, so please correct me If there is needed.
So, I've made some changes to support the `pacman` package manager in your `getdeps.py` script. In `manifests` I'm also duplicated some packages from `debs` and `rpms` sections and create a new `pps` sections with according packages for  `pacman`.

Issue:  #1701