### PR TITLE
fix non-existing ThrowsMessage in ExceptionWrapperTest

### DIFF
--- a/folly/test/ExceptionWrapperTest.cpp
+++ b/folly/test/ExceptionWrapperTest.cpp
@@ -78,9 +78,15 @@ TEST(ExceptionWrapper, throw_test) {
   std::vector<exception_wrapper> container;
   container.push_back(ew);
 
-  EXPECT_THAT(
-      [&]() { container[0].throw_exception(); },
-      ThrowsMessage<std::runtime_error>(StrEq("payload")));
+//   EXPECT_THAT(
+//       [&]() { container[0].throw_exception(); },
+//       ThrowsMessage<std::runtime_error>(StrEq("payload")));
+
+  try {
+    container[0].throw_exception();
+  } catch (std::runtime_error& outer) {
+    EXPECT_STREQ(outer.what(), "payload");
+  }
 }
 
 // Tests that when we call throw_with_nested, we can unnest it later.
@@ -92,9 +98,15 @@ TEST(ExceptionWrapper, throw_with_nested) {
   } catch (std::runtime_error& outer) {
     EXPECT_STREQ(outer.what(), "outer");
 
-    EXPECT_THAT(
-        [&]() { std::rethrow_if_nested(outer); },
-        ThrowsMessage<std::runtime_error>(StrEq("inner")));
+    // EXPECT_THAT(
+    //     [&]() { std::rethrow_if_nested(outer); },
+    //     ThrowsMessage<std::runtime_error>(StrEq("inner")));
+
+    try {
+      std::rethrow_if_nested(outer);
+    } catch (std::runtime_error& inner) {
+      EXPECT_STREQ(inner.what(), "inner");
+    }
   }
 }
 


### PR DESCRIPTION
ThrowsMessage not exist in folly lib, cleanup