### PR TITLE
IsZeroInitializable reflects value-initialization, not default-construction

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -443,8 +443,8 @@ FOLLY_INLINE_VARIABLE constexpr bool is_trivially_copyable_v =
  * It may be unset in a base class by overriding the typedef to false_type.
  */
 /*
- * IsZeroInitializable describes the property that default construction is the
- * same as memset(dst, 0, sizeof(T)).
+ * IsZeroInitializable describes the property that value-initialization
+ * is the same as memset(dst, 0, sizeof(T)).
  */
 
 namespace traits_detail {

--- a/folly/test/FBVectorTest.cpp
+++ b/folly/test/FBVectorTest.cpp
@@ -309,3 +309,13 @@ TEST(FBVector, overflowAssign) {
       vec.assign(SIZE_MAX / sizeof(std::string) + 1, "hello"),
       std::length_error);
 }
+
+TEST(FBVector, zeroInit) {
+  // This is a higher-level version of TEST(Traits, zeroInit).
+  struct S1 { int i_; };
+  struct S3 { int S1::*mp_; };
+  folly::fbvector<S3> vec(4);
+  vec.resize(10);
+  EXPECT_EQ(vec[0].mp_, nullptr);
+  EXPECT_EQ(vec[8].mp_, nullptr);
+}

--- a/folly/test/TraitsTest.cpp
+++ b/folly/test/TraitsTest.cpp
@@ -86,9 +86,24 @@ TEST(Traits, unset) {
   EXPECT_TRUE(IsRelocatable<F4>::value);
 }
 
-TEST(Traits, bitAndInit) {
+TEST(Traits, zeroInit) {
+  // S1 is both trivially default-constructible and trivially value-initializable.
+  // S2 is neither.
+  // S3 is trivially default-constructible but not trivially value-initializable.
+  struct S1 { int i_; };
+  struct S2 { int i_ = 42; };
+  struct S3 { int S1::*mp_; };
+
   EXPECT_TRUE(IsZeroInitializable<int>::value);
+  EXPECT_TRUE(IsZeroInitializable<int*>::value);
   EXPECT_FALSE(IsZeroInitializable<vector<int>>::value);
+  EXPECT_FALSE(IsZeroInitializable<S2>::value);
+  EXPECT_FALSE(IsZeroInitializable<int S1::*>::value); // Itanium
+  EXPECT_FALSE(IsZeroInitializable<S3>::value); // Itanium
+
+  // TODO: S1 actually can be trivially zero-initialized, but
+  // there's no portable way to distinguish it from S3, which can't.
+  EXPECT_FALSE(IsZeroInitializable<S1>::value);
 }
 
 template <bool V>


### PR DESCRIPTION
This commit updates some comments and unit-tests so that they reflect the current state of the world: `IsZeroInitializable` currently answers the question "Can `T t = T();` be implemented with memset?" That's the reason it's currently false even for trivially default-constructible class and union types: there exist trivially default-constructible types (such as `S3` in the new unit-test) which are nevertheless non-trivially value-initializable.