### PR TITLE
fix atomic_fetch_flip under MSVC

### DIFF
--- a/folly/synchronization/AtomicUtil-inl.h
+++ b/folly/synchronization/AtomicUtil-inl.h
@@ -222,8 +222,6 @@ inline bool atomic_fetch_reset_native(
 template <typename Atomic>
 inline bool atomic_fetch_flip_native(
     Atomic& atomic, std::size_t bit, std::memory_order mo) {
-  static_assert(!std::is_same<Atomic, std::atomic<std::uint32_t>>{}, "");
-  static_assert(!std::is_same<Atomic, std::atomic<std::uint64_t>>{}, "");
   return atomic_fetch_flip_fallback(atomic, bit, mo);
 }
 


### PR DESCRIPTION
Summary: There are static-asserts which are copy-pasted from similar functions but which are not applicable to this one.

Differential Revision: D36416227

