### PR TITLE
Fix detection of clock_gettime availability

### DIFF
--- a/folly/portability/Time.h
+++ b/folly/portability/Time.h
@@ -27,11 +27,7 @@
 // solve that by pretending we have it here in the header and
 // then enable our implementation on the source side so that
 // gets linked in instead.
-#if defined(__MACH__) &&                                               \
-        ((!defined(TARGET_OS_OSX) || TARGET_OS_OSX) &&                 \
-         (MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_12)) || \
-    (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE != 0 &&             \
-     (__IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_10_0))
+#if defined(__MACH__) && defined(__CLOCK_AVAILABILITY)
 
 #ifdef FOLLY_HAVE_CLOCK_GETTIME
 #undef FOLLY_HAVE_CLOCK_GETTIME


### PR DESCRIPTION
On Apple platforms, following the SDK development [1] guidelines, we can check
for the availability (as in definition) of symbols using macros. This is more
reliable notably when targeting iOS platforms or simulators where the previous
approach used to create redefinition problems [2] & [3].

[1] https://developer.apple.com/forums/thread/67102
[2] https://github.com/facebook/folly/issues/1470
[3] https://github.com/facebook/flipper/issues/834