### PR TITLE
Add double conversion flags to folly json

### DIFF
--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -754,11 +754,12 @@ typename std::enable_if<
 toAppend(
     Src value,
     Tgt* result,
+    double_conversion::DoubleToStringConverter::Flags flags,
     double_conversion::DoubleToStringConverter::DtoaMode mode,
     unsigned int numDigits) {
   using namespace double_conversion;
   DoubleToStringConverter conv(
-      DoubleToStringConverter::NO_FLAGS,
+      flags,
       "Infinity",
       "NaN",
       'E',
@@ -797,7 +798,8 @@ typename std::enable_if<
     std::is_floating_point<Src>::value && IsSomeString<Tgt>::value>::type
 toAppend(Src value, Tgt* result) {
   toAppend(
-      value, result, double_conversion::DoubleToStringConverter::SHORTEST, 0);
+      value, result, double_conversion::DoubleToStringConverter::NO_FLAGS,
+      double_conversion::DoubleToStringConverter::SHORTEST, 0);
 }
 
 /**

--- a/folly/json.h
+++ b/folly/json.h
@@ -64,6 +64,7 @@ struct serialization_opts {
         sort_keys(false),
         skip_invalid_utf8(false),
         allow_nan_inf(false),
+        double_flags(double_conversion::DoubleToStringConverter::NO_FLAGS),
         double_mode(double_conversion::DoubleToStringConverter::SHORTEST),
         double_num_digits(0), // ignored when mode is SHORTEST
         double_fallback(false),
@@ -115,6 +116,7 @@ struct serialization_opts {
 
   // Options for how to print floating point values.  See Conv.h
   // toAppend implementation for floating point for more info
+  double_conversion::DoubleToStringConverter::Flags double_flags;
   double_conversion::DoubleToStringConverter::DtoaMode double_mode;
   unsigned int double_num_digits;
 


### PR DESCRIPTION
support passing double conversion flags when serializing json using folly.