### PR TITLE
Adding ELI5 video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ designs that are more idiosyncratic than they would otherwise be (see
 e.g. `PackedSyncPtr.h`, `SmallLocks.h`). Good performance at large
 scale is a unifying theme in all of Folly.
 
+## Check it out in the intro video
+[![Explain Like I’m 5: Folly](https://img.youtube.com/vi/Wr_IfOICYSs/0.jpg)](https://www.youtube.com/watch?v=Wr_IfOICYSs)
+
 # Logical Design
 
 Folly is a collection of relatively independent components, some as


### PR DESCRIPTION
# Motivation

Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Litho home page](https://fblitho.com/) or in [Docusaurus home page](https://docusaurus.io/)

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/12485205/154306102-af74c009-a377-44a7-a4e2-785971b46356.png">
