### PR TITLE
correct the wrong comment for encodeZigZag

### DIFF
--- a/folly/Varint.h
+++ b/folly/Varint.h
@@ -90,7 +90,7 @@ Expected<uint64_t, DecodeVarintError> tryDecodeVarint(Range<T*>& data);
  * encoding negative values using Varint would use up 9 or 10 bytes.
  *
  * if x >= 0, encodeZigZag(x) == 2*x
- * if x <  0, encodeZigZag(x) == -2*x + 1
+ * if x <  0, encodeZigZag(x) == -2*x - 1
  */
 
 inline uint64_t encodeZigZag(int64_t val) {


### PR DESCRIPTION
The comment for encodeZigZag(x) is wrong. 

Should be encodeZigZag(x) == -2*x - 1, as 

encodeZigZag(-1) = 1

and 

encodeZigZag(-2) = 3

Closes #2046 