### PR TITLE
Fix iouring under 32-bit linux

### DIFF
--- a/folly/experimental/io/IoUringBackend.h
+++ b/folly/experimental/io/IoUringBackend.h
@@ -381,17 +381,10 @@ class IoUringBackend : public EventBaseBackendBase {
   };
 
   struct UserData {
-    uint64_t value;
-    explicit UserData(uint64_t i) noexcept : value{i} {}
-    template <
-        typename T = int,
-        std::enable_if_t<sizeof(void*) == sizeof(uint64_t), T> = 0>
+    uintptr_t value;
     explicit UserData(void* p) noexcept
         : value{reinterpret_cast<uintptr_t>(p)} {}
     /* implicit */ operator uint64_t() const noexcept { return value; }
-    template <
-        typename T = int,
-        std::enable_if_t<sizeof(void*) == sizeof(uint64_t), T> = 0>
     /* implicit */ operator void*() const noexcept {
       return reinterpret_cast<void*>(value);
     }


### PR DESCRIPTION
Summary:
The workaround for a different bug was explicitly restricting this code to 64-bit systems, but supporting them is trivial as long as we require UserData to be initialized from a pointer, which is fine since that was the only way it was being used.
Fixes: https://github.com/facebook/folly/issues/1850

Differential Revision: D39109122

