### PR TITLE
Fix duplicate frees in usingJEMalloc() / usingTCMalloc() checks

### DIFF
--- a/folly/memory/Malloc.h
+++ b/folly/memory/Malloc.h
@@ -180,7 +180,7 @@ FOLLY_EXPORT inline bool usingJEMalloc() noexcept {
 
       uint64_t origAllocated = *counter;
 
-      static void* volatile ptr = malloc(1);
+      void* volatile ptr = malloc(1);
       if (!ptr) {
         // wtf, failing to allocate 1 byte
         return false;
@@ -239,7 +239,7 @@ FOLLY_EXPORT inline bool usingTCMalloc() noexcept {
       size_t before_bytes = 0;
       getTCMallocNumericProperty(kAllocBytes, &before_bytes);
 
-      static void* volatile ptr = malloc(1);
+      void* volatile ptr = malloc(1);
       if (!ptr) {
         // wtf, failing to allocate 1 byte
         return false;


### PR DESCRIPTION
I'm using folly & jemalloc in one of my projects. After recently updating folly, I was seeing random segfaults in the test suite.

With a debug build of jemalloc, I got:

```
<jemalloc>: size mismatch detected (true size 96 vs input size 8), likely caused by application sized deallocation bugs
```

Further debugging and bisecting pointed at commit 73f67d4.

The problem is that the new code introduced by that commit does not prevent the slow path from being run multiple times, as was the case with the original code. For some reason, the checks for jemalloc/tcmalloc use a `static` variable for capturing the result of the `malloc` call. If the slow path is executed multiple times, this leads to multiple `free` calls on the same address. I don't know why the variable was made `static`, but it doesn't seem to be necessary and changing the variable to automatic storage duration fixes the issue.

(The check for tcmalloc still looks a little questionable as it only looks at the global number of allocated bytes, which also depends on allocations in other threads.)