### PR TITLE
fix __noinline__ issue introduced by a HIP header

### DIFF
--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -186,6 +186,9 @@
 // noinline
 #ifdef _MSC_VER
 #define FOLLY_NOINLINE __declspec(noinline)
+#elif defined(__HIP_PLATFORM_HCC__)
+// HIP software stack defines its own __noinline__ macro.
+#define FOLLY_NOINLINE __attribute__((noinline))
 #elif defined(__GNUC__)
 #define FOLLY_NOINLINE __attribute__((__noinline__))
 #else


### PR DESCRIPTION
Summary:
## Problem

HIP, a C/C++ programming framework for AMD GPUs, cannot be compiled with folly because HIP's header wrongly overwrites `__noinline__` in by its own macro.

## Solution

When HIP is used (o.e., `__HIP_PLATFORM_HCC__` is defined), use another definition of `FOLLY_NOINLINE` in `CPortability.h`.

 `__HIP_PLATFORM_HCC__` is defined only when AMD HIP compiler is used, so there should be no side effect on other platforms.

Differential Revision: D35991506

