### PR TITLE
cut is_complete

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -625,27 +625,6 @@ FOLLY_INLINE_VARIABLE constexpr bool is_transparent_v =
 template <typename T>
 struct is_transparent : bool_constant<is_transparent_v<T>> {};
 
-namespace detail {
-template <typename T>
-using sizeof_t = decltype(sizeof(T));
-} // namespace detail
-
-//  is_complete_v
-//  is_complete
-//
-//  A trait to test if the provided type T is a complete type or not.
-//  See https://en.cppreference.com/w/cpp/language/type.
-//
-//  If is_complete_v<T> is used (possibly cv-ref qualified), then the type T
-//  must always be incomplete. That is, it's not safe to instantiate
-//  is_complete_v<T> on a forward-declared class type T and then again after the
-//  class T is defined. Doing so would be an ODR violation for is_complete_v.
-template <typename T>
-FOLLY_INLINE_VARIABLE constexpr bool is_complete_v =
-    Disjunction<is_detected<detail::sizeof_t, T>, std::is_function<T>>::value;
-template <typename T>
-struct is_complete : bool_constant<is_complete_v<T>> {};
-
 } // namespace folly
 
 /**

--- a/folly/container/test/heap_vector_types_test.cpp
+++ b/folly/container/test/heap_vector_types_test.cpp
@@ -636,7 +636,7 @@ TEST(HeapVectorTypes, Sizes) {
       sizeof(std::vector<std::pair<int, int>>));
   EXPECT_EQ(
       sizeof(small_heap_vector_map<int, int>),
-      sizeof(folly::small_vector<std::pair<int, int>, 0>));
+      sizeof(folly::small_vector<std::pair<int, int>, 0, uint32_t>));
 
   using SetT = heap_vector_set<
       int,

--- a/folly/small_vector.h
+++ b/folly/small_vector.h
@@ -1298,7 +1298,9 @@ class small_vector : public detail::small_vector_base<
     size_t allocationExtraBytes() const { return kHeapifyCapacitySize; }
   } FOLLY_SV_PACK_ATTR;
 
-  typedef aligned_storage_for_t<value_type[MaxInline]> InlineStorageDataType;
+  static constexpr size_t kMaxInlineNonZero = MaxInline ? MaxInline : 1u;
+  typedef aligned_storage_for_t<value_type[kMaxInlineNonZero]>
+      InlineStorageDataType;
 
   typedef typename std::conditional<
       sizeof(value_type) * MaxInline != 0,

--- a/folly/synchronization/AtomicUtil-inl.h
+++ b/folly/synchronization/AtomicUtil-inl.h
@@ -222,8 +222,6 @@ inline bool atomic_fetch_reset_native(
 template <typename Atomic>
 inline bool atomic_fetch_flip_native(
     Atomic& atomic, std::size_t bit, std::memory_order mo) {
-  static_assert(!std::is_same<Atomic, std::atomic<std::uint32_t>>{}, "");
-  static_assert(!std::is_same<Atomic, std::atomic<std::uint64_t>>{}, "");
   return atomic_fetch_flip_fallback(atomic, bit, mo);
 }
 

--- a/folly/test/TraitsTest.cpp
+++ b/folly/test/TraitsTest.cpp
@@ -343,23 +343,6 @@ TEST(Traits, is_detected_v) {
   EXPECT_FALSE((folly::is_detected_v<detector_find, double, char>));
 }
 
-TEST(Traits, is_complete) {
-  struct Incomplete;
-  struct Complete {};
-  enum FwdDeclaredEnum : int;
-  enum IncompleteEnum { IS_COMPLETE = folly::is_complete_v<IncompleteEnum> };
-
-  EXPECT_TRUE(folly::is_complete_v<Complete>);
-  EXPECT_FALSE(folly::is_complete_v<Incomplete>);
-  EXPECT_TRUE(folly::is_complete_v<FwdDeclaredEnum>);
-  EXPECT_FALSE(IncompleteEnum::IS_COMPLETE);
-  EXPECT_FALSE(folly::is_complete_v<const void>);
-  EXPECT_TRUE(folly::is_complete_v<int[10]>);
-  EXPECT_FALSE(folly::is_complete_v<int[]>);
-  EXPECT_FALSE(folly::is_complete_v<Incomplete[10]>);
-  EXPECT_TRUE(folly::is_complete_v<void()>);
-}
-
 TEST(Traits, aligned_storage_for_t) {
   struct alignas(2) Foo {
     char data[4];


### PR DESCRIPTION
Summary:
This is a dangerous trait that we do not really need.

Effectively reverts {D35615227 (https://github.com/facebook/folly/commit/ad7ec0b0e87b6441ad417345519e12d60b5f15b3)}.

Addresses the following build failure observed in the Github Actions build iunder Windows:

```
Test project Z:/build/folly
    Start 1823: traits_test.Traits.is_complete
1/1 Test #1823: traits_test.Traits.is_complete ...***Failed    0.02 sec
Note: Google Test filter = Traits.is_complete
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Traits
[ RUN      ] Traits.is_complete
D:\a\folly\folly\folly\test\TraitsTest.cpp(355): error: Value of: IncompleteEnum::IS_COMPLETE
  Actual: true
Expected: false
[  FAILED  ] Traits.is_complete (0 ms)
[----------] 1 test from Traits (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] Traits.is_complete

 1 FAILED TEST
```

Differential Revision: D36426055

