### PR TITLE
update disable ubsan macro

### DIFF
--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -151,22 +151,34 @@
 #endif
 
 /**
+ * Define a convenience macro to test when undefined-behavior sanitizer is being used
+ * across the different compilers (e.g. clang, gcc)
+ */
+#ifndef FOLLY_SANITIZE_UNDEFINED_BEHAVIOR
+#if FOLLY_HAS_FEATURE(undefined_behavior_sanitizer) || \
+    defined(__SANITIZER_UNDEFINED__)
+#define FOLLY_SANITIZE_UNDEFINED_BEHAVIOR(...) 1
+#endif
+#endif
+
+#ifdef FOLLY_SANITIZE_UNDEFINED_BEHAVIOR
+#define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER(...) \
+  __attribute__((no_sanitize(__VA_ARGS__)))
+#else
+#define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER(...)
+#endif
+
+/**
  * Define a convenience macro to test when ASAN, UBSAN, TSAN or MSAN sanitizer
  * are being used
  */
 #ifndef FOLLY_SANITIZE
 #if defined(FOLLY_SANITIZE_ADDRESS) || defined(FOLLY_SANITIZE_THREAD) || \
-    defined(FOLLY_SANITIZE_MEMORY) || defined(FOLLY_SANITIZE_DATAFLOW)
+    defined(FOLLY_SANITIZE_MEMORY) || defined(FOLLY_SANITIZE_DATAFLOW) || \
+    defined(FOLLY_SANITIZE_UNDEFINED_BEHAVIOR)
 #define FOLLY_SANITIZE 1
 #endif
 #endif
-
-#ifdef FOLLY_SANITIZE
-#define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER(...) \
-  __attribute__((no_sanitize(__VA_ARGS__)))
-#else
-#define FOLLY_DISABLE_UNDEFINED_BEHAVIOR_SANITIZER(...)
-#endif // FOLLY_SANITIZE
 
 #define FOLLY_DISABLE_SANITIZERS  \
   FOLLY_DISABLE_ADDRESS_SANITIZER \


### PR DESCRIPTION
no_sanitize attribute now supports undefined-behavior sanitizers including `no_sanitize("unsigned-integer-overflow")`, `no_sanitize("undefined")` etc. 

In the current code, running `__attribute__((no_sanitize("unsigned-integer-overflow")))` for ASan, MSan, or TSan is enabled leads to the warnings for attribute ignored. The logic here is hence incorrect. This kind of an attribute should be used only when UBSan is enabled.