### PR TITLE
asm_volatile_pause: use isb on aarch64

### DIFF
--- a/folly/portability/Asm.h
+++ b/folly/portability/Asm.h
@@ -39,7 +39,9 @@ inline void asm_volatile_pause() {
 #elif defined(__i386__) || FOLLY_X64 || \
     (defined(__mips_isa_rev) && __mips_isa_rev > 1)
   asm volatile("pause");
-#elif FOLLY_AARCH64 || (defined(__arm__) && !(__ARM_ARCH < 7))
+#elif FOLLY_AARCH64
+  asm volatile("isb");
+#elif (defined(__arm__) && !(__ARM_ARCH < 7))
   asm volatile("yield");
 #elif FOLLY_PPC64
   asm volatile("or 27,27,27");


### PR DESCRIPTION
Summary:
On aarch64, we've found ```isb``` to be a better analogue to the x86 ```pause``` instruction. The ```SpinLock.TryLock``` test/microbenchmark shows a one to two order-of-magnitude reduction in runtime (its runtime is highly variable with and without this change due to its very race-y nature).

Testing:
I ran this on aarch64 with Ubuntu 22. Sample runtimes of ```SpinLock.TryLock``` before:
```
[       OK ] SpinLock.TryLock (50903 ms)
```
```
[       OK ] SpinLock.TryLock (32773 ms)
```
```
[       OK ] SpinLock.TryLock (70178 ms)
```
and after:
```
[       OK ] SpinLock.TryLock (728 ms)
```
```
[       OK ] SpinLock.TryLock (2003 ms)
```
```
[       OK ] SpinLock.TryLock (2 ms)
```
