### PR TITLE
fix linux and macOS build

### DIFF
--- a/folly/concurrency/test/ConcurrentHashMapTest.cpp
+++ b/folly/concurrency/test/ConcurrentHashMapTest.cpp
@@ -17,7 +17,10 @@
 #include <folly/concurrency/ConcurrentHashMap.h>
 
 #include <atomic>
+#if __cplusplus > 201703L
+// std::latch becomes visible in C++20 mode
 #include <latch>
+#endif
 #include <limits>
 #include <memory>
 #include <thread>
@@ -1135,6 +1138,8 @@ TYPED_TEST_P(ConcurrentHashMapTest, ConcurrentInsertClear) {
 }
 
 TYPED_TEST_P(ConcurrentHashMapTest, StressTestReclamation) {
+  // std::latch becomes visible in C++20 mode
+#if __cplusplus > 201703L
   // Create a map where we keep reclaiming a lot of objects that are linked to
   // one node.
 
@@ -1178,6 +1183,7 @@ TYPED_TEST_P(ConcurrentHashMapTest, StressTestReclamation) {
   for (auto& t : threads) {
     join;
   }
+#endif
 }
 
 REGISTER_TYPED_TEST_SUITE_P(

--- a/folly/detail/FileUtilDetail.cpp
+++ b/folly/detail/FileUtilDetail.cpp
@@ -44,13 +44,13 @@ std::string getTemporaryFilePathStringWithoutTempDirectory(
 
 std::string getTemporaryFilePathStringWithTemporaryDirectory(
     const std::string& temporaryDirectory) {
-#if defined(__linux__) && !FOLLY_MOBILE
+#if !defined(_WIN32) && !FOLLY_MOBILE
   return (temporaryDirectory.back() == '/')
       ? (temporaryDirectory + std::string{"tempForAtomicWrite.XXXXXX"})
       : (temporaryDirectory + std::string{"/tempForAtomicWrite.XXXXXX"});
 #else
-  // The implementation currently, does not support any platform other than
-  // linux for temporary directory based atomic file writes.
+  // The implementation currently does not support win32 or mobile
+  // for temporary directory based atomic file writes.
   static_cast<void>(temporaryDirectory);
   assert(false);
 

--- a/folly/lang/test/ExceptionTest.cpp
+++ b/folly/lang/test/ExceptionTest.cpp
@@ -68,7 +68,7 @@ template <typename Ex>
 static std::string message_for_terminate_with(std::string const& what) {
   auto const name = folly::pretty_name<Ex>();
   std::string const p0 = "terminate called after throwing an instance of";
-  std::string const p1 = "terminating with uncaught exception of type";
+  std::string const p1 = "terminating (due to|with) uncaught exception of type";
   // clang-format off
   return
       folly::kIsGlibcxx ? p0 + " '" + name + "'\\s+what\\(\\):\\s+" + what :

--- a/folly/logging/test/RateLimiterTest.cpp
+++ b/folly/logging/test/RateLimiterTest.cpp
@@ -120,7 +120,10 @@ TEST(RateLimiter, concurrentThreads) {
   EXPECT_EQ(maxEvents, count.load(std::memory_order_relaxed));
 }
 
+#if __cplusplus > 201703L
+// std::chrono::years becomes visible in C++20 mode
 TEST(RateLimiter, LargeInterval) {
   IntervalRateLimiter limiter{1, std::chrono::hours{8765}}; // Just under a year
   EXPECT_TRUE(limiter.check());
 }
+#endif

--- a/folly/stats/DigestBuilder.h
+++ b/folly/stats/DigestBuilder.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include <folly/Memory.h>
 #include <folly/SpinLock.h>

--- a/folly/test/ConstexprMathTest.cpp
+++ b/folly/test/ConstexprMathTest.cpp
@@ -16,6 +16,7 @@
 
 #include <folly/ConstexprMath.h>
 
+#include <array>
 #include <cmath>
 #include <limits>
 #include <type_traits>


### PR DESCRIPTION
fix linux and macOS build

Summary:

linux and mac build was failing:
   * gcc and xcode hide std::chrono::years if C++ 20 mode not set.  Disable the affected test in this case
   * same with std::latch, also disable the affected test in this case

macOS build was failing with:

   * missing header includes, added them

macOS test run was failing with:
   * libcpp exception text has changed from "with" to "due to" which was breaking ExceptionTest.cpp, update the expectation to cover both.
   * FileUtilDetail.cpp was only enabling custom temp dir on linux, breaking FileUtilTest.cpp.  Enable custom temp dir for non-windows (i.e. mac and other unix) to fix it.

Test Plan:

CI.  Before, build error on vector
```
CMakeFiles/tdigest_benchmark.dir/folly/stats/test/TDigestBenchmark.cpp.o -MF CMakeFiles/tdigest_benchmark.dir/folly/stats/test/TDigestBenchmark.cpp.o.d -o CMakeFiles/tdigest_benchmark.dir/folly/stats/test/TDigestBenchmark.cpp.o -c /Users/runner/work/folly/folly/folly/stats/test/TDigestBenchmark.cpp
In file included from /Users/runner/work/folly/folly/folly/stats/test/TDigestBenchmark.cpp:17:
/Users/runner/work/folly/folly/folly/stats/DigestBuilder.h:59:25: error: implicit instantiation of undefined template 'std::vector<double>'
    std::vector<double> buffer;
```

then build error on array
```
CMakeFiles/constexpr_math_test.dir/folly/test/ConstexprMathTest.cpp.o -c /Users/runner/work/folly/folly/folly/test/ConstexprMathTest.cpp
/Users/runner/work/folly/folly/folly/test/ConstexprMathTest.cpp:38:29: error: implicit instantiation of undefined template 'std::array<unsigned long, 7>'
    std::array<res_t, size> res{};
```

the build error on std::chrono::year
```
/Users/alex/local/folly.sapling/folly/logging/test/RateLimiterTest.cpp:124:47: error: no member named 'years' in namespace 'std::chrono'
  IntervalRateLimiter limiter{1, std::chrono::years{1}};
```

then test failues

After, works

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/folly/pull/2073).
* #2074
* #2068
* #2084
* __->__ #2073