### PR TITLE
Specify compatiable folly version

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -299,7 +299,7 @@ endif()
 
 add_library(folly_deps INTERFACE)
 
-find_package(fmt CONFIG)
+find_package(fmt 8 CONFIG)
 if (NOT DEFINED fmt_CONFIG)
     # Fallback on a normal search on the current system
     find_package(Fmt MODULE REQUIRED)


### PR DESCRIPTION
Trying to build with fmt 7.x results in:

```
/tmp/nix-build-folly-2022.02.07.00.drv-0/source/folly/Range.h:1558:36: error: no matching member function for call to 'format'
    return formatter<string_view>::format({s.data(), s.size()}, ctx);
```    