### PR TITLE
Make thenInline work when the previous Promise has already fullfilled

### DIFF
--- a/folly/futures/detail/Core.cpp
+++ b/folly/futures/detail/Core.cpp
@@ -20,6 +20,7 @@
 
 #include <fmt/core.h>
 #include <folly/Utility.h>
+#include <folly/futures/detail/Types.h>
 #include <folly/lang/Assume.h>
 
 namespace folly {
@@ -465,7 +466,11 @@ void CoreBase::setCallback_(
             std::memory_order_relaxed)) {
       terminate_unexpected_state("setCallback", state);
     }
-    doCallback(Executor::KeepAlive<>{}, state);
+    auto&& completingKA =
+        allowInline == futures::detail::InlineContinuation::permit
+        ? executor_.getKeepAliveExecutor()
+        : Executor::KeepAlive<>{};
+    doCallback(std::move(completingKA), allowInline);
   } else if (state == State::Proxy) {
     if (!folly::atomic_compare_exchange_strong_explicit(
             &state_,
@@ -507,7 +512,11 @@ void CoreBase::setResult_(Executor::KeepAlive<>&& completingKA) {
               std::memory_order_relaxed)) {
         terminate_unexpected_state("setResult", state);
       }
-      doCallback(std::move(completingKA), state);
+      doCallback(
+          std::move(completingKA),
+          state == State::OnlyCallbackAllowInline
+              ? futures::detail::InlineContinuation::permit
+              : futures::detail::InlineContinuation::forbid);
       return;
     case State::OnlyResult:
     case State::Proxy:
@@ -561,7 +570,8 @@ void CoreBase::setProxy_(CoreBase* proxy) {
 
 // May be called at most once.
 void CoreBase::doCallback(
-    Executor::KeepAlive<>&& completingKA, State priorState) {
+    Executor::KeepAlive<>&& completingKA,
+    futures::detail::InlineContinuation allowInline) {
   DCHECK(state_ == State::Done);
 
   auto executor = std::exchange(executor_, KeepAliveOrDeferred{});
@@ -587,7 +597,7 @@ void CoreBase::doCallback(
 
   if (executor) {
     // If we are not allowing inline, clear the completing KA to disallow
-    if (!(priorState == State::OnlyCallbackAllowInline)) {
+    if (allowInline == futures::detail::InlineContinuation::forbid) {
       completingKA = Executor::KeepAlive<>{};
     }
     exception_wrapper ew;

--- a/folly/futures/detail/Core.h
+++ b/folly/futures/detail/Core.h
@@ -516,7 +516,9 @@ class CoreBase {
 
   void setResult_(Executor::KeepAlive<>&& completingKA);
   void setProxy_(CoreBase* proxy);
-  void doCallback(Executor::KeepAlive<>&& completingKA, State priorState);
+  void doCallback(
+      Executor::KeepAlive<>&& completingKA,
+      futures::detail::InlineContinuation allowInline);
   void proxyCallback(State priorState);
 
   void detachOne() noexcept;


### PR DESCRIPTION
The main change is in `Core::setCallback_`,  if by the time when we call the `setCallback_`, the previous promise has already been fulfilled, we execute the callback inline, rather than schedule it to an executor