### PR TITLE
Use std::declval<A>() instead of A{} to workaround gcc-12 + CWG 903

### DIFF
--- a/folly/lang/SafeAssert.h
+++ b/folly/lang/SafeAssert.h
@@ -130,7 +130,7 @@ FOLLY_INLINE_VARIABLE constexpr safe_assert_msg_types_one_fn
     safe_assert_msg_types_one{}; // a function object to prevent extensions
 
 template <typename... A>
-safe_assert_msg_type_s<decltype(safe_assert_msg_types_one(A{}))::value...>
+safe_assert_msg_type_s<decltype(safe_assert_msg_types_one(std::declval<A>()))::value...>
 safe_assert_msg_types_seq_of(A...); // only used in unevaluated contexts
 
 template <typename>


### PR DESCRIPTION
- it is workaround CWG 903 in gcc-12, which is considering `int{}`  as null pointer constant, and so can't choose between `safe_assert_msg_types_one(uint64_t)` and `safe_assert_msg_types_one(char const *)`
- see https://godbolt.org/z/fov5xPjEe

closes #1772 