### PR TITLE
Fix cancellation of ServerSocket::accept()

### DIFF
--- a/folly/io/coro/ServerSocket.cpp
+++ b/folly/io/coro/ServerSocket.cpp
@@ -105,13 +105,14 @@ Task<std::unique_ptr<Transport>> ServerSocket::accept() {
   socket_->addAcceptCallback(&cb, nullptr);
   socket_->startAccepting();
   auto cancelToken = co_await folly::coro::co_current_cancellation_token;
-  CancellationCallback cancellationCallback{cancelToken, [&baton, this] {
-                                              this->socket_->stopAccepting();
-                                              baton.post();
-                                            }};
+  CancellationCallback cancellationCallback{
+      cancelToken, [&baton] { baton.post(); }};
 
   co_await baton;
-  co_await folly::coro::co_safe_point;
+  if (cancelToken.isCancellationRequested()) {
+    socket_->stopAccepting();
+    co_yield co_cancelled;
+  }
   if (cb.error) {
     co_yield co_error(std::move(cb.error));
   }

--- a/folly/io/coro/test/TransportTest.cpp
+++ b/folly/io/coro/test/TransportTest.cpp
@@ -24,7 +24,6 @@
 #include <folly/io/coro/ServerSocket.h>
 #include <folly/io/coro/Transport.h>
 #include <folly/portability/GTest.h>
-#include <folly/synchronization/detail/Sleeper.h>
 
 #if FOLLY_HAS_COROUTINES
 
@@ -304,11 +303,7 @@ TEST_F(TransportTest, AcceptCancelled) {
 TEST_F(TransportTest, RequestCancellationInAnotherThread) {
   auto ass = AsyncServerSocket::newSocket(&evb);
   std::thread anotherThread([&] {
-    folly::detail::Sleeper sleeper;
-    while (!ass->getAccepting()) {
-      sleeper.wait();
-    }
-    std::this_thread::sleep_for(5ms);
+    std::this_thread::sleep_for(10ms);
     cancelSource.requestCancellation();
   });
 


### PR DESCRIPTION
Now the cancellation callback is run in caller thread. But `AsyncServerSocket::stopAccepting` will do `dcheckIsInEventBaseThread`.
Therefore move `AsyncServerSocket::stopAccepting` out of the callback function.