### PR TITLE
Invoking thread_local dtor register early to fix folly::ThreadLocal crash issue with glibc < 2.18

### DIFF
--- a/folly/detail/ThreadLocalDetail.cpp
+++ b/folly/detail/ThreadLocalDetail.cpp
@@ -19,6 +19,7 @@
 #include <list>
 #include <mutex>
 
+#include <folly/lang/Hint.h>
 #include <folly/synchronization/CallOnce.h>
 
 constexpr auto kSmallGrowthFactor = 1.1;
@@ -470,5 +471,22 @@ void StaticMetaBase::pushBackUnlocked(ThreadEntry* t, uint32_t id) {
 
 FOLLY_STATIC_CTOR_PRIORITY_MAX
 PthreadKeyUnregister PthreadKeyUnregister::instance_;
+#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 18)
+// Invoking thread_local dtor register early to fix issue
+// https://github.com/facebook/folly/issues/1252
+struct GlibcThreadLocalInit {
+  struct GlibcThreadLocalInitHelper {
+    FOLLY_NOINLINE ~GlibcThreadLocalInitHelper() {
+      compiler_must_not_elide(this);
+    }
+  };
+  GlibcThreadLocalInit() {
+    static thread_local GlibcThreadLocalInitHelper glibcThreadLocalInit;
+    compiler_must_not_elide(glibcThreadLocalInit);
+  }
+};
+__attribute__((__init_priority__(101)))
+GlibcThreadLocalInit glibcThreadLocalInit;
+#endif
 } // namespace threadlocal_detail
 } // namespace folly

--- a/folly/detail/ThreadLocalDetail.cpp
+++ b/folly/detail/ThreadLocalDetail.cpp
@@ -471,7 +471,7 @@ void StaticMetaBase::pushBackUnlocked(ThreadEntry* t, uint32_t id) {
 
 FOLLY_STATIC_CTOR_PRIORITY_MAX
 PthreadKeyUnregister PthreadKeyUnregister::instance_;
-#if __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 18)
+#if defined(__GLIBC__) && (__GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 18))
 // Invoking thread_local dtor register early to fix issue
 // https://github.com/facebook/folly/issues/1252
 struct GlibcThreadLocalInit {


### PR DESCRIPTION
Invoking thread_local dtor register early to fix folly::ThreadLocal crash issue with glibc < 2.18
Details see https://github.com/facebook/folly/issues/1252

Signed-off-by: lrita lrita@163.com