### PR TITLE
More MSVC Warnings Fixes

### DIFF
--- a/folly/concurrency/CacheLocality.cpp
+++ b/folly/concurrency/CacheLocality.cpp
@@ -467,7 +467,8 @@ class SimpleAllocator {
       // leave pointers that could hide leaks at shutdown, since the backing
       // slabs may not be deallocated if the instance is a leaky singleton.
       auto* base = static_cast<char*>(ptr);
-      std::fill(base + sizeof(void*), base + allocator->sz_, 0);
+      std::fill(
+          base + sizeof(void*), base + allocator->sz_, static_cast<char>(0));
     }
     allocator->freelist_ = ptr;
   }

--- a/folly/hash/Hash.h
+++ b/folly/hash/Hash.h
@@ -528,7 +528,7 @@ struct integral_hasher {
       auto const u = to_unsigned(i);
       auto const hi = static_cast<uint64_t>(u >> sizeof(Int) * 4);
       auto const lo = static_cast<uint64_t>(u);
-      return hash::hash_128_to_64(hi, lo);
+      return static_cast<size_t>(hash::hash_128_to_64(hi, lo));
     }
   }
 };


### PR DESCRIPTION
Summary: This fixes up a couple more MSVC warnings I ran into when trying to update the OSS React Native Windows build to a newer version of Folly. Specifically, another instance of C4146 "unary minus operator applied to unsigned type, result still unsigned", and a couple instances of C4244 "conversion from 'type1' to 'type2', possible loss of data"

Differential Revision: D50383545


