### PR TITLE
suppress violations of gcc warning tautological-pointer-compare

### DIFF
--- a/folly/detail/MemoryIdler.cpp
+++ b/folly/detail/MemoryIdler.cpp
@@ -47,7 +47,8 @@ void MemoryIdler::flushLocalMallocCaches() {
   if (!usingJEMalloc()) {
     return;
   }
-  if (!mallctl || !mallctlnametomib || !mallctlbymib) {
+  if (&mallctl == nullptr || &mallctlnametomib == nullptr ||
+      &mallctlbymib == nullptr) {
     FB_LOG_EVERY_MS(ERROR, 10000) << "mallctl* weak link failed";
     return;
   }

--- a/folly/experimental/JemallocNodumpAllocator.cpp
+++ b/folly/experimental/JemallocNodumpAllocator.cpp
@@ -106,11 +106,11 @@ bool JemallocNodumpAllocator::extend_and_setup_arena() {
 }
 
 void* JemallocNodumpAllocator::allocate(size_t size) {
-  return mallocx != nullptr ? mallocx(size, flags_) : malloc(size);
+  return &mallocx != nullptr ? mallocx(size, flags_) : malloc(size);
 }
 
 void* JemallocNodumpAllocator::reallocate(void* p, size_t size) {
-  return rallocx != nullptr ? rallocx(p, size, flags_) : realloc(p, size);
+  return &rallocx != nullptr ? rallocx(p, size, flags_) : realloc(p, size);
 }
 
 #ifdef FOLLY_JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED
@@ -153,12 +153,12 @@ void* JemallocNodumpAllocator::alloc(
 #endif // FOLLY_JEMALLOC_NODUMP_ALLOCATOR_SUPPORTED
 
 void JemallocNodumpAllocator::deallocate(void* p, size_t) {
-  dallocx != nullptr ? dallocx(p, flags_) : free(p);
+  &dallocx != nullptr ? dallocx(p, flags_) : free(p);
 }
 
 void JemallocNodumpAllocator::deallocate(void* p, void* userData) {
   const auto flags = reinterpret_cast<uint64_t>(userData);
-  dallocx != nullptr ? dallocx(p, static_cast<int>(flags)) : free(p);
+  &dallocx != nullptr ? dallocx(p, static_cast<int>(flags)) : free(p);
 }
 
 JemallocNodumpAllocator& globalJemallocNodumpAllocator() {

--- a/folly/memory/Malloc.h
+++ b/folly/memory/Malloc.h
@@ -100,10 +100,10 @@ FOLLY_NOINLINE inline bool usingJEMalloc() noexcept {
     // Some platforms (*cough* OSX *cough*) require weak symbol checks to be
     // in the form if (mallctl != nullptr). Not if (mallctl) or if (!mallctl)
     // (!!). http://goo.gl/xpmctm
-    if (mallocx == nullptr || rallocx == nullptr || xallocx == nullptr ||
-        sallocx == nullptr || dallocx == nullptr || sdallocx == nullptr ||
-        nallocx == nullptr || mallctl == nullptr ||
-        mallctlnametomib == nullptr || mallctlbymib == nullptr) {
+    if (&mallocx == nullptr || &rallocx == nullptr || &xallocx == nullptr ||
+        &sallocx == nullptr || &dallocx == nullptr || &sdallocx == nullptr ||
+        &nallocx == nullptr || &mallctl == nullptr ||
+        &mallctlnametomib == nullptr || &mallctlbymib == nullptr) {
       return false;
     }
 
@@ -177,7 +177,7 @@ FOLLY_NOINLINE inline bool usingTCMalloc() noexcept {
     // in the form if (mallctl != nullptr). Not if (mallctl) or if (!mallctl)
     // (!!). http://goo.gl/xpmctm
     if (MallocExtension_Internal_GetNumericProperty == nullptr ||
-        sdallocx == nullptr || nallocx == nullptr) {
+        &sdallocx == nullptr || &nallocx == nullptr) {
       return false;
     }
     static const char kAllocBytes[] = "generic.current_allocated_bytes";


### PR DESCRIPTION
This suppresses several gcc warning violations of the form:
  warning: comparison of function '{...}' not equal to a null pointer is always true [-Wtautological-pointer-compare]

It is documentsed that the warning may be suppressed by using `&` and comparing the address of the function to a null pointer, rather than comparing the function directly to a null pointer.