### PR TITLE
add std:array dependency needed for SimdForEachTest to run

### DIFF
--- a/folly/detail/test/SimdForEachTest.cpp
+++ b/folly/detail/test/SimdForEachTest.cpp
@@ -15,8 +15,9 @@
  */
 
 #include <folly/detail/SimdForEach.h>
-
 #include <folly/portability/GTest.h>
+
+#include <array>
 
 namespace folly {
 namespace simd_detail {


### PR DESCRIPTION
Without the added "#include ", the build fails when BUILD_TESTS is turned on in CMakeLists.txt, as line 53/54 uses std:array:

alignas(64) std::array<char, 100u> buf;