### PR TITLE
upgrade getdeps GitHub actions to Ubuntu 20

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Fetch boost

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1115,7 +1115,7 @@ jobs:
             help="Allow CI to fire on all branches - Handy for testing",
         )
         parser.add_argument(
-            "--ubuntu-version", default="18.04", help="Version of Ubuntu to use"
+            "--ubuntu-version", default="20.04", help="Version of Ubuntu to use"
         )
         parser.add_argument(
             "--main-branch",


### PR DESCRIPTION
Summary:
Sadly, even though Ubuntu 18.04 is still in LTS, GitHub is deprecating
its runner image.

Migrate the generated GitHub Actions to 20.04.

https://github.com/actions/runner-images/issues/6002

https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Reviewed By: fanzeyi

Differential Revision: D38877286

