### PR TITLE
Fixes necessary to build benchmark tests on OSX Monterey

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1032,8 +1032,8 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       TEST padded_test SOURCES PaddedTest.cpp
       #TEST poly_test SOURCES PolyTest.cpp
       TEST portability_test SOURCES PortabilityTest.cpp
-      BENCHMARK producer_consumer_queue_benchmark
-        SOURCES ProducerConsumerQueueBenchmark.cpp
+      # Turns out this benchmark uses Linux only API for setting CPU affinity i.e. cpu_set_t.
+      BENCHMARK producer_consumer_queue_benchmark APPLE_DISABLED SOURCES ProducerConsumerQueueBenchmark.cpp
       TEST producer_consumer_queue_test SLOW
         SOURCES ProducerConsumerQueueTest.cpp
       BENCHMARK range_find_benchmark SOURCES RangeFindBenchmark.cpp

--- a/folly/futures/test/Benchmark.cpp
+++ b/folly/futures/test/Benchmark.cpp
@@ -278,6 +278,10 @@ void throwWrappedAndCatchWrappedImpl() {
       });
 }
 
+// Apparently OSX doesn't implement barriers since it is an optional part of
+// POSIX realtime threads extension, therefore we test for its presence.
+// Details: https://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap02.html
+#if defined(_POSIX_BARRIERS) &&  (_POSIX_BARRIERS > 0)
 // Simulate heavy contention on func
 void contend(void (*func)()) {
   folly::BenchmarkSuspender s;
@@ -302,6 +306,7 @@ void contend(void (*func)()) {
   s.rehire();
   pthread_barrier_destroy(&barrier);
 }
+#endif
 
 BENCHMARK(throwAndCatch) {
   throwAndCatchImpl();
@@ -321,6 +326,7 @@ BENCHMARK_RELATIVE(throwWrappedAndCatchWrapped) {
 
 BENCHMARK_DRAW_LINE();
 
+#if defined(_POSIX_BARRIERS) &&  (_POSIX_BARRIERS > 0)
 BENCHMARK(throwAndCatchContended) {
   contend(throwAndCatchImpl);
 }
@@ -336,8 +342,8 @@ BENCHMARK_RELATIVE(throwWrappedAndCatchContended) {
 BENCHMARK_RELATIVE(throwWrappedAndCatchWrappedContended) {
   contend(throwWrappedAndCatchWrappedImpl);
 }
-
 BENCHMARK_DRAW_LINE();
+#endif
 
 namespace {
 struct Bulky {

--- a/folly/test/ProducerConsumerQueueBenchmark.cpp
+++ b/folly/test/ProducerConsumerQueueBenchmark.cpp
@@ -49,6 +49,9 @@ struct ThroughputTest {
       cpu_set_t cpuset;
       CPU_ZERO(&cpuset);
       CPU_SET(cpu0_, &cpuset);
+      /* TODO(cavalcanti): enable this bench on OSX and use pthread_set_qos_self_np for handling
+       * big.LITTLE macs.
+       */
       pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
     }
     for (int i = 0; i < iters_; ++i) {


### PR DESCRIPTION
ToT (Top of Tree) will fail to build if benchmarks are enabled (i.e.  cmake ../ -DBUILD_BENCHMARKS=ON) on Monterey with clang++ 13.1.6.

This patchset will fix the build.


