### PR TITLE
Remove CXX_STD and inherit CMAKE_CXX_STANDARD from parent project

### DIFF
--- a/CMake/FollyCompilerUnix.cmake
+++ b/CMake/FollyCompilerUnix.cmake
@@ -12,28 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Provide an option to control the -std argument for the C++ compiler.
-# We don't use CMAKE_CXX_STANDARD since it requires at least CMake 3.8
-# to support C++17.
-#
-# Most users probably want to stick with the default here.  However, gnu++1z
-# does change the linkage of how some symbols are emitted (e.g., constexpr
-# variables defined in headers).  In case this causes problems for downstream
-# libraries that aren't using gnu++1z yet, provide an option to let them still
-# override this with gnu++14 if they need to.
-set(
-  CXX_STD "gnu++1z"
-  CACHE STRING
-  "The C++ standard argument to pass to the compiler.  Defaults to gnu++1z"
-)
-mark_as_advanced(CXX_STD)
-
 set(CMAKE_CXX_FLAGS_COMMON "-g -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${CMAKE_CXX_FLAGS_COMMON}")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${CMAKE_CXX_FLAGS_COMMON} -O3")
 
-# Note that CMAKE_REQUIRED_FLAGS must be a string, not a list
-set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=${CXX_STD}")
 list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
 function(apply_folly_compile_options_to_target THETARGET)
   target_compile_definitions(${THETARGET}
@@ -44,7 +26,6 @@ function(apply_folly_compile_options_to_target THETARGET)
   target_compile_options(${THETARGET}
     PRIVATE
       -g
-      -std=${CXX_STD}
       -finput-charset=UTF-8
       -fsigned-char
       -Wall

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,8 +90,11 @@ set(FOLLY_SUPPORT_SHARED_LIBRARY "${BUILD_SHARED_LIBS}")
 include(FBBuildOptions)
 fb_activate_static_library_option()
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  message(STATUS "setting C++ standard to C++${CMAKE_CXX_STANDARD}")
+endif()
 
 if("${CMAKE_LIBRARY_ARCHITECTURE}" STREQUAL "")
   # CMAKE_LIBRARY_ARCHITECTURE is not always set, so we have to assume


### PR DESCRIPTION
This follows up on a discussion in #1949 and the comment by @ot that the C++ standard for folly should be (easily) settable by a parent project.

There are two commits in this PR:

- The first commit removes the redundant `CXX_STD`, which causes `-std=` to be passed to the compiler twice.
- The second commit introduces a check before setting `CMAKE_CXX_STANDARD`, so a value set by a parent project won't be overridden.