### PR TITLE
Support ASAN suppressions under MSVC

### DIFF
--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -96,6 +96,8 @@
 #define FOLLY_DISABLE_ADDRESS_SANITIZER \
   __attribute__((__no_address_safety_analysis__, __noinline__))
 #endif
+#elif defined(_MSC_VER)
+#define FOLLY_DISABLE_ADDRESS_SANITIZER __declspec(no_sanitize_address)
 #endif
 #ifndef FOLLY_DISABLE_ADDRESS_SANITIZER
 #define FOLLY_DISABLE_ADDRESS_SANITIZER


### PR DESCRIPTION
Summary: MSVC has support for asan, so enable the ASAN suppression macros where needed.

Differential Revision: D47345965

