### PR TITLE
Move callables another time in exception_wrapper

### DIFF
--- a/folly/ExceptionWrapper-inl.h
+++ b/folly/ExceptionWrapper-inl.h
@@ -491,7 +491,7 @@ inline bool exception_wrapper::with_exception_(This& this_, Fn fn_) {
   using from_ex = with_exception_from_ex_;
   using from = conditional_t<std::is_void<Ex>::value, from_fn, from_ex>;
   using type = typename from::template apply<Ex, Fn>;
-  return with_exception_(this_, fn_, tag<type>);
+  return with_exception_(this_, std::move(fn_), tag<type>);
 }
 
 template <class This, class... CatchFns>

--- a/folly/test/ExceptionWrapperTest.cpp
+++ b/folly/test/ExceptionWrapperTest.cpp
@@ -16,6 +16,7 @@
 
 #include <folly/ExceptionWrapper.h>
 
+#include <memory>
 #include <stdexcept>
 
 #include <folly/Conv.h>
@@ -152,17 +153,8 @@ TEST(ExceptionWrapper, with_exception_test) {
   EXPECT_FALSE(cew.with_exception([&](int&) {}));
   */
 
-  // Test with lambda capturing move-only type.
-  // Just needs to compile.
-  struct MoveOnly {
-    MoveOnly() = default;
-    MoveOnly(const MoveOnly&) = delete;
-    MoveOnly& operator=(const MoveOnly&) = delete;
-    MoveOnly(MoveOnly&&) noexcept = default;
-    void Foo() const {}
-  };
-  MoveOnly move_only;
-  cew.with_exception([move_only = std::move(move_only)](const std::exception&) { move_only.Foo(); };
+  // a move-only callback type:
+  cew.with_exception([v = std::make_unique<int>(7)](const std::exception&) {});
 }
 
 TEST(ExceptionWrapper, get_or_make_exception_ptr_test) {

--- a/folly/test/ExceptionWrapperTest.cpp
+++ b/folly/test/ExceptionWrapperTest.cpp
@@ -151,6 +151,18 @@ TEST(ExceptionWrapper, with_exception_test) {
   EXPECT_FALSE(cew.with_exception([&](std::runtime_error&) {}));
   EXPECT_FALSE(cew.with_exception([&](int&) {}));
   */
+
+  // Test with lambda capturing move-only type.
+  // Just needs to compile.
+  struct MoveOnly {
+    MoveOnly() = default;
+    MoveOnly(const MoveOnly&) = delete;
+    MoveOnly& operator=(const MoveOnly&) = delete;
+    MoveOnly(MoveOnly&&) noexcept = default;
+    void Foo() const {}
+  };
+  MoveOnly move_only;
+  cew.with_exception([move_only = std::move(move_only)](const std::exception&) { move_only.Foo(); };
 }
 
 TEST(ExceptionWrapper, get_or_make_exception_ptr_test) {


### PR DESCRIPTION
The `exception_wrapper` moves callables around in `with_exception,` except for one place. This forces callables to be copyable. Use `std::move` in the remaining place.