### PR TITLE
std::-qualify **`move`** & **`forward`** in 5 files starting w/ folly/concurrency/test/AtomicSharedPtrPerformance.cpp

### DIFF
--- a/folly/concurrency/test/AtomicSharedPtrPerformance.cpp
+++ b/folly/concurrency/test/AtomicSharedPtrPerformance.cpp
@@ -150,12 +150,22 @@ void contended_read_write(
   for (size_t i = 0; i < readers; ++i) {
     unique_lock<mutex> ulock(lock);
     threads.emplace_back(
-        &read_asp<T>, move(ulock), ref(cvar), ref(go), ref(aptr), readOrder);
+        &read_asp<T>,
+        std::move(ulock),
+        ref(cvar),
+        ref(go),
+        ref(aptr),
+        readOrder);
   }
   for (size_t i = 0; i < writers; ++i) {
     unique_lock<mutex> ulock(lock);
     threads.emplace_back(
-        &write_asp<T>, move(ulock), ref(cvar), ref(go), ref(aptr), writeOrder);
+        &write_asp<T>,
+        std::move(ulock),
+        ref(cvar),
+        ref(go),
+        ref(aptr),
+        writeOrder);
   }
   unique_lock<mutex> ulock(lock);
   ulock.unlock();

--- a/folly/test/FBStringTest.cpp
+++ b/folly/test/FBStringTest.cpp
@@ -1043,7 +1043,7 @@ void clause11_21_4_8_1_l(String& test) {
   randomString(&s, maxString);
   String s1;
   randomString(&s1, maxString);
-  test = move(s) + s1.c_str();
+  test = std::move(s) + s1.c_str();
 }
 
 // Numbering here is from C++11

--- a/folly/test/stl_tests/StlVectorTest.cpp
+++ b/folly/test/stl_tests/StlVectorTest.cpp
@@ -2785,7 +2785,7 @@ STL_TEST("23.2.3 Table 101.8", pushBackRV, is_move_constructible, a, t) {
   auto am = a.get_allocator();
 
   try {
-    a.push_back(move(t));
+    a.push_back(std::move(t));
   } catch (...) {
     ASSERT_TRUE(dsa == a) << "failed strong exception guarantee";
     throw;


### PR DESCRIPTION
Summary:
With LLVM-15, we require that `move` be qualified as `std::move` (and same with `forward`). This fixes that in this file.

The use of an unqualified `move`/`forward` often means that a `using namespace std` is present in a file. Bitter experience has shown that `using namespace std` causes severe problems in header (`.h`) files and even in implementation files (`.cpp`) and therefore is a kind of tech debt. This diff removes such debt.

Our "use after move" linter also only inspects `std::move`/`std::forward`. Therefore, adding appropriate qualifications makes our code safer by allowing the linter to detect problematic instances.

Please see T140686815 for FAQ.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: luciang

Differential Revision: D42253382

