### PR TITLE
Eliminate a copy on get_shared_ptr.

### DIFF
--- a/folly/concurrency/AtomicSharedPtr.h
+++ b/folly/concurrency/AtomicSharedPtr.h
@@ -311,7 +311,7 @@ class atomic_shared_ptr {
       auto aliasedp =
           CountedDetail::template get_shared_ptr_from_counted_base<SharedPtr>(
               p.get());
-      res = *aliasedp;
+      return *aliasedp;
     }
     return res;
   }


### PR DESCRIPTION
Summary: Eliminate a copy on get_shared_ptr.

Differential Revision: D42944929

