### PR TITLE
Fix libfmt errors from not finding enum formatter

### DIFF
--- a/folly/futures/detail/Core.cpp
+++ b/folly/futures/detail/Core.cpp
@@ -19,6 +19,7 @@
 #include <new>
 
 #include <fmt/core.h>
+#include <folly/Utility.h>
 #include <folly/lang/Assume.h>
 
 namespace folly {
@@ -30,7 +31,7 @@ namespace {
 template <class Enum>
 void terminate_unexpected_state(fmt::string_view context, Enum state) {
   terminate_with<std::logic_error>(
-      fmt::format("{} unexpected state: {}", context, state));
+      fmt::format("{} unexpected state: {}", context, to_underlying(state)));
 }
 
 } // namespace


### PR DESCRIPTION
Recent versions of libfmt have become more strict and require `enum` types to be formattable:

    static assertion failed due to requirement 'formattable': Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt

This is a quick fix to simply use the underlying type.