### PR TITLE
CI: bump actions version, fix Node 12 deprecation warning

### DIFF
--- a/.github/workflows/TagIt.yml
+++ b/.github/workflows/TagIt.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Archive project
         id: archive_project
         run: |
@@ -29,7 +29,7 @@ jobs:
           echo "::set-output name=zip_512::$(openssl dgst -sha512 ${{ steps.archive_project.outputs.file_name }}.zip)"
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -49,7 +49,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Upload zip
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -58,7 +58,7 @@ jobs:
           asset_name: ${{ steps.archive_project.outputs.file_name }}.zip
           asset_content_type: application/zip
       - name: Upload tar.gz
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -87,7 +87,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. folly  --project-install-prefix folly:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --strip --src-dir=. folly _artifacts/linux  --project-install-prefix folly:/usr/local --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: folly
         path: _artifacts

--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch boost
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
     - name: Fetch ninja

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch boost
       run: python3 build/fbcode_builder/getdeps.py fetch --no-tests boost
     - name: Fetch openssl
@@ -91,7 +91,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py build --src-dir=. folly  --project-install-prefix folly:/usr/local
     - name: Copy artifacts
       run: python3 build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. folly _artifacts/mac  --project-install-prefix folly:/usr/local --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: folly
         path: _artifacts

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -21,7 +21,7 @@ jobs:
       run: git config --system core.longpaths true
     - name: Disable autocrlf
       run: git config --system core.autocrlf false
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Fetch boost
       run: python build/fbcode_builder/getdeps.py fetch --no-tests boost
     - name: Fetch libsodium
@@ -90,7 +90,7 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --src-dir=. folly 
     - name: Copy artifacts
       run: python build/fbcode_builder/getdeps.py fixup-dyn-deps --src-dir=. folly _artifacts/windows  --final-install-prefix /usr/local
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: folly
         path: _artifacts


### PR DESCRIPTION
## Changes

- Bump `actions/checkout` from `v2` (Node 12) to `v3`.
- Bump `actions/upload-artifact` from `v2` to `v3`.
- Replace deprecated actions [`actions/create-release@v1`](https://github.com/actions/create-release) and [`actions/upload-release-asset@v1`](https://github.com/actions/upload-release-asset) with suggested `softprops/action-gh-release@v1`.