### PR TITLE
Properly forward Args to fmt::format in AutoTimer::logFormat

### DIFF
--- a/folly/experimental/AutoTimer.h
+++ b/folly/experimental/AutoTimer.h
@@ -96,9 +96,9 @@ class AutoTimer final {
   }
 
   template <typename... Args>
-  DoubleSeconds logFormat(Args&&... args) {
+  DoubleSeconds logFormat(fmt::format_string<Args...> s, Args&&... args) {
     auto now = Clock::now();
-    return logImpl(now, fmt::format(std::forward<Args>(args)...));
+    return logImpl(now, fmt::format(s, std::forward<Args>(args)...));
   }
 
  private:


### PR DESCRIPTION
Summary:
Fixes a C++20 compile time error in `AutoTimer::logFormat`

# Problem
With C++20, calling
```
timer.logFormat("{:d}",1);
```
Results in the following compile time error:
```
call to consteval function 'fmt::basic_format_string<char>::basic_format_string<char [5], 0>' is not a constant expression
```

# Solution
The call to the constructor of `fmt::format_string` needs to be a constant expression.
So `AutoTimer::logFormat` needs to take the first argument as a `fmt::format_string` instead of a generic type.

[See this post for reference](https://stackoverflow.com/questions/68675303/how-to-create-a-function-that-forwards-its-arguments-to-fmtformat-keeping-the).

Differential Revision: D36140324

