### PR TITLE
Disable execstack for sure

### DIFF
--- a/folly/memcpy.S
+++ b/folly/memcpy.S
@@ -458,8 +458,8 @@ __folly_memcpy:
 #endif
 
         .ident "GCC: (GNU) 4.8.2"
+
+#endif
 #ifdef __linux__
         .section .note.GNU-stack,"",@progbits
-#endif
-
 #endif

--- a/folly/memset.S
+++ b/folly/memset.S
@@ -240,3 +240,6 @@ LABEL(none_or_one):
 #endif // FOLLY_MEMSET_IS_MEMSET
 
 #endif // __AVX2__
+#ifdef __linux__
+        .section .note.GNU-stack,"",@progbits
+#endif


### PR DESCRIPTION
libfolly is flagged by rpmlint (in e.g. openSUSE) for being unsafe:

```
[  410s] libfolly-v2022_05_23_00.x86_64: E: executable-stack (Badness: 10000) /usr/lib64/libfolly.so.v2022.05.23.00
[  410s] The binary declares the stack as executable. Executable stack is usually an
[  410s] error as it is only needed if the code contains GCC trampolines or similar
[  410s] constructs which uses code on the stack. One common source for needlessly
[  410s] executable stack cases are object files built from assembler files which don't
[  410s] define a proper .note.GNU-stack section.
```

Resolve that.