### PR TITLE
Add double conversion flags to folly json

### DIFF
--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -646,9 +646,10 @@ typename std::enable_if<
 toAppend(
     Src value,
     Tgt* result,
-    double_conversion::DoubleToStringConverter::Flags flags,
     double_conversion::DoubleToStringConverter::DtoaMode mode,
-    unsigned int numDigits) {
+    unsigned int numDigits,
+    double_conversion::DoubleToStringConverter::Flags flags =
+        double_conversion::DoubleToStringConverter::NO_FLAGS) {
   using namespace double_conversion;
   DoubleToStringConverter conv(
       flags,
@@ -693,11 +694,7 @@ typename std::enable_if<
     std::is_floating_point<Src>::value && IsSomeString<Tgt>::value>::type
 toAppend(Src value, Tgt* result) {
   toAppend(
-      value,
-      result,
-      double_conversion::DoubleToStringConverter::NO_FLAGS,
-      double_conversion::DoubleToStringConverter::SHORTEST,
-      0);
+      value, result, double_conversion::DoubleToStringConverter::SHORTEST, 0);
 }
 
 /**

--- a/folly/Conv.h
+++ b/folly/Conv.h
@@ -646,11 +646,12 @@ typename std::enable_if<
 toAppend(
     Src value,
     Tgt* result,
+    double_conversion::DoubleToStringConverter::Flags flags,
     double_conversion::DoubleToStringConverter::DtoaMode mode,
     unsigned int numDigits) {
   using namespace double_conversion;
   DoubleToStringConverter conv(
-      DoubleToStringConverter::NO_FLAGS,
+      flags,
       "Infinity",
       "NaN",
       'E',
@@ -692,7 +693,11 @@ typename std::enable_if<
     std::is_floating_point<Src>::value && IsSomeString<Tgt>::value>::type
 toAppend(Src value, Tgt* result) {
   toAppend(
-      value, result, double_conversion::DoubleToStringConverter::SHORTEST, 0);
+      value,
+      result,
+      double_conversion::DoubleToStringConverter::NO_FLAGS,
+      double_conversion::DoubleToStringConverter::SHORTEST,
+      0);
 }
 
 /**

--- a/folly/json.cpp
+++ b/folly/json.cpp
@@ -118,7 +118,11 @@ struct Printer {
           }
         }
         toAppend(
-            v.asDouble(), &out_, opts_.double_mode, opts_.double_num_digits);
+            v.asDouble(),
+            &out_,
+            opts_.double_flags,
+            opts_.double_mode,
+            opts_.double_num_digits);
         break;
       case dynamic::INT64: {
         auto intval = v.asInt();

--- a/folly/json.cpp
+++ b/folly/json.cpp
@@ -120,9 +120,9 @@ struct Printer {
         toAppend(
             v.asDouble(),
             &out_,
-            opts_.double_flags,
             opts_.double_mode,
-            opts_.double_num_digits);
+            opts_.double_num_digits,
+            opts_.double_flags);
         break;
       case dynamic::INT64: {
         auto intval = v.asInt();

--- a/folly/json.h
+++ b/folly/json.h
@@ -109,11 +109,11 @@ struct serialization_opts {
 
   // Options for how to print floating point values.  See Conv.h
   // toAppend implementation for floating point for more info
-  double_conversion::DoubleToStringConverter::Flags double_flags{
-      double_conversion::DoubleToStringConverter::NO_FLAGS};
   double_conversion::DoubleToStringConverter::DtoaMode double_mode{
       double_conversion::DoubleToStringConverter::SHORTEST};
   unsigned int double_num_digits{0}; // ignored when mode is SHORTEST
+  double_conversion::DoubleToStringConverter::Flags double_flags{
+      double_conversion::DoubleToStringConverter::NO_FLAGS};
 
   // Fallback to double when a value that looks like integer is too big to
   // fit in an int64_t. Can result in loss a of precision.

--- a/folly/json.h
+++ b/folly/json.h
@@ -109,6 +109,8 @@ struct serialization_opts {
 
   // Options for how to print floating point values.  See Conv.h
   // toAppend implementation for floating point for more info
+  double_conversion::DoubleToStringConverter::Flags double_flags{
+      double_conversion::DoubleToStringConverter::NO_FLAGS};
   double_conversion::DoubleToStringConverter::DtoaMode double_mode{
       double_conversion::DoubleToStringConverter::SHORTEST};
   unsigned int double_num_digits{0}; // ignored when mode is SHORTEST


### PR DESCRIPTION
support `double-conversion` flags for folly json serialization