### PR TITLE
Fix EliasFanoCodingTest build issue on non-x86_64 systems

### DIFF
--- a/folly/experimental/EliasFanoCoding.h
+++ b/folly/experimental/EliasFanoCoding.h
@@ -39,10 +39,6 @@
 #include <folly/lang/Assume.h>
 #include <folly/lang/Bits.h>
 
-#if !FOLLY_X64
-#error EliasFanoCoding.h requires x86_64
-#endif
-
 namespace folly {
 namespace compression {
 


### PR DESCRIPTION
## Description

This is a fix for #1730 which I encountered on an M1 MacBook.

`EliasFanoCoding.h` was gated on only building if the system is `x86_64`, but this shouldn't be necessary because it has fallback implementations on other systems.

## Reproduction Steps

On an M1 Macbook or any non-x64 system, try to build the code from scratch, with tests enabled, per the README.

Without this fix, the build will fail with a message like this:

```
> make -j16
# ...
[ 54%] Building CXX object CMakeFiles/eliasfano_test.dir/folly/experimental/test/EliasFanoCodingTest.cpp.o
In file included from src/folly/folly/experimental/test/EliasFanoCodingTest.cpp:23:
In file included from src/folly/folly/Benchmark.h:19:
In file included from src/folly/folly/BenchmarkUtil.h:19:
In file included from src/folly/folly/Portability.h:21:
In file included from src/folly/folly/CPortability.h:22:
                                                        
In file included from src/folly/folly/experimental/test/EliasFanoCodingTest.cpp:25:
src/folly/folly/experimental/EliasFanoCoding.h:43:2: error: EliasFanoCoding.h requires x86_64
#error EliasFanoCoding.h requires x86_64
 ^
2 warnings and 1 error generated.
make[2]: *** [CMakeFiles/eliasfano_test.dir/folly/experimental/test/EliasFanoCodingTest.cpp.o] Error 1
make[1]: *** [CMakeFiles/eliasfano_test.dir/all] Error 2
make: *** [all] Error 2
```

With this change, all tests should build:

```
> make -j 16
# ...
[ 96%] Built target replaceable_test
[ 96%] Linking CXX executable eliasfano_test
Consolidate compiler generated dependencies of target unit_test
Consolidate compiler generated dependencies of target varint_test
Consolidate compiler generated dependencies of target traits_test
Consolidate compiler generated dependencies of target uri_test
Consolidate compiler generated dependencies of target blake2xb_test
[ 96%] Built target string_test
[ 96%] Built target sorted_vector_types_test
[ 97%] Built target synchronized_test
[ 98%] Built target small_vector_test
[ 98%] Built target singleton_test_global
Consolidate compiler generated dependencies of target lt_hash_test
[ 98%] Built target thread_cached_int_test
[ 98%] Built target unit_test
[ 98%] Built target try_test
[ 98%] Built target traits_test
[ 99%] Built target token_bucket_test
[ 99%] Built target blake2xb_test
[100%] Built target timeout_queue_test
[100%] Built target varint_test
[100%] Built target thread_local_test
[100%] Built target lt_hash_test
[100%] Built target uri_test
[100%] Built target eliasfano_test
```