### PR TITLE
fix Range specialization of fmt::formatter under fmt v7

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -1604,10 +1604,17 @@ template <>
 struct formatter<folly::StringPiece> : private formatter<string_view> {
   using formatter<string_view>::parse;
 
+#if FMT_VERSION >= 80000
   template <typename Context>
   typename Context::iterator format(folly::StringPiece s, Context& ctx) const {
     return formatter<string_view>::format({s.data(), s.size()}, ctx);
   }
+#else
+  template <typename Context>
+  typename Context::iterator format(folly::StringPiece s, Context& ctx) {
+    return formatter<string_view>::format({s.data(), s.size()}, ctx);
+  }
+#endif
 };
 } // namespace fmt
 #endif


### PR DESCRIPTION
The `fmt::formatter<...>::format` member was non-`const` prior to `fmt` v8 and `const` starting with `fmt` v8.