### PR TITLE
Overview.md: Fix link to an external paper

### DIFF
--- a/folly/docs/Overview.md
+++ b/folly/docs/Overview.md
@@ -41,7 +41,7 @@ interface.
 
 An implementation of the structure described in [A Provably Correct
 Scalable Concurrent Skip
-List](http://www.cs.tau.ac.il/~shanir/nir-pubs-web/Papers/OPODIS2006-BA.pdf)
+List](http://people.csail.mit.edu/shanir/publications/OPODIS2006-BA.pdf)
 by Herlihy et al.
 
 #### [`Conv.h`](Conv.md)


### PR DESCRIPTION
Summary: The link to "A Provably Correct Scalable Skip List" was no longer valid