### PR TITLE
Fixing gcc build

### DIFF
--- a/folly/detail/SimdAnyOf.h
+++ b/folly/detail/SimdAnyOf.h
@@ -34,7 +34,8 @@ namespace simd_detail {
  */
 template <typename Platform, typename I, typename P>
 struct AnyOfDelegate {
-  explicit AnyOfDelegate(P p) : p(p) {}
+  // _p to deal with a shadow warning on an old gcc
+  explicit AnyOfDelegate(P _p) : p(_p) {}
 
   template <typename Ignore, typename UnrollStep>
   FOLLY_ALWAYS_INLINE bool step(I it, Ignore ignore, UnrollStep) {

--- a/folly/detail/UnrollUtils.h
+++ b/folly/detail/UnrollUtils.h
@@ -81,7 +81,14 @@ struct UnrollUtils {
   FOLLY_ALWAYS_INLINE static constexpr auto arrayMapImpl(
       const std::array<T, N>& x, Op op, std::index_sequence<i...>) {
     using U = decltype(op(std::declval<const T&>()));
-    std::array<U, N> res{op(x[i])...};
+
+    FOLLY_PUSH_WARNING
+    // This is a very common gcc issue,
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=97222 apparently discarding
+    // it here is fine and done through out.
+    FOLLY_GCC_DISABLE_WARNING("-Wignored-attributes")
+    std::array<U, N> res{{op(x[i])...}};
+    FOLLY_POP_WARNING
     return res;
   }
 


### PR DESCRIPTION
Summary:
Apparently this change caused some warning issues on gcc.
There was a shadow warning - that's easy.
The "loosing attributes" warning is a bit trickier, but if you look for it, you will see it disabled everywhere.

It's basically saying that some attributes (like alignas) will be ignored. And __m128 are done with attributes, though these ones are not ignored.

Alternative is to wrap intrinsics but that's too much.

Differential Revision: D46298812

