### PR TITLE
Use folly::IsRelocatable in folly::Function

### DIFF
--- a/folly/Function.h
+++ b/folly/Function.h
@@ -747,7 +747,7 @@ class Function final : private detail::function::FunctionTraits<FunctionType> {
               noexcept(Fun(FOLLY_DECLVAL(Fun))))>
   /* implicit */ Function(Fun fun) noexcept(IsSmall) {
     using Dispatch = conditional_t<
-        IsSmall && is_trivially_copyable_v<Fun>,
+        IsSmall && folly::IsRelocatable<Fun>::value,
         detail::function::DispatchSmallTrivial,
         conditional_t<
             IsSmall,


### PR DESCRIPTION
The `Op::MOVE` operation here is exactly "move-construct plus destroy," which is the same operation optimized into memcpy by `FBVector::make_window` and `FBVector::reserve`. So we can optimize it into memcpy here for the same set of types, namely, trivially relocatable types.

I haven't figured out how to run `FunctionTest.cpp` locally, so someone should look closely at whether the test change actually even works at all.

