### PR TITLE
Fix cache_locality_test.Getcpu.VdsoGetcpu on aarch64

### DIFF
--- a/folly/concurrency/test/CacheLocalityTest.cpp
+++ b/folly/concurrency/test/CacheLocalityTest.cpp
@@ -1034,10 +1034,13 @@ TEST(CacheLocality, BenchmarkSysfs) {
 
 #if defined(FOLLY_HAVE_LINUX_VDSO) && !defined(FOLLY_SANITIZE_MEMORY)
 TEST(Getcpu, VdsoGetcpu) {
-  unsigned cpu;
-  Getcpu::resolveVdsoFunc()(&cpu, nullptr, nullptr);
+  Getcpu::Func func = Getcpu::resolveVdsoFunc();
+  if (func != nullptr) {
+    unsigned cpu;
+    func(&cpu, nullptr, nullptr);
 
-  EXPECT_TRUE(cpu < CPU_SETSIZE);
+    EXPECT_TRUE(cpu < CPU_SETSIZE);
+  }
 }
 #endif
 


### PR DESCRIPTION
Summary:
```Getcpu::resolveVdsoFunc()``` will return null when the vdso does not contain the function ```__vdso_getcpu```, which it does only on x86_64. The test was assuming a non-null return, resulting in segfaults on other platforms such as aarch64.

Testing:
I tested this change on x86 and aarch64, both Ubuntu 22.

Example failure on aarch64 before the change:
```
7/9 Test  #322: cache_locality_test.Getcpu.VdsoGetcpu ......................***Exception: SegFault  0.11 sec
Note: Google Test filter = Getcpu.VdsoGetcpu
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Getcpu
[ RUN      ] Getcpu.VdsoGetcpu
*** Aborted at 1670948200 (Unix time, try 'date -d @1670948200') ***
*** Signal 11 (SIGSEGV) (0x0) received by PID 54696 (pthread TID 0xffffb5236020) (linux TID 54696) (code: address not mapped to object), stack trace: ***
(error retrieving stack trace)
```