### PR TITLE
MicroSpinLock: Use `atomic_exchange` instead of `atomic_compare_exchange`

### DIFF
--- a/folly/synchronization/MicroSpinLock.h
+++ b/folly/synchronization/MicroSpinLock.h
@@ -73,7 +73,7 @@ struct MicroSpinLock {
   void init() noexcept { payload()->store(FREE); }
 
   bool try_lock() noexcept {
-    bool ret = cas(FREE, LOCKED);
+    bool ret = xchg(LOCKED) == FREE;
     annotate_rwlock_try_acquired(
         this, annotate_rwlock_level::wrlock, ret, __FILE__, __LINE__);
     return ret;
@@ -81,7 +81,7 @@ struct MicroSpinLock {
 
   void lock() noexcept {
     detail::Sleeper sleeper;
-    while (!cas(FREE, LOCKED)) {
+    while (xchg(LOCKED) != FREE) {
       do {
         sleeper.wait();
       } while (payload()->load(std::memory_order_relaxed) == LOCKED);
@@ -103,13 +103,9 @@ struct MicroSpinLock {
     return reinterpret_cast<std::atomic<uint8_t>*>(&this->lock_);
   }
 
-  bool cas(uint8_t compare, uint8_t newVal) noexcept {
-    return std::atomic_compare_exchange_strong_explicit(
-        payload(),
-        &compare,
-        newVal,
-        std::memory_order_acquire,
-        std::memory_order_relaxed);
+  uint8_t xchg(uint8_t newVal) noexcept {
+    return std::atomic_exchange_explicit(
+        payload(), newVal, std::memory_order_acq_rel);
   }
 };
 static_assert(


### PR DESCRIPTION
The lock only has two-states, so `atomic_exchange` works and is as or more performant in any situation.