### PR TITLE
folly::unsafe_for_async_usage

### DIFF
--- a/folly/SingletonThreadLocal.h
+++ b/folly/SingletonThreadLocal.h
@@ -27,6 +27,7 @@
 #include <folly/detail/Singleton.h>
 #include <folly/detail/UniqueInstance.h>
 #include <folly/functional/Invoke.h>
+#include <folly/lang/Hint.h>
 
 namespace folly {
 
@@ -254,6 +255,8 @@ detail::UniqueInstance SingletonThreadLocal<T, Tag, Make, TLTag>::unique{
   struct __folly_reused_type_##name {                                          \
     __VA_ARGS__ object;                                                        \
   };                                                                           \
+  FOLLY_MAYBE_UNUSED ::folly::unsafe_for_async_usage                           \
+      __folly_reused_g_prevent_async_##name;                                   \
   auto& name =                                                                 \
       ::folly::SingletonThreadLocal<__folly_reused_type_##name>::get().object; \
   auto __folly_reused_g_##name = ::folly::makeGuard([&] { name.clear(); })

--- a/folly/lang/Hint.h
+++ b/folly/lang/Hint.h
@@ -113,6 +113,30 @@ struct compiler_must_not_predict_fn {
 FOLLY_INLINE_VARIABLE constexpr compiler_must_not_predict_fn
     compiler_must_not_predict{};
 
+// folly_is_unsafe_for_async_usage
+// Brief: marker for static analysis.
+//
+// Some objects, especially those intended for RAII use, require that the
+// current thread is not yielded throughout their lifetime, for example through
+// a coroutine suspension point.
+//
+// Examples:
+//  * Objects that are internally relying global or thread local memory.
+//    (storage in FOLLY_DECLARE_REUSED).
+//  * Advanced concurrency primitives, such as hazard pointers.
+//
+// This can be used to implement a static analysis that detects
+// such misuse for classes marked with this tag.
+//
+// In order to mark a class:
+//  * declare a typedef inside `using folly_is_unsafe_for_async_usage = void`
+//  * or: have a member or a base for which this check is enabled.
+//        For members it is recommended to use FOLLY_ATTR_NO_UNIQUE_ADDRESS to
+//        avoid increasing an object's footprint.
+struct unsafe_for_async_usage {
+  using folly_is_unsafe_for_async_usage = void;
+};
+
 } // namespace folly
 
 #include <folly/lang/Hint-inl.h>


### PR DESCRIPTION
Summary:
A marker for static analysis to indicate types that should not move to a different thread.
In a discussion with ot we decided to focus only on coroutines - since with futures one has to be much more explicit

## Why not attribute?

I think I'd have to introduce some weird macros then. FOLLY_UNSAFE_ASYNC. I think inheritance is cleaner.

I don't mind if you think otherwise, can do that.

Differential Revision: D48477186

