### PR TITLE
Avoid calling clock::now in the common case.

### DIFF
--- a/folly/synchronization/detail/Spin.h
+++ b/folly/synchronization/detail/Spin.h
@@ -41,6 +41,10 @@ spin_result spin_pause_until(
     return spin_result::advance;
   }
 
+  if (f()) {
+    return spin_result::success;
+  }
+
   auto tbegin = Clock::now();
   while (true) {
     if (f()) {


### PR DESCRIPTION
Summary:
Avoid calling clock::now in the common case.

Clock::now() can be an expensive call (a call to libc's __clock_gettime). PGO
data shows that the first check almost always succeeds, which makes the call to
Clock::now redundant. This patch peels one iteration that calls f() before
calling clock::now(). Notice that a very common use of this API is a function
that performs a single load in the function, so timing is not a major concern.

Differential Revision: D39611860

