### PR TITLE
fix errors and warnings in checked_mul

### DIFF
--- a/folly/lang/CheckedMath.h
+++ b/folly/lang/CheckedMath.h
@@ -169,18 +169,12 @@ bool checked_mul(T* result, T a, T b) {
 #elif _MSC_VER
   static_assert(sizeof(T) <= sizeof(unsigned __int64));
   if (sizeof(T) < sizeof(uint64_t)) {
-    return detail::generic_checked_small_mul(result, a, b);
+    return detail::generic_checked_mul(result, a, b);
   } else {
     unsigned __int64 high;
     unsigned __int64 low = _umul128(a, b, &high);
-    // unsigned right shift is guaranteed to be 0
-    // if sizeof(T) == sizeof(unsigned __int64)
-    if (FOLLY_UNLIKELY(low >> (sizeof(T) * 8) != 0)) {
-      *result = {};
-      return false;
-    }
     if (FOLLY_LIKELY(high == 0)) {
-      *result = low;
+      *result = static_cast<T>(low);
       return true;
     }
     *result = {};


### PR DESCRIPTION
Summary:
Fixes the following errors and warning under MSVC, observed via Github Actions CI:
```
folly/lang/CheckedMath.h(183): warning C4244: '=': conversion from 'unsigned __int64' to 'T', possible loss of data
!! Failed
        with
        [
            T=unsigned int
        ]
folly\lang\test\CheckedMathTest.cpp(128): note: see reference to function template instantiation 'bool folly::checked_mul<unsigned int,void>(T *,T,T)' being compiled
        with
        [
            T=unsigned int
        ]
folly/lang/CheckedMath.h(178): warning C4293: '>>': shift count negative or too big, undefined behavior
folly\lang\test\CheckedMathTest.cpp(144): note: see reference to function template instantiation 'bool folly::checked_mul<uint64_t,void>(T *,T,T)' being compiled
        with
        [
            T=uint64_t
        ]
folly/lang/CheckedMath.h(48): error C2607: static assertion failed
folly/lang/CheckedMath.h(172): note: see reference to function template instantiation 'bool folly::detail::generic_checked_small_mul<T,void>(T *,T,T)' being compiled
        with
        [
            T=uint64_t
        ]
folly\lang\test\CheckedMathTest.cpp(144): note: see reference to function template instantiation 'bool folly::checked_mul<uint64_t,void>(T *,T,T)' being compiled
        with
        [
            T=uint64_t
        ]
folly/lang/CheckedMath.h(50): warning C4293: '<<': shift count negative or too big, undefined behavior
```

Reviewed By: Orvid

Differential Revision: D35834411

