### PR TITLE
Fix shadowed variable in fbcode/folly/detail/SimdAnyOf.h

### DIFF
--- a/folly/detail/SimdAnyOf.h
+++ b/folly/detail/SimdAnyOf.h
@@ -34,7 +34,7 @@ namespace simd_detail {
  */
 template <typename Platform, typename I, typename P>
 struct AnyOfDelegate {
-  explicit AnyOfDelegate(P p) : p(p) {}
+  explicit AnyOfDelegate(P p0) : p(p0) {}
 
   template <typename Ignore, typename UnrollStep>
   FOLLY_ALWAYS_INLINE bool step(I it, Ignore ignore, UnrollStep) {


### PR DESCRIPTION
Summary:
Fixes:
```
[2023-05-30T10:43:47.365-07:00] buck-out/v2/gen/fbcode/421793878b383059/folly/detail/__simd_any_of__/buck-headers/folly/detail/SimdAnyOf.h:37:28: error: declaration of ‘p’ shadows a member of ‘folly::simd_detail::AnyOfDelegate<folly::simd_detail::SimdCharPlatformCommon<folly::simd_detail::SimdCharAvx2PlatformSpecific>, const char*, folly::detail::SimpleSimdStringUtilsImpl<folly::simd_detail::SimdCharPlatformCommon<folly::simd_detail::SimdCharAvx2PlatformSpecific> >::HasSpaceOrCntrlSymbolsLambda>’ [-Werror=shadow]
[CONTEXT] [2023-05-30T10:43:47.365-07:00]    37 |   explicit AnyOfDelegate(P p) : p(p) {}
[CONTEXT] [2023-05-30T10:43:47.365-07:00]       |
```

Differential Revision: D46292800

