### PR TITLE
[QueuedImmediateExecutor] Do not call deleted `Indestructable` constructor

### DIFF
--- a/folly/executors/QueuedImmediateExecutor.cpp
+++ b/folly/executors/QueuedImmediateExecutor.cpp
@@ -21,7 +21,7 @@
 namespace folly {
 
 QueuedImmediateExecutor& QueuedImmediateExecutor::instance() {
-  static auto instance = Indestructible<QueuedImmediateExecutor>{};
+  static Indestructible<QueuedImmediateExecutor> instance;
   return *instance;
 }
 


### PR DESCRIPTION
While trying to update `Flipper-folly` in the flipper repo to the latest version of folly ("v2023.02.20.00") at the time of writing, I got the following error:

>    - ERROR | [iOS] xcodebuild:  Flipper-Folly/folly/executors/QueuedImmediateExecutor.cpp:24:15: error: call to deleted constructor of 'folly::Indestructible<folly::QueuedImmediateExecutor>'

Looking further, this is the deleted constructor:

>   Indestructible(Indestructible const&) = delete;

and how we use it in `QueuedImmediateExecutor.cpp`:

> QueuedImmediateExecutor& QueuedImmediateExecutor::instance() {
  static auto instance = Indestructible<QueuedImmediateExecutor>{};
  return *instance;
}

So I looked around to see how `Indesctructable<foo>` is used elsewhere, and saw a pattern that mostly looks like this:

> SyncVecThreadPoolExecutors& getSyncVecThreadPoolExecutors() {
  static Indestructible<SyncVecThreadPoolExecutors> storage;
  return *storage;
}

It seems this allows us to avoid calling the deleted constructor. I updated `QueuedImmediateExecutor.cpp` to reflect that.