### PR TITLE
fix build with fmt on fedora (without runtime)

### DIFF
--- a/folly/experimental/test/AutoTimerTest.cpp
+++ b/folly/experimental/test/AutoTimerTest.cpp
@@ -58,7 +58,7 @@ TEST(TestAutoTimer, HandleBasicClosure) {
   timer.log("foo");
   ASSERT_EQ("foo", StubLogger::m);
   ASSERT_EQ(2, StubLogger::t);
-  timer.logFormat(fmt::runtime("bar {}"), 5e-2);
+  timer.logFormat(fmt::format("bar {}"), 5e-2);
   ASSERT_EQ("bar 0.05", StubLogger::m);
   ASSERT_EQ(0, StubLogger::t);
 }
@@ -70,7 +70,7 @@ TEST(TestAutoTimer, HandleBasic) {
   timer.log("foo");
   ASSERT_EQ("foo", StubLogger::m);
   ASSERT_EQ(2, StubLogger::t);
-  timer.logFormat(fmt::runtime("bar {}"), 5e-2);
+  timer.logFormat(fmt::format("bar {}"), 5e-2);
   ASSERT_EQ("bar 0.05", StubLogger::m);
   ASSERT_EQ(0, StubLogger::t);
 }


### PR DESCRIPTION
fmt::runtime not exist in system fmt lib on Fedora 34 (or some older fmt lib).
May be not really needed in this test ?
