### PR TITLE
Implement support for RISC-V

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -185,7 +185,7 @@ message(STATUS "Setting FOLLY_HAVE_DWARF: ${FOLLY_HAVE_DWARF}")
 check_cxx_source_compiles("
   #include <atomic>
   int main(int argc, char** argv) {
-    struct Test { int val; };
+    struct Test { bool val; };
     std::atomic<Test> s;
     return static_cast<int>(s.is_lock_free());
   }"
@@ -197,7 +197,7 @@ if(NOT FOLLY_CPP_ATOMIC_BUILTIN)
   check_cxx_source_compiles("
     #include <atomic>
     int main(int argc, char** argv) {
-      struct Test { int val; };
+      struct Test { bool val; };
       std::atomic<Test> s2;
       return static_cast<int>(s2.is_lock_free());
     }"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,7 @@ list(APPEND folly_base_files
   ${files} ${hfiles}
 )
 
-if (NOT MSVC)
+if (IS_X86_64_ARCH AND NOT MSVC)
   set_property(
     SOURCE
     ${FOLLY_DIR}/memcpy.S

--- a/folly/DiscriminatedPtr.h
+++ b/folly/DiscriminatedPtr.h
@@ -35,8 +35,8 @@
 #include <folly/Portability.h>
 #include <folly/detail/DiscriminatedPtrDetail.h>
 
-#if !FOLLY_X64 && !FOLLY_AARCH64 && !FOLLY_PPC64
-#error "DiscriminatedPtr is x64, arm64 and ppc64 specific code."
+#if !FOLLY_X64 && !FOLLY_AARCH64 && !FOLLY_PPC64 && !FOLLY_RISCV64
+#error "DiscriminatedPtr is x64, arm64, ppc64 and riscv64 specific code."
 #endif
 
 namespace folly {

--- a/folly/GroupVarint.h
+++ b/folly/GroupVarint.h
@@ -31,7 +31,7 @@
 #error GroupVarint.h requires GCC or MSVC
 #endif
 
-#if FOLLY_X64 || defined(__i386__) || FOLLY_PPC64 || FOLLY_AARCH64
+#if FOLLY_X64 || defined(__i386__) || FOLLY_PPC64 || FOLLY_AARCH64 || FOLLY_RISCV64
 #define FOLLY_HAVE_GROUP_VARINT 1
 #else
 #define FOLLY_HAVE_GROUP_VARINT 0

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -119,12 +119,19 @@ constexpr bool kHasUnalignedAccess = false;
 #define FOLLY_S390X 0
 #endif
 
+#if defined(__riscv)
+#define FOLLY_RISCV64 1
+#else
+#define FOLLY_RISCV64 0
+#endif
+
 namespace folly {
 constexpr bool kIsArchArm = FOLLY_ARM == 1;
 constexpr bool kIsArchAmd64 = FOLLY_X64 == 1;
 constexpr bool kIsArchAArch64 = FOLLY_AARCH64 == 1;
 constexpr bool kIsArchPPC64 = FOLLY_PPC64 == 1;
 constexpr bool kIsArchS390X = FOLLY_S390X == 1;
+constexpr bool kIsArchRISCV64 = FOLLY_RISCV64 == 1;
 } // namespace folly
 
 namespace folly {

--- a/folly/container/detail/F14IntrinsicsAvailability.h
+++ b/folly/container/detail/F14IntrinsicsAvailability.h
@@ -32,7 +32,7 @@
 // If FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE differs across compilation
 // units the program will fail to link due to a missing definition of
 // folly::container::detail::F14LinkCheck<X>::check() for some X.
-#if (FOLLY_SSE >= 2 || (FOLLY_NEON && FOLLY_AARCH64)) && !FOLLY_MOBILE
+#if (FOLLY_SSE >= 2 || (FOLLY_NEON && FOLLY_AARCH64) || FOLLY_RISCV64) && !FOLLY_MOBILE
 #define FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE 1
 #else
 #define FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE 0

--- a/folly/container/detail/F14Mask.h
+++ b/folly/container/detail/F14Mask.h
@@ -47,11 +47,7 @@ FOLLY_ALWAYS_INLINE static unsigned findFirstSetNonZero(T mask) {
 using MaskType = uint64_t;
 
 constexpr unsigned kMaskSpacing = 4;
-#elif FOLLY_SSE >= 2
-using MaskType = uint32_t;
-
-constexpr unsigned kMaskSpacing = 1;
-#else
+#else // FOLLY_SSE >= 2 || FOLLY_RISCV64
 using MaskType = uint32_t;
 
 constexpr unsigned kMaskSpacing = 1;

--- a/folly/container/detail/F14Mask.h
+++ b/folly/container/detail/F14Mask.h
@@ -25,8 +25,9 @@
 #include <folly/Portability.h>
 #include <folly/lang/Assume.h>
 #include <folly/lang/SafeAssert.h>
+#include <folly/container/detail/F14IntrinsicsAvailability.h>
 
-#if (FOLLY_SSE >= 2 || (FOLLY_NEON && FOLLY_AARCH64)) && !FOLLY_MOBILE
+#if FOLLY_F14_VECTOR_INTRINSICS_AVAILABLE
 
 namespace folly {
 namespace f14 {
@@ -46,7 +47,11 @@ FOLLY_ALWAYS_INLINE static unsigned findFirstSetNonZero(T mask) {
 using MaskType = uint64_t;
 
 constexpr unsigned kMaskSpacing = 4;
-#else // SSE2
+#elif FOLLY_SSE >= 2
+using MaskType = uint32_t;
+
+constexpr unsigned kMaskSpacing = 1;
+#else
 using MaskType = uint32_t;
 
 constexpr unsigned kMaskSpacing = 1;

--- a/folly/container/detail/F14Table.h
+++ b/folly/container/detail/F14Table.h
@@ -69,7 +69,7 @@
 
 #if FOLLY_NEON
 #include <arm_neon.h> // uint8x16t intrinsics
-#else // SSE2
+#elif FOLLY_SSE >= 2 // SSE2
 #include <emmintrin.h> // _mm_set1_epi8
 #include <immintrin.h> // __m128i intrinsics
 #include <xmmintrin.h> // _mm_prefetch
@@ -247,7 +247,7 @@ FOLLY_ALWAYS_INLINE static void prefetchAddr(T const* ptr) {
   __builtin_prefetch(static_cast<void const*>(ptr));
 #elif FOLLY_NEON
   __prefetch(static_cast<void const*>(ptr));
-#else
+#elif FOLLY_SSE >= 2
   _mm_prefetch(
       static_cast<char const*>(static_cast<void const*>(ptr)), _MM_HINT_T0);
 #endif
@@ -255,8 +255,10 @@ FOLLY_ALWAYS_INLINE static void prefetchAddr(T const* ptr) {
 
 #if FOLLY_NEON
 using TagVector = uint8x16_t;
-#else // SSE2
+#elif FOLLY_SSE >= 2
 using TagVector = __m128i;
+#else
+using TagVector = __uint128_t;
 #endif
 
 // We could use unaligned loads to relax this requirement, but that
@@ -436,7 +438,7 @@ struct alignas(kRequiredVectorAlignment) F14Chunk {
     uint8x8_t maskV = vshrn_n_u16(vreinterpretq_u16_u8(occupiedV), 4);
     return vget_lane_u64(vreinterpret_u64_u8(maskV), 0) & kFullMask;
   }
-#else
+#elif FOLLY_SSE >= 2
   ////////
   // Tag filtering using SSE2 intrinsics
 
@@ -473,6 +475,30 @@ struct alignas(kRequiredVectorAlignment) F14Chunk {
   MaskType occupiedMask() const {
     auto tagV = _mm_load_si128(tagVector());
     return _mm_movemask_epi8(tagV) & kFullMask;
+  }
+#else
+  ////////
+  // Tag filtering using plain C/C++
+
+  SparseMaskIter tagMatchIter(std::size_t needle) const {
+    FOLLY_SAFE_DCHECK(needle >= 0x80 && needle < 0x100, "");
+    auto tagV = static_cast<uint8_t const*>(&tags_[0]);
+    MaskType mask = 0;
+    #pragma unroll 16
+    for (int i = 0; i < kCapacity; i++) {
+      mask |= ((tagV[i] == static_cast<uint8_t>(needle)) ? 1 : 0) << i;
+    }
+    return SparseMaskIter{mask & kFullMask};
+  }
+
+  MaskType occupiedMask() const {
+    auto tagV = static_cast<uint8_t const*>(&tags_[0]);
+    MaskType mask = 0;
+    #pragma unroll 16
+    for (int i = 0; i < kCapacity; i++) {
+      mask |= ((tagV[i] & 0x80) ? 1 : 0) << i;
+    }
+    return mask & kFullMask;
   }
 #endif
 
@@ -1156,7 +1182,7 @@ class F14Table : public Policy {
   // For hash functions we don't trust to avalanche, we repair things by
   // applying a bit mixer to the user-supplied hash.
 
-#if FOLLY_X64 || FOLLY_AARCH64
+#if FOLLY_X64 || FOLLY_AARCH64 || FOLLY_RISCV64
   // 64-bit
   static HashPair splitHash(std::size_t hash) {
     static_assert(sizeof(std::size_t) == sizeof(uint64_t), "");

--- a/folly/container/detail/F14Table.h
+++ b/folly/container/detail/F14Table.h
@@ -257,7 +257,7 @@ FOLLY_ALWAYS_INLINE static void prefetchAddr(T const* ptr) {
 using TagVector = uint8x16_t;
 #elif FOLLY_SSE >= 2
 using TagVector = __m128i;
-#else
+#elif FOLLY_HAVE_INT128_T
 using TagVector = __uint128_t;
 #endif
 
@@ -476,7 +476,7 @@ struct alignas(kRequiredVectorAlignment) F14Chunk {
     auto tagV = _mm_load_si128(tagVector());
     return _mm_movemask_epi8(tagV) & kFullMask;
   }
-#else
+#elif FOLLY_HAVE_INT128_T
   ////////
   // Tag filtering using plain C/C++
 

--- a/folly/container/detail/F14Table.h
+++ b/folly/container/detail/F14Table.h
@@ -484,7 +484,11 @@ struct alignas(kRequiredVectorAlignment) F14Chunk {
     FOLLY_SAFE_DCHECK(needle >= 0x80 && needle < 0x100, "");
     auto tagV = static_cast<uint8_t const*>(&tags_[0]);
     MaskType mask = 0;
-    #pragma unroll 16
+#if defined(__GNUC__)
+#pragma GCC unroll 16
+#else
+#pragma unroll 16
+#endif
     for (int i = 0; i < kCapacity; i++) {
       mask |= ((tagV[i] == static_cast<uint8_t>(needle)) ? 1 : 0) << i;
     }
@@ -494,7 +498,11 @@ struct alignas(kRequiredVectorAlignment) F14Chunk {
   MaskType occupiedMask() const {
     auto tagV = static_cast<uint8_t const*>(&tags_[0]);
     MaskType mask = 0;
-    #pragma unroll 16
+#if defined(__GNUC__)
+#pragma GCC unroll 16
+#else
+#pragma unroll 16
+#endif
     for (int i = 0; i < kCapacity; i++) {
       mask |= ((tagV[i] & 0x80) ? 1 : 0) << i;
     }

--- a/folly/io/async/Request.cpp
+++ b/folly/io/async/Request.cpp
@@ -117,7 +117,7 @@ struct RequestContext::State::Combined : hazptr_obj_base<Combined> {
   // Efficiency of copying the container also matters in setShallowCopyContext
   SingleWriterFixedHashMap<RequestToken, RequestData*> requestData_;
   // This must be optimized for iteration, its hot path is setContext
-  SingleWriterFixedHashMap<RequestData*, bool> callbackData_;
+  SingleWriterFixedHashMap<RequestData*, int> callbackData_;
   // Vector of cleared data. Accessed only sequentially by writers.
   std::vector<std::pair<RequestToken, RequestData*>> cleared_;
 

--- a/folly/small_vector.h
+++ b/folly/small_vector.h
@@ -49,7 +49,7 @@
 #include <folly/memory/Malloc.h>
 #include <folly/portability/Malloc.h>
 
-#if (FOLLY_X64 || FOLLY_PPC64 || FOLLY_AARCH64)
+#if (FOLLY_X64 || FOLLY_PPC64 || FOLLY_AARCH64 || FOLLY_RISCV64)
 #define FOLLY_SV_PACK_ATTR FOLLY_PACK_ATTR
 #define FOLLY_SV_PACK_PUSH FOLLY_PACK_PUSH
 #define FOLLY_SV_PACK_POP FOLLY_PACK_POP

--- a/folly/test/small_vector_test.cpp
+++ b/folly/test/small_vector_test.cpp
@@ -37,10 +37,10 @@
 
 using folly::small_vector;
 
-#if FOLLY_X64 || FOLLY_PPC64 || FOLLY_AARCH64
-
 using folly::small_vector_policy::policy_in_situ_only;
 using folly::small_vector_policy::policy_size_type;
+
+#if FOLLY_X64 || FOLLY_PPC64 || FOLLY_AARCH64 || FOLLY_RISCV64
 
 template <typename...>
 struct same_;


### PR DESCRIPTION
RISC-V is a growing platform, and Folly and commonly used dependency. We want to make sure that any projects that relies on Folly can be ported to RISC-V.

I'm verifying that everything builds and run correctly by cross-compiling it locally and passing the test suite using QEMU.