### PR TITLE
Fix gcc11 build (cleanup const in some constexpr format)

### DIFF
--- a/folly/FBString.h
+++ b/folly/FBString.h
@@ -2738,7 +2738,7 @@ struct fmt::formatter<folly::fbstring> : private formatter<fmt::string_view> {
 
   template <typename Context>
   typename Context::iterator format(
-      const folly::fbstring& s, Context& ctx) const {
+      const folly::fbstring& s, Context& ctx) {
     return formatter<fmt::string_view>::format({s.data(), s.size()}, ctx);
   }
 };

--- a/folly/Range.h
+++ b/folly/Range.h
@@ -1554,7 +1554,7 @@ struct formatter<folly::StringPiece> : private formatter<string_view> {
   using formatter<string_view>::parse;
 
   template <typename Context>
-  typename Context::iterator format(folly::StringPiece s, Context& ctx) const {
+  typename Context::iterator format(folly::StringPiece s, Context& ctx) {
     return formatter<string_view>::format({s.data(), s.size()}, ctx);
   }
 };


### PR DESCRIPTION
```
In file included from /data/msv/git/lib/facebook/folly/folly/IPAddressV4.h:28,
                 from /data/msv/git/lib/facebook/folly/folly/IPAddress.h:28,
                 from /data/msv/git/lib/facebook/folly/folly/IPAddress.cpp:17:
/data/msv/git/lib/facebook/folly/folly/Range.h: In instantiation of ‘typename Context::iterator fmt::v7::formatter<folly::Range<const char*> >::format(folly::StringPiece, Context&) const [with Context = fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>; typename Context::iterator = fmt::v7::detail::buffer_appender<char>; folly::StringPiece = folly::Range<const char*>]’:
/usr/include/fmt/core.h:1110:28:   required from ‘static void fmt::v7::detail::value<Context>::format_custom_arg(const void*, typename Context::parse_context_type&, Context&) [with T = folly::Range<const char*>; Formatter = fmt::v7::formatter<folly::Range<const char*> >; Context = fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>; typename Context::parse_context_type = fmt::v7::basic_format_parse_context<char>]’
/usr/include/fmt/core.h:1096:19:   required from ‘fmt::v7::detail::value<Context>::value(const T&) [with T = folly::Range<const char*>; Context = fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>]’
/usr/include/fmt/core.h:1438:49:   required from ‘fmt::v7::detail::value<Context> fmt::v7::detail::make_arg(const T&) [with bool IS_PACKED = true; Context = fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>; fmt::v7::detail::type <anonymous> = fmt::v7::detail::type::custom_type; T = folly::Range<const char*>; typename std::enable_if<IS_PACKED, int>::type <anonymous> = 0]’
/usr/include/fmt/core.h:1589:64:   required from ‘fmt::v7::format_arg_store<Context, Args>::format_arg_store(const Args& ...) [with Context = fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>; Args = {folly::Range<const char*>}]’
/usr/include/fmt/core.h:1626:18:   required from ‘fmt::v7::format_arg_store<fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<Char>, Char>, typename std::remove_reference<Args>::type ...> fmt::v7::make_args_checked(const S&, fmt::v7::remove_reference_t<Args>& ...) [with Args = {folly::Range<const char*>&}; S = char [65]; Char = char]’
/usr/include/fmt/core.h:2075:54:   required from ‘std::__cxx11::basic_string<Char> fmt::v7::format(const S&, Args&& ...) [with S = char [65]; Args = {folly::Range<const char*>&}; Char = char]’
/data/msv/git/lib/facebook/folly/folly/IPAddress.cpp:97:47:   required from here
/data/msv/git/lib/facebook/folly/folly/Range.h:1558:42: error: passing ‘const fmt::v7::formatter<folly::Range<const char*> >’ as ‘this’ argument discards qualifiers [-fpermissive]
 1558 |     return formatter<string_view>::format(string_view{s.data(), s.size()}, ctx);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /data/msv/git/lib/facebook/folly/folly/FBString.h:34,
                 from /data/msv/git/lib/facebook/folly/folly/IPAddressV4.h:26,
                 from /data/msv/git/lib/facebook/folly/folly/IPAddress.h:28,
                 from /data/msv/git/lib/facebook/folly/folly/IPAddress.cpp:17:
/usr/include/fmt/format.h:3466:8: note:   in call to ‘decltype (ctx.out()) fmt::v7::formatter<T, Char, typename std::enable_if<(fmt::v7::detail::type_constant<T, Char>::value != fmt::v7::detail::type::custom_type), void>::type>::format(const T&, FormatContext&) [with FormatContext = fmt::v7::basic_format_context<fmt::v7::detail::buffer_appender<char>, char>; T = fmt::v7::basic_string_view<char>; Char = char; typename std::enable_if<(fmt::v7::detail::type_constant<T, Char>::value != fmt::v7::detail::type::custom_type), void>::type = void; decltype (ctx.out()) = fmt::v7::detail::buffer_appender<char>]’
 3466 |   auto format(const T& val, FormatContext& ctx) -> decltype(ctx.out()) {
      |        ^~~~~~
gmake[2]: *** [CMakeFiles/folly_base.dir/build.make:272: CMakeFiles/folly_base.dir/folly/IPAddress.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:4022: CMakeFiles/folly_base.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```