### PR TITLE
io_uring: implement io_uring_enable_rings locally

### DIFF
--- a/folly/experimental/io/IoUringBackend.cpp
+++ b/folly/experimental/io/IoUringBackend.cpp
@@ -56,6 +56,20 @@ namespace folly {
 
 namespace {
 
+#if FOLLY_IO_URING_UP_TO_DATE
+int ioUringEnableRings(FOLLY_MAYBE_UNUSED struct io_uring* ring) {
+  // Ideally this would call ::io_uring_enable_rings directly which just runs
+  // the below however this was missing from a stable version of liburing, which
+  // means that some distributions were not able to compile it. see
+  // https://github.com/axboe/liburing/issues/773
+
+  // since it is so simple, just implement it here until the fix rolls out to an
+  // acceptable number of OSS distributions.
+  return ::io_uring_register(
+      ring->ring_fd, IORING_REGISTER_ENABLE_RINGS, NULL, 0);
+}
+#endif
+
 struct SignalRegistry {
   struct SigInfo {
     struct sigaction sa_ {};
@@ -1360,7 +1374,7 @@ void IoUringBackend::delayedInit() {
   if (usingDeferTaskrun_) {
     // usingDeferTaskrun_ is guarded already on having an up to date liburing
 #if FOLLY_IO_URING_UP_TO_DATE
-    int ret = ::io_uring_enable_rings(&ioRing_);
+    int ret = ioUringEnableRings(&ioRing_);
     if (ret) {
       LOG(ERROR) << "io_uring_enable_rings gave " << folly::errnoStr(-ret);
     }


### PR DESCRIPTION
Summary:
io_uring_enable_rings was missing from liburing upstream (see https://github.com/axboe/liburing/issues/773) which is breaking the open source build. See https://github.com/facebook/folly/issues/1908

Instead just implement it locally, as it's trivial

Differential Revision: D42497664

