### PR TITLE
Use pretty_carray_from(__PRETTY_FUNCTION__) when compiling with clang on Windows (#9357)

### DIFF
--- a/folly/lang/Pretty.h
+++ b/folly/lang/Pretty.h
@@ -78,19 +78,19 @@ using pretty_default_tag = std::conditional_t< //
     pretty_tag_msc,
     pretty_tag_gcc>;
 
+#if defined(_MSC_VER) && !defined(__clang__)
 template <typename T>
 static constexpr auto pretty_raw(pretty_tag_msc) {
-#if defined(_MSC_VER)
   return pretty_carray_from(__FUNCSIG__);
-#endif
 }
+#endif
 
+#if defined(__GNUC__) || defined(__clang__)
 template <typename T>
 static constexpr auto pretty_raw(pretty_tag_gcc) {
-#if defined(__GNUC__) || defined(__clang__)
   return pretty_carray_from(__PRETTY_FUNCTION__);
-#endif
 }
+#endif
 
 template <std::size_t S>
 static constexpr pretty_info pretty_parse(


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/hhvm/pull/9357

When compiling react-native code with clang on Windows (using the MSVC STL) I am getting many errors as
```
1 error generated.
    When running <c++ preprocess_and_compile>.
    When building rule react-native-github/packages/react-native/ReactCommon/react/renderer/core:coreWindows#compile-RawPropsParser.cpp.obj576b4248,windows-x86_64 (//tools/build_defs/config/platform/windows:Archon-dev).
In file included from react-native-github\packages\react-native\ReactCommon\react\renderer\core\PropsMapBuffer.cpp:9:
In file included from react-native-github\packages\react-native\ReactCommon\react\renderer\core/Props.h:10:
In file included from folly/dynamic.h:69:
In file included from folly/container/F14Map.h:42:
In file included from folly/container/detail/F14Policy.h:28:
In file included from folly/container/detail/F14Table.h:47:
folly/lang/Pretty.h:84:29: error: extension used [-Werror,-Wlanguage-extension-token]
  return pretty_carray_from(__FUNCSIG__);
                            ^
```

Differential Revision: D45139890

