### PR TITLE
io_uring: guard io_uring_enable_rings by liburing version

### DIFF
--- a/folly/experimental/io/IoUringBackend.cpp
+++ b/folly/experimental/io/IoUringBackend.cpp
@@ -1358,10 +1358,16 @@ void IoUringBackend::delayedInit() {
   needsDelayedInit_ = false;
 
   if (usingDeferTaskrun_) {
+    // usingDeferTaskrun_ is guarded already on having an up to date liburing
+#if FOLLY_IO_URING_UP_TO_DATE
     int ret = ::io_uring_enable_rings(&ioRing_);
     if (ret) {
       LOG(ERROR) << "io_uring_enable_rings gave " << folly::errnoStr(-ret);
     }
+#else
+    LOG(ERROR)
+        << "Unexpectedly usingDeferTaskrun_=true, but liburing does not support it?";
+#endif
     initSubmissionLinked();
   }
 


### PR DESCRIPTION
Summary:
io_uring_enable_rings is newer than expected, so only call it if compiling against a later version.

This is a no-op anyway, as defer_taskrun is already gated on this.

Differential Revision: D42383230

