### PR TITLE
Inline a method to save two hot load instructions.

### DIFF
--- a/folly/io/IOBuf.h
+++ b/folly/io/IOBuf.h
@@ -1217,9 +1217,13 @@ class IOBuf {
    * Returns ByteRange that points to the data IOBuf stores.
    */
   ByteRange coalesce() {
-    const std::size_t newHeadroom = headroom();
-    const std::size_t newTailroom = prev()->tailroom();
-    return coalesceWithHeadroomTailroom(newHeadroom, newTailroom);
+    if (isChained()) {
+      const std::size_t newHeadroom = headroom();
+      const std::size_t newTailroom = prev()->tailroom();
+      coalesceAndReallocate(
+          newHeadroom, computeChainDataLength(), this, newTailroom);
+    }
+    return ByteRange(data_, length_);
   }
 
   /**


### PR DESCRIPTION
Summary:
Inline coalesceWithHeadroomTailroom into coalesce to save two loads. The
profile information shows that we usually don't enter the if inside the
'tailroom' function, and the compiler can't sinkt the two method calls, so the
two loads are wasted. Sinking the two loads/method-calls into the the body of
the IF should allow us to avoid the cost of the hot loads.

Differential Revision: D39221756

