### PR TITLE
work around gcc build failure

### DIFF
--- a/folly/container/test/F14MapTest.cpp
+++ b/folly/container/test/F14MapTest.cpp
@@ -2302,9 +2302,12 @@ template <template <class...> class TMap>
 void testInitializerListDeductionGuide() {
   TMap<int, double> source({{1, 2.0}, {3, 4.0}});
 
+#if !defined(__GNUC__) || __GNUC__ > 12 || defined(__clang__)
+  // some versions of gcc, including until at least gcc v12, fail here
   TMap dest1{std::pair{1, 2.0}, {3, 4.0}};
   static_assert(std::is_same_v<decltype(dest1), decltype(source)>);
   EXPECT_EQ(dest1, source);
+#endif
 
   TMap dest2({std::pair{1, 2.0}, {3, 4.0}});
   static_assert(std::is_same_v<decltype(dest2), decltype(source)>);


### PR DESCRIPTION
Summary:
One line in a unit-test exercising the class template argument deduction guides for the F14FastMap etc containers fails to compile under gcc, until at least gcc v12. The line should compile, and does compile under clang.

To work around, we exclude this line when building under gcc.

Reviewed By: Orvid

Differential Revision: D48440179

