### PR TITLE
Add sorted_vector_set::const_pointer

### DIFF
--- a/folly/sorted_vector_types.h
+++ b/folly/sorted_vector_types.h
@@ -271,6 +271,7 @@ class sorted_vector_set : detail::growth_policy_wrapper<GrowthPolicy> {
   typedef typename Container::pointer pointer;
   typedef typename Container::reference reference;
   typedef typename Container::const_reference const_reference;
+  typedef typename Container::const_pointer const_pointer;
   /*
    * XXX: Our normal iterator ought to also be a constant iterator
    * (cf. Defect Report 103 for std::set), but this is a bit more of a

--- a/folly/test/sorted_vector_test.cpp
+++ b/folly/test/sorted_vector_test.cpp
@@ -65,6 +65,9 @@ static_assert(!folly::is_sorted_vector_set_v<std::set<int>>);
 static_assert(!folly::is_sorted_vector_set_v<std::unordered_set<int>>);
 static_assert(!folly::is_sorted_vector_set_v<std::vector<int>>);
 
+static_assert(
+    std::is_same_v<folly::sorted_vector_set<int>::const_pointer, const int*>);
+
 static_assert(std::is_same_v<
               folly::sorted_vector_map<int, double>::pointer,
               std::pair<int, double>*>);


### PR DESCRIPTION
Summary: similarly, `std::set` has const_pointer

Differential Revision: D45194122

