### PR TITLE
add "rocky" as a known distro using rpm

### DIFF
--- a/build/fbcode_builder/getdeps/platform.py
+++ b/build/fbcode_builder/getdeps/platform.py
@@ -231,7 +231,7 @@ class HostType(object):
             return None
         if self.is_darwin():
             return "homebrew"
-        if self.distro in ("fedora", "centos", "centos_stream"):
+        if self.distro in ("fedora", "centos", "centos_stream", "rocky"):
             return "rpm"
         if self.distro.startswith(("debian", "ubuntu")):
             return "deb"


### PR DESCRIPTION
this allows us to use the preinstalled package on a "rocky" box
as the build dependencies.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>