### PR TITLE
Swap positions of `ptr` and `extra` in PackedSyncPtr

### DIFF
--- a/folly/PackedSyncPtr.h
+++ b/folly/PackedSyncPtr.h
@@ -77,7 +77,7 @@ class PackedSyncPtr {
   void init(T* initialPtr = nullptr, uint16_t initialExtra = 0) {
     auto intPtr = reinterpret_cast<uintptr_t>(initialPtr);
     CHECK(!(intPtr >> 48));
-    data_.init(intPtr);
+    data_.init(intPtr << 16);
     setExtra(initialExtra);
   }
 
@@ -88,9 +88,8 @@ class PackedSyncPtr {
    */
   void set(T* t) {
     auto intPtr = reinterpret_cast<uintptr_t>(t);
-    auto shiftedExtra = uintptr_t(extra()) << 48;
     CHECK(!(intPtr >> 48));
-    data_.setData(intPtr | shiftedExtra);
+    data_.setData((intPtr << 16) | uintptr_t(extra()));
   }
 
   /*
@@ -101,7 +100,7 @@ class PackedSyncPtr {
    * without locking.
    */
   T* get() const {
-    return reinterpret_cast<T*>(data_.getData() & (-1ull >> 16));
+    return reinterpret_cast<T*>(data_.getData() >> 16);
   }
   T* operator->() const { return get(); }
   reference operator*() const { return *get(); }
@@ -118,7 +117,7 @@ class PackedSyncPtr {
    *
    * It is ok to call this without holding the lock.
    */
-  uint16_t extra() const { return data_.getData() >> 48; }
+  uint16_t extra() const { return data_.getData() & 0xffff; }
 
   /*
    * Don't try to put anything into this that has the high bit set:
@@ -128,12 +127,12 @@ class PackedSyncPtr {
    */
   void setExtra(uint16_t extra) {
     CHECK(!(extra & 0x8000));
-    auto ptr = data_.getData() & (-1ull >> 16);
-    data_.setData((uintptr_t(extra) << 48) | ptr);
+    auto ptr = data_.getData();
+    data_.setData(uintptr_t(extra) | (ptr & (-1ull << 16)));
   }
 
  private:
-  PicoSpinLock<uintptr_t> data_;
+  PicoSpinLock<uintptr_t, 15> data_;
 } FOLLY_PACK_ATTR;
 
 static_assert(


### PR DESCRIPTION
Summary:
Change layout:
    [63:48][47:0] ->  [63:16][ 15:0]
    [extra][ ptr] ->  [  ptr][extra]

Previous PackedSyncPtr was organized s.t:
    [63:48][47:0]
    [extra][ ptr]

So access pointer required a 48-bit bitmask:
    `data_.getData() & (-1ull >> 16)`

This isn't great on x86 because imm operands max out at imm32 so this requires two instructions:
    1. movabs + and
    2. movl + andn

Either way its almost certainly cheaper to just just a shift which can be done by swap the placements of `extra` and `ptr` s.t:
    [63:16][ 15:0]
    [  ptr][extra]

As a slightly plus, `extra` can also be accessed essentially for free with `movzwl` (which can move-elim).

On aarch64 `get()` might be slightly more expensive now (and `extra()` correspondingly cheaper) because `lsl` is sometimes slightly slower than `and`.