### PR TITLE
let small_vector handle MaxInline = 0 under MSVC

### DIFF
--- a/folly/container/test/heap_vector_types_test.cpp
+++ b/folly/container/test/heap_vector_types_test.cpp
@@ -636,7 +636,7 @@ TEST(HeapVectorTypes, Sizes) {
       sizeof(std::vector<std::pair<int, int>>));
   EXPECT_EQ(
       sizeof(small_heap_vector_map<int, int>),
-      sizeof(folly::small_vector<std::pair<int, int>, 0>));
+      sizeof(folly::small_vector<std::pair<int, int>, 0, uint32_t>));
 
   using SetT = heap_vector_set<
       int,

--- a/folly/small_vector.h
+++ b/folly/small_vector.h
@@ -1298,7 +1298,9 @@ class small_vector : public detail::small_vector_base<
     size_t allocationExtraBytes() const { return kHeapifyCapacitySize; }
   } FOLLY_SV_PACK_ATTR;
 
-  typedef aligned_storage_for_t<value_type[MaxInline]> InlineStorageDataType;
+  static constexpr size_t kMaxInlineNonZero = MaxInline ? MaxInline : 1u;
+  typedef aligned_storage_for_t<value_type[kMaxInlineNonZero]>
+      InlineStorageDataType;
 
   typedef typename std::conditional<
       sizeof(value_type) * MaxInline != 0,

--- a/folly/synchronization/AtomicUtil-inl.h
+++ b/folly/synchronization/AtomicUtil-inl.h
@@ -222,8 +222,6 @@ inline bool atomic_fetch_reset_native(
 template <typename Atomic>
 inline bool atomic_fetch_flip_native(
     Atomic& atomic, std::size_t bit, std::memory_order mo) {
-  static_assert(!std::is_same<Atomic, std::atomic<std::uint32_t>>{}, "");
-  static_assert(!std::is_same<Atomic, std::atomic<std::uint64_t>>{}, "");
   return atomic_fetch_flip_fallback(atomic, bit, mo);
 }
 


### PR DESCRIPTION
Summary:
MSVC does not permit zero-sized arrays (GCC and Clang permit them as a compiler extension) and enforces against them.

```
folly/small_vector.h(1301): error C2070: 'std::pair<int,const char *> [0]': illegal sizeof operand
```

Differential Revision: D36418283

