### PR TITLE
Optimize crc32

### DIFF
--- a/folly/hash/Checksum.cpp
+++ b/folly/hash/Checksum.cpp
@@ -61,6 +61,9 @@ uint32_t crc32_hw(
   }
 
   // Remaining unaligned bytes
+  if (nbytes == 0) {
+    return sum;
+  }
   return crc32_sw(data + offset, nbytes, sum);
 }
 


### PR DESCRIPTION
Summary:
folly::crc32 implementation splits the buffer into unaligned head, multiple-of-16-bytes middle and unaligned tail. It uses boost to compute checksum for unaligned head and tail and SIMD for the aligned middle. We noticed that even when head and tail are empty (the buffer is fully aligned and its size is a multiple of 16), boost is still used and takes up > half of the profile.

{F984595200}

The optimization is to skip boost computation when tail is empty.

{F984596010}

Reviewed By: tonyxug

Differential Revision: D45751314

