### PR TITLE
bm_warm_up_iteration flag

### DIFF
--- a/folly/Benchmark.cpp
+++ b/folly/Benchmark.cpp
@@ -677,7 +677,7 @@ BenchmarksToRun selectBenchmarksToRun(
       continue;
     }
 
-    if (!bmRegex || boost::regex_match(bm.name, *bmRegex)) {
+    if (!bmRegex || boost::regex_search(bm.name, *bmRegex)) {
       res.benchmarks.push_back(&bm);
     }
   }

--- a/folly/Benchmark.cpp
+++ b/folly/Benchmark.cpp
@@ -72,6 +72,11 @@ FOLLY_GFLAGS_DEFINE_string(
     "",
     "Print benchmark results relative to an earlier dump (via --bm_json_verbose)");
 
+FOLLY_GFLAGS_DEFINE_bool(
+    bm_warm_up_iteration,
+    false,
+    "Run one iteration of the benchmarks before measuring. Always true if `bm_perf_args` is passed");
+
 FOLLY_GFLAGS_DEFINE_string(
     bm_json_verbose,
     "",
@@ -687,7 +692,17 @@ BenchmarksToRun selectBenchmarksToRun(
   return res;
 }
 
-void runAllBenchmarksOnce(const BenchmarksToRun& toRun) {
+void maybeRunAllBenchmarksOnce(const BenchmarksToRun& toRun) {
+  bool should = FLAGS_bm_warm_up_iteration;
+
+#if FOLLY_PERF_IS_SUPPORTED
+  should = should || !FLAGS_bm_perf_args.empty();
+#endif
+
+  if (!should) {
+    return;
+  }
+
   for (const auto* bm : toRun.benchmarks) {
     bm->func(1);
   }
@@ -815,7 +830,7 @@ std::pair<std::set<std::string>, std::vector<BenchmarkResult>>
 BenchmarkingStateBase::runBenchmarksWithPrinter(Printer* printer) const {
   std::lock_guard<std::mutex> guard(mutex_);
   BenchmarksToRun toRun = selectBenchmarksToRun(benchmarks_);
-  runAllBenchmarksOnce(toRun);
+  maybeRunAllBenchmarksOnce(toRun);
 
   detail::PerfScoped perf = setUpPerfScoped();
   return runBenchmarksWithPrinterImpl(printer, toRun);

--- a/folly/test/BenchmarkTest.cpp
+++ b/folly/test/BenchmarkTest.cpp
@@ -71,13 +71,13 @@ struct BenchmarkingStateTest : ::testing::Test {
 };
 
 TEST_F(BenchmarkingStateTest, Basic) {
-  state.addBenchmark(__FILE__, "1ns", [&] {
+  state.addBenchmark(__FILE__, "a1ns", [&] {
     doBaseline();
     TestClock::advance(std::chrono::nanoseconds(1));
     return 1;
   });
 
-  state.addBenchmark(__FILE__, "2ns", [&] {
+  state.addBenchmark(__FILE__, "b2ns", [&] {
     doBaseline();
     TestClock::advance(std::chrono::nanoseconds(2));
     return 1;
@@ -85,20 +85,32 @@ TEST_F(BenchmarkingStateTest, Basic) {
 
   {
     const std::vector<BenchmarkResult> expected{
-        {__FILE__, "1ns", 1, {}},
-        {__FILE__, "2ns", 2, {}},
+        {__FILE__, "a1ns", 1, {}},
+        {__FILE__, "b2ns", 2, {}},
     };
 
     EXPECT_EQ(expected, state.runBenchmarksWithResults());
   }
 
-  // --bm_regex
+  // --bm_regex full match
   {
     gflags::FlagSaver _;
-    gflags::SetCommandLineOption("bm_regex", "1.*");
+    gflags::SetCommandLineOption("bm_regex", "a1.*");
 
     const std::vector<BenchmarkResult> expected{
-        {__FILE__, "1ns", 1, {}},
+        {__FILE__, "a1ns", 1, {}},
+    };
+
+    EXPECT_EQ(expected, state.runBenchmarksWithResults());
+  }
+
+  // --bm_regex part match
+  {
+    gflags::FlagSaver _;
+    gflags::SetCommandLineOption("bm_regex", "1.");
+
+    const std::vector<BenchmarkResult> expected{
+        {__FILE__, "a1ns", 1, {}},
     };
 
     EXPECT_EQ(expected, state.runBenchmarksWithResults());


### PR DESCRIPTION
Summary:
[hyrumslaw](https://www.hyrumslaw.com/) as far as the eye can see - introduction of a separater warm up iteration broke a lot of people.

Adding a separate flag and forcing it for profiling.

Differential Revision: D47414433

