### PR TITLE
fix deadlock in RCU retire when rcu_reader active

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -941,6 +941,7 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       TEST call_once_test SOURCES CallOnceTest.cpp
       TEST lifo_sem_test WINDOWS_DISABLED SOURCES LifoSemTests.cpp
       TEST relaxed_atomic_test WINDOWS_DISABLED SOURCES RelaxedAtomicTest.cpp
+      TEST rcu_test SOURCES RcuTest.cpp
       TEST rw_spin_lock_test SOURCES RWSpinLockTest.cpp
       TEST semaphore_test WINDOWS_DISABLED SOURCES SemaphoreTest.cpp
 


### PR DESCRIPTION
Summary:
Every 3.2 seconds RCU retire tries to opportunistically drain the queue of pending work.  If this happens while the current thread is holding an rcu_reader and another thread is currently running synchronize(), a deadlock will occur.  This diff adds a unit test for the behavior and fixes the problem.

Test Plan:
* unit test that reproduces the problem
* unit test passes with the fix