### PR TITLE
Fix folly::__folly_memcpy on non-AVX2 platforms

### DIFF
--- a/folly/FollyMemcpy.cpp
+++ b/folly/FollyMemcpy.cpp
@@ -20,8 +20,8 @@
 namespace folly {
 
 extern "C" void* __folly_memcpy(
-    void* __restrict dst, const void* __restrict src, std::size_t size) {
-  return std::memcpy(dst, src, size);
+    void* dst, const void* src, std::size_t size) {
+  return std::memmove(dst, src, size);
 }
 
 } // namespace folly

--- a/folly/FollyMemcpy.h
+++ b/folly/FollyMemcpy.h
@@ -21,6 +21,6 @@
 namespace folly {
 
 extern "C" void* __folly_memcpy(
-    void* __restrict dst, const void* __restrict src, std::size_t size);
+    void* dst, const void* src, std::size_t size);
 
 } // namespace folly


### PR DESCRIPTION
**Important note:**
I decided to resolve this by making the non-AVX2 case match AVX2, since there had been significant investment in assembly and unit test code towards that behavior, versus a single line invested in the fallback. Changing the behavior in the AVX2 case seems unlikely (and incompatible), so if the desire is to leave memcpy semantics for the non-AVX2 case, then the unit test will instead need adjustments to exclude overlap cases there.

Summary:
When AVX2 is available, ```__folly_memcpy``` is implemented in x86 assembly (```folly/memcpy.S```). This implementation "acts as a memmove" according to its comments and according to the ```folly_memcpy.overlap``` test, which explicitly tests overlap scenarios. However, the non-AVX2 path was delegating to ```std::memcpy```, which is not safe under overlap conditions. This change switches that case to ```std::memmove```, making it consistent with the assembly implementation and unit tests.

Testing:
I tested this change on x86 and aarch64, both Ubuntu 22.

Example failure on aarch64 before the change:
```
5/7 Test #2413: memcpy_test.folly_memcpy.overlap ...........................***Failed    0.04 sec
Note: Google Test filter = folly_memcpy.overlap
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from folly_memcpy
[ RUN      ] folly_memcpy.overlap
/home/ubuntu/folly-Memcpy/folly/test/MemcpyTest.cpp:146: Failure
Expected equality of these values:
  *(copy_buf.data() + kStartIndex + overlap_offset + i)
    Which is: 'w' (119, 0x77)
  *(check_buf.data() + i)
    Which is: '\x18' (24)
Error after __folly_memcpy(src + 1000 + 33, src + 1000, 129) at index i = 48
[  FAILED  ] folly_memcpy.overlap (33 ms)
[----------] 1 test from folly_memcpy (33 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (33 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] folly_memcpy.overlap
```