### PR TITLE
Add support for --bm_perf_args in folly bench

### DIFF
--- a/folly/Benchmark.cpp
+++ b/folly/Benchmark.cpp
@@ -32,7 +32,7 @@
 #include <folly/FileUtil.h>
 #include <folly/MapUtil.h>
 #include <folly/String.h>
-#include <folly/container/Foreach.h>
+#include <folly/detail/PerfScoped.h>
 #include <folly/json.h>
 
 // This needs to be at the end because some versions end up including
@@ -49,6 +49,17 @@ FOLLY_GFLAGS_DEFINE_bool(benchmark, false, "Run benchmarks.");
 FOLLY_GFLAGS_DEFINE_bool(json, false, "Output in JSON format.");
 
 FOLLY_GFLAGS_DEFINE_bool(bm_estimate_time, false, "Estimate running time");
+
+#if FOLLY_PERF_IS_SUPPORTED
+FOLLY_GFLAGS_DEFINE_string(
+    bm_perf_args,
+    "",
+    "Run selected benchmarks while attaching `perf` profiling tool."
+    "Advantage over attaching perf externally is that this skips "
+    "initialization. The first iteration of the benchmark is also "
+    "skipped to allow for all statics to be set up. This requires perf "
+    " to be available on the system. Example: --bm_perf_args=\"record -g\"");
+#endif
 
 FOLLY_GFLAGS_DEFINE_bool(
     bm_profile, false, "Run benchmarks with constant number of iterations");
@@ -639,56 +650,72 @@ void checkRunMode() {
 
 namespace {
 
-std::size_t getBenchmarkBaselineIndex(
+struct BenchmarksToRun {
+  const detail::BenchmarkRegistration* baseline = nullptr;
+  std::vector<const detail::BenchmarkRegistration*> benchmarks;
+};
+
+BenchmarksToRun selectBenchmarksToRun(
     const std::vector<detail::BenchmarkRegistration>& benchmarks) {
-  auto it = std::find_if(
-      benchmarks.begin(),
-      benchmarks.end(),
-      [&](const detail::BenchmarkRegistration& v) {
-        return v.name == kGlobalBenchmarkBaseline;
-      });
-  CHECK(it != benchmarks.end());
-  return size_t(std::distance(benchmarks.begin(), it));
+  BenchmarksToRun res;
+
+  folly::Optional<boost::regex> bmRegex;
+
+  res.benchmarks.reserve(benchmarks.size());
+
+  if (!FLAGS_bm_regex.empty()) {
+    bmRegex.emplace(FLAGS_bm_regex);
+  }
+
+  for (auto& bm : benchmarks) {
+    if (bm.name == "-") { // skip separators
+      continue;
+    }
+
+    if (bm.name == kGlobalBenchmarkBaseline) {
+      res.baseline = &bm;
+      continue;
+    }
+
+    if (!bmRegex || boost::regex_match(bm.name, *bmRegex)) {
+      res.benchmarks.push_back(&bm);
+    }
+  }
+
+  CHECK(res.baseline);
+
+  return res;
+}
+
+void runAllBenchmarksOnce(const BenchmarksToRun& toRun) {
+  for (const auto* bm : toRun.benchmarks) {
+    bm->func(1);
+  }
 }
 
 std::pair<std::set<std::string>, std::vector<detail::BenchmarkResult>>
 runBenchmarksWithPrinterImpl(
     BenchmarkResultsPrinter* FOLLY_NULLABLE printer,
-    const std::vector<detail::BenchmarkRegistration>& benchmarks) {
+    const BenchmarksToRun& toRun) {
   vector<detail::BenchmarkResult> results;
-  results.reserve(benchmarks.size() - 1);
-
-  std::unique_ptr<boost::regex> bmRegex;
-  if (!FLAGS_bm_regex.empty()) {
-    bmRegex = std::make_unique<boost::regex>(FLAGS_bm_regex);
-  }
+  results.reserve(toRun.benchmarks.size());
 
   // PLEASE KEEP QUIET. MEASUREMENTS IN PROGRESS.
 
-  size_t baselineIndex = getBenchmarkBaselineIndex(benchmarks);
-
   auto const globalBaseline =
-      runBenchmarkGetNSPerIteration(benchmarks[baselineIndex].func, 0);
+      runBenchmarkGetNSPerIteration(toRun.baseline->func, 0);
 
   std::set<std::string> counterNames;
-  FOR_EACH_RANGE (i, 0, benchmarks.size()) {
-    if (i == baselineIndex) {
-      continue;
-    }
+  for (const auto bmPtr : toRun.benchmarks) {
     std::pair<double, UserCounters> elapsed;
-    auto& bm = benchmarks[i];
-    if (bm.name != "-") { // skip separators
-      if (bmRegex && !boost::regex_search(bm.name, *bmRegex)) {
-        continue;
-      }
-      if (FLAGS_bm_profile) {
-        elapsed = runProfilingGetNSPerIteration(bm.func, globalBaseline.first);
-      } else {
-        elapsed = FLAGS_bm_estimate_time
-            ? runBenchmarkGetNSPerIterationEstimate(
-                  bm.func, globalBaseline.first)
-            : runBenchmarkGetNSPerIteration(bm.func, globalBaseline.first);
-      }
+    const detail::BenchmarkRegistration& bm = *bmPtr;
+
+    if (FLAGS_bm_profile) {
+      elapsed = runProfilingGetNSPerIteration(bm.func, globalBaseline.first);
+    } else {
+      elapsed = FLAGS_bm_estimate_time
+          ? runBenchmarkGetNSPerIterationEstimate(bm.func, globalBaseline.first)
+          : runBenchmarkGetNSPerIteration(bm.func, globalBaseline.first);
     }
 
     // if customized user counters is used, it cannot print the result in real
@@ -767,11 +794,31 @@ folly::StringPiece BenchmarkingStateBase::getGlobalBaselineNameForTests() {
   return kGlobalBenchmarkBaseline;
 }
 
+PerfScoped BenchmarkingStateBase::doSetUpPerfScoped(
+    const std::vector<std::string>& args) const {
+  return PerfScoped{args};
+}
+
+PerfScoped BenchmarkingStateBase::setUpPerfScoped() const {
+  std::vector<std::string> perfArgs;
+#if FOLLY_PERF_IS_SUPPORTED
+  folly::split(' ', FLAGS_bm_perf_args, perfArgs, true);
+#endif
+  if (perfArgs.empty()) {
+    return PerfScoped{};
+  }
+  return doSetUpPerfScoped(perfArgs);
+}
+
 template <typename Printer>
 std::pair<std::set<std::string>, std::vector<BenchmarkResult>>
 BenchmarkingStateBase::runBenchmarksWithPrinter(Printer* printer) const {
   std::lock_guard<std::mutex> guard(mutex_);
-  return runBenchmarksWithPrinterImpl(printer, benchmarks_);
+  BenchmarksToRun toRun = selectBenchmarksToRun(benchmarks_);
+  runAllBenchmarksOnce(toRun);
+
+  detail::PerfScoped perf = setUpPerfScoped();
+  return runBenchmarksWithPrinterImpl(printer, toRun);
 }
 
 std::vector<BenchmarkResult> BenchmarkingStateBase::runBenchmarksWithResults()

--- a/folly/Benchmark.h
+++ b/folly/Benchmark.h
@@ -186,6 +186,8 @@ struct BenchmarkSuspender : BenchmarkSuspenderBase {
   TimePoint start;
 };
 
+class PerfScoped;
+
 class BenchmarkingStateBase {
  public:
   template <typename Printer>
@@ -202,7 +204,14 @@ class BenchmarkingStateBase {
       const char* file, StringPiece name, BenchmarkFun, bool useCounter);
 
  protected:
-  ~BenchmarkingStateBase() = default;
+  // There is no need for this virtual but we overcome a check
+  virtual ~BenchmarkingStateBase() = default;
+
+  PerfScoped setUpPerfScoped() const;
+
+  // virtual for purely testing purposes.
+  virtual PerfScoped doSetUpPerfScoped(
+      const std::vector<std::string>& args) const;
 
   mutable std::mutex mutex_;
   std::vector<BenchmarkRegistration> benchmarks_;

--- a/folly/detail/PerfScoped.cpp
+++ b/folly/detail/PerfScoped.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/detail/PerfScoped.h>
+
+#include <folly/Conv.h>
+
+#if FOLLY_PERF_IS_SUPPORTED
+#include <folly/Subprocess.h> // @manual
+#include <folly/experimental/TestUtil.h>
+#include <folly/system/Pid.h>
+#endif
+
+#include <stdexcept>
+#include <thread>
+
+namespace folly {
+namespace detail {
+
+#if FOLLY_PERF_IS_SUPPORTED
+
+namespace {
+
+constexpr std::chrono::milliseconds kTerminateTimeout{500};
+
+std::vector<std::string> prependCommonArgs(
+    const std::vector<std::string>& passed, const test::TemporaryFile* output) {
+  std::vector<std::string> res{"/usr/bin/perf"};
+  res.insert(res.end(), passed.begin(), passed.end());
+
+  res.push_back("-p");
+  res.push_back(folly::to<std::string>(get_cached_pid()));
+  if (output) {
+    res.push_back("--output");
+    res.push_back(output->path().string());
+  }
+  return res;
+}
+
+Subprocess::Options subprocessOptions() {
+  Subprocess::Options res;
+  res.terminateChildOnDestruction(kTerminateTimeout);
+  return res;
+}
+
+} // namespace
+
+class PerfScoped::PerfScopedImpl {
+ public:
+  PerfScopedImpl(const std::vector<std::string>& args, std::string* output)
+      : proc_(
+            prependCommonArgs(args, output != nullptr ? &outputFile_ : nullptr),
+            subprocessOptions()),
+        output_(output) {}
+
+  PerfScopedImpl(const PerfScopedImpl&) = delete;
+  PerfScopedImpl(PerfScopedImpl&&) = delete;
+  PerfScopedImpl& operator=(const PerfScopedImpl&) = delete;
+  PerfScopedImpl& operator=(PerfScopedImpl&&) = delete;
+
+  ~PerfScopedImpl() noexcept {
+    proc_.sendSignal(SIGINT);
+    proc_.wait();
+
+    if (output_) {
+      readFile(outputFile_.fd(), *output_);
+    }
+  }
+
+ private:
+  test::TemporaryFile outputFile_;
+  Subprocess proc_;
+  std::string* output_;
+};
+
+PerfScoped::PerfScoped(
+    const std::vector<std::string>& args, std::string* output)
+    : pimpl_(std::make_unique<PerfScopedImpl>(args, output)) {}
+
+#else // FOLLY_PERF_IS_SUPPORTED
+
+class PerfScoped::PerfScopedImpl {};
+
+[[noreturn]] PerfScoped::PerfScoped(
+    const std::vector<std::string>& args, std::string* output) {
+  (void)args;
+  (void)output;
+  throw std::runtime_error("Perf is not supported on Windows.");
+}
+
+#endif
+
+PerfScoped::PerfScoped() = default;
+PerfScoped::PerfScoped(PerfScoped&&) noexcept = default;
+PerfScoped& PerfScoped::operator=(PerfScoped&&) noexcept = default;
+PerfScoped::~PerfScoped() noexcept = default;
+
+} // namespace detail
+} // namespace folly

--- a/folly/detail/PerfScoped.h
+++ b/folly/detail/PerfScoped.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace folly {
+namespace detail {
+
+#if defined(__linux__) && !defined(__ANDROID__)
+#define FOLLY_PERF_IS_SUPPORTED 1
+#else
+#define FOLLY_PERF_IS_SUPPORTED 0
+#endif
+
+/*
+ * A folly::benchmark helper for attaching `perf` profiler
+ * to a given block of code.
+ *
+ * Only available on linux.
+ */
+class PerfScoped {
+ public:
+  // Not running. Used to be able to move things/not start
+  PerfScoped();
+
+  // Actually starts perf
+  // Output is for testing, if passed, perf output will be
+  // put there.
+  //
+  // NOTE: noretrun has to be here to ignore a warning
+#if !FOLLY_PERF_IS_SUPPORTED
+  [[noreturn]]
+#endif
+  explicit PerfScoped(
+      const std::vector<std::string>& args, std::string* output = nullptr);
+
+  // Sends Ctrl-C to stop recording.
+  ~PerfScoped() noexcept;
+
+  PerfScoped(const PerfScoped&) = delete;
+  PerfScoped& operator=(const PerfScoped&) = delete;
+
+  PerfScoped(PerfScoped&& x) noexcept;
+  PerfScoped& operator=(PerfScoped&& x) noexcept;
+
+ private:
+  class PerfScopedImpl;
+
+  std::unique_ptr<PerfScopedImpl> pimpl_;
+};
+
+} // namespace detail
+} // namespace folly

--- a/folly/detail/test/PerfScopedTest.cpp
+++ b/folly/detail/test/PerfScopedTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/detail/PerfScoped.h>
+
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <folly/portability/Unistd.h>
+
+#include <thread>
+
+#if FOLLY_PERF_IS_SUPPORTED
+
+namespace folly {
+namespace detail {
+namespace {
+
+// This is obviously not amazing
+// but if perf didn't start properly,
+// we won't get any results.
+template <typename Test>
+void retryWithTimeOuts(Test test) {
+  for (auto timeOut = std::chrono::seconds(1);
+       timeOut != std::chrono::seconds(10);
+       ++timeOut) {
+    if (test(timeOut)) {
+      return;
+    }
+  }
+}
+
+TEST(PerfScopedTest, Stat) {
+  std::string output;
+
+  retryWithTimeOuts([&](auto timeOut) {
+    {
+      PerfScoped perf{{"stat"}, &output};
+      std::this_thread::sleep_for(timeOut);
+    }
+    return !output.empty();
+  });
+
+  ASSERT_THAT(
+      output, ::testing::HasSubstr("Performance counter stats for process id"));
+}
+
+TEST(PerfScopedTest, Move) {
+  std::string output;
+
+  retryWithTimeOuts([&](auto timeOut) {
+    {
+      PerfScoped assignHere;
+      {
+        PerfScoped fromHere{{"stat"}, &output};
+        assignHere = std::move(fromHere);
+        std::this_thread::sleep_for(timeOut);
+      }
+      // because assign here is still alive, should not do anything.
+      EXPECT_TRUE(output.empty());
+    }
+    std::this_thread::sleep_for(timeOut);
+
+    // Now that all guards are off, should be fine.
+    return !output.empty();
+  });
+
+  ASSERT_FALSE(output.empty());
+}
+
+TEST(PerfScopedTest, Record) {
+  std::string output;
+
+  retryWithTimeOuts([&](auto timeOut) {
+    {
+      PerfScoped perf{{"record"}, &output};
+      std::this_thread::sleep_for(timeOut);
+    }
+    return !output.empty();
+  });
+
+  ASSERT_FALSE(output.empty());
+}
+
+TEST(PerfScopedTest, StatNoOutput) {
+  // Just verifying that this doesn't crash.
+  PerfScoped perf{{"stat"}};
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+}
+
+} // namespace
+} // namespace detail
+} // namespace folly
+
+#endif // defined(__linux__)


### PR DESCRIPTION
Summary: Add ` -bm_perf_args` to folly::benchmark so that we can exclude set up from the data collection.

Differential Revision: D47135199

