### PR TITLE
Don't use C++20 auto parameter types in SimdForEachTest

### DIFF
--- a/folly/detail/test/SimdForEachTest.cpp
+++ b/folly/detail/test/SimdForEachTest.cpp
@@ -29,7 +29,8 @@ template <bool kSameUnrollValue>
 struct TestDelegate {
   char* stopAt = nullptr;
 
-  bool step(char* s, ignore_extrema ignore, auto unroll_i) const {
+  template <typename N>
+  bool step(char* s, ignore_extrema ignore, N unroll_i) const {
     int middle = kCardinal - ignore.first - ignore.last;
     while (ignore.first--) {
       EXPECT_EQ(*s, 0);
@@ -50,7 +51,8 @@ struct TestDelegate {
     return stopAt != nullptr && s > stopAt;
   }
 
-  bool step(char* s, ignore_none, auto unroll_i) const {
+  template <typename N>
+  bool step(char* s, ignore_none, N unroll_i) const {
     for (int i = 0; i != kCardinal; ++i) {
       EXPECT_EQ(*s, 0);
       if (kSameUnrollValue) {


### PR DESCRIPTION
Summary:
We're not yet to the point where we can blindly use C++20 features unguarded yet, so switch this to a normal template parameter
Fixes: https://github.com/facebook/folly/issues/2032

Reviewed By: DenisYaroshevskiy

Differential Revision: D47345349

