### PR TITLE
folly::tape

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -27,6 +27,11 @@
 #define FOLLY_CPLUSPLUS __cplusplus
 #endif
 
+// On MSVC an incorrect <version> header get's picked up
+#if !defined(_MSC_VER) && __has_include(<version>)
+#include <version>
+#endif
+
 static_assert(FOLLY_CPLUSPLUS >= 201402L, "__cplusplus >= 201402L");
 
 #if defined(__GNUC__) && !defined(__clang__)
@@ -606,4 +611,10 @@ constexpr auto kCpplibVer = 0;
 #define FOLLY_HAS_DEDUCTION_GUIDES 1
 #else
 #define FOLLY_HAS_DEDUCTION_GUIDES 0
+#endif
+// C++20 ranges
+#if defined(__cpp_lib_ranges)
+#define FOLLY_HAS_RANGES 1
+#else
+#define FOLLY_HAS_RANGES 0
 #endif

--- a/folly/container/detail/tape_detail.h
+++ b/folly/container/detail/tape_detail.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Portability.h>
+#include <folly/Range.h>
+#include <folly/container/Iterator.h>
+#include <folly/lang/Hint.h>
+#include <folly/memory/UninitializedMemoryHacks.h>
+
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#if FOLLY_HAS_STRING_VIEW
+#include <string_view>
+#endif
+
+#if FOLLY_HAS_RANGES
+#include <ranges>
+#endif
+
+namespace folly {
+namespace detail {
+
+template <template <typename...> class templ, typename T>
+struct instance_of : std::false_type {};
+
+template <template <typename...> class templ, typename... Args>
+struct instance_of<templ, templ<Args...>> : std::true_type {};
+
+template <template <typename...> class templ, typename T>
+constexpr bool instance_of_v = instance_of<templ, T>::value;
+
+#if FOLLLY_HAS_RANGES
+template <typename R>
+constexpr bool guaranteed_contigious_range_cpp20_v =
+    std::ranges::contigious_iterator<I>;
+#endif
+
+template <typename R>
+constexpr bool guaranteed_contigious_range_cpp17_v =
+    instance_of_v<std::vector, R> || instance_of_v<std::basic_string, R> ||
+    std::is_pointer_v<typename R::iterator>
+#if FOLLY_HAS_STRING_VIEW
+    || instance_of_v<std::basic_string_view, R>
+#endif
+    ;
+
+#if FOLLLY_HAS_RANGES
+
+template <typename R>
+constexpr bool guaranteed_contigious_range =
+    guaranteed_contigious_range_cpp20_v<R>;
+
+#else
+
+template <typename R>
+constexpr bool guaranteed_contigious_range =
+    guaranteed_contigious_range_cpp17_v<R>;
+
+#endif
+
+template <typename Container, bool = guaranteed_contigious_range<Container>>
+struct tape_reference_traits {
+  using iterator = typename Container::const_iterator;
+  using reference = Range<iterator>;
+
+  static reference make(iterator f, iterator l) { return reference{f, l}; }
+};
+
+template <typename Container>
+struct tape_reference_traits<Container, true> {
+  using iterator = typename Container::const_iterator;
+  using value_type = typename std::iterator_traits<iterator>::value_type;
+  using reference = Range<const value_type*>;
+
+  static auto* get_address(iterator it) {
+    // std::to_address is only available since C++20
+    if constexpr (std::is_pointer_v<iterator>) {
+      return it;
+    } else {
+      return it.operator->();
+    }
+  }
+
+  static reference make(iterator f, iterator l) {
+    return reference{get_address(f), get_address(l)};
+  }
+};
+
+template <typename R>
+using get_range_const_iterator_t =
+    decltype(std::cbegin(std::declval<const R&>()));
+
+struct fake_type {};
+
+template <typename R>
+using maybe_range_const_iterator_t =
+    detected_or_t<fake_type*, get_range_const_iterator_t, R>;
+
+template <typename R>
+using maybe_range_value_t =
+    iterator_value_type_t<maybe_range_const_iterator_t<R>>;
+
+// This is a big function to inline but it's used insie a big function too
+template <typename I, typename S>
+auto compute_total_tape_len_if_possible(I f, S l) {
+  using successs = std::pair<std::size_t, std::size_t>;
+  using failure = fake_type;
+  if constexpr (!iterator_category_matches_v<I, std::forward_iterator_tag>) {
+    return failure{};
+  } else if constexpr (std::is_convertible_v<
+                           iterator_value_type_t<I>,
+                           folly::StringPiece>) {
+    std::size_t records_size = 0U;
+    std::size_t flat_size = 0U;
+
+    for (I i = f; i != l; ++i) {
+      ++records_size;
+      flat_size += folly::StringPiece(*i).size();
+    }
+    return successs{records_size, flat_size};
+  } else if constexpr (!range_has_known_distance_v<iterator_value_type_t<I>>) {
+    return failure{};
+  } else {
+    std::size_t records_size = 0U;
+    std::size_t flat_size = 0U;
+
+    for (I i = f; i != l; ++i) {
+      ++records_size;
+      flat_size +=
+          static_cast<std::size_t>(std::distance(std::begin(*i), std::end(*i)));
+    }
+    return successs{records_size, flat_size};
+  }
+}
+
+template <typename Container, typename I, typename S>
+void append_range_unsafe(Container& c, I f, S l) {
+  if constexpr (
+      !iterator_category_matches_v<I, std::random_access_iterator_tag> ||
+      !std::is_trivially_copy_constructible_v<iterator_value_type_t<I>> ||
+      !(instance_of_v<std::vector, Container> ||
+        instance_of_v<std::basic_string, Container>)) {
+    c.insert(c.end(), f, l);
+  } else {
+    folly::compiler_may_unsafely_assume(l >= f);
+    auto old_size = c.size();
+    detail::unsafeVectorSetLargerSize(c, c.size() + (l - f));
+    std::copy(f, l, c.begin() + old_size);
+  }
+}
+
+} // namespace detail
+} // namespace folly

--- a/folly/container/tape.h
+++ b/folly/container/tape.h
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Portability.h>
+#include <folly/Range.h>
+#include <folly/container/Iterator.h>
+#include <folly/container/detail/tape_detail.h>
+#include <folly/memory/UninitializedMemoryHacks.h>
+
+#include <algorithm>
+#include <cassert>
+#include <initializer_list>
+#include <iterator>
+#include <numeric>
+#include <string_view>
+#include <type_traits>
+#include <vector>
+
+namespace folly {
+
+#if FOLLY_HAS_RANGES
+#define FOLLY_TAPE_CONTAINER_REQUIRES std::ranges::random_access_range
+#else
+#define FOLLY_TAPE_CONTAINER_REQUIRES
+#endif
+
+/* # Tape
+ *
+ * A container adapter, that builds a version of `vector<vector>` on top of a
+ * random access underlying container.
+ *
+ * Instead of having a container of containers it's more efficient to have
+ * a single container and store where the separators are.
+ *
+ *  >     >            >
+ * [ word second word  thrid word ]
+ *
+ * One subrange of internal elements we call a `record`.
+ *
+ * You can `push` a new `record` or pop one from the back.
+ * We also support an `erase` like `std::vector` but `insert` only for one
+ * element. (there is no reason for limitation, except it's not implemented).
+ *
+ * NOTE: for when you don't have the `record` ready, you can use a
+ * `record_builder` interface.
+ *
+ * Existing `records` can be accessed by index.
+ *
+ * Existing records cannot be mutated.
+ *
+ * NOTE: in theory there is nothing to prevent `tape<tape>` (and it could be
+ * useful) but that doesn't work at the moment.
+ *
+ * ## PERFORMANCE CHARACTERISTICS (folly/container/test/tape_bench):
+ *
+ * If you know for a fact that all the elements are fitting into SSO buffer,
+ * and you always have complete records (not building) then `tape` does not help
+ * you, or can even be a regression.
+ *
+ * Otherwise tape can give you good speedups, especially if you need to
+ * `push_back` on individual records.
+ *
+ * It is also much more cache friendly than vector of vectors,
+ * which can be relevant in prod.
+ *
+ * ## NAME TAPE
+ *
+ * Name tape is taken from a lecture by Alexander Stepanov but we are not 100%
+ * sure if this is the container he had in mind.
+ */
+template <FOLLY_TAPE_CONTAINER_REQUIRES Container>
+class tape;
+
+// string_tape - a common usecase.
+using string_tape = tape<std::vector<char>>;
+
+template <FOLLY_TAPE_CONTAINER_REQUIRES Container>
+class tape {
+  using ref_traits = detail::tape_reference_traits<Container>;
+
+ public:
+  using container_type = Container;
+
+  using const_reference = typename ref_traits::reference;
+  using reference = const_reference;
+
+  // value_type for tape does not make much sense.
+  // The best we found is to make reference type to be value type.
+  // This does not quite make sense but works well enough.
+  using value_type = const_reference;
+  using scalar_value_type = detail::maybe_range_value_t<container_type>;
+
+  using size_type = typename Container::size_type;
+  using difference_type = typename Container::difference_type;
+
+  using iterator = folly::index_iterator<const tape>;
+  using const_iterator = iterator;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  // concepts ------
+
+  template <typename I>
+  static constexpr bool iterator_of_scalars =
+      std::is_convertible_v<iterator_value_type_t<I>, scalar_value_type>;
+
+  template <typename I>
+  static constexpr bool range_of_scalars =
+      iterator_of_scalars<detail::maybe_range_const_iterator_t<I>>;
+
+  template <typename I>
+  static constexpr bool iterator_of_records =
+      range_of_scalars<iterator_value_type_t<I>>;
+
+  template <typename I>
+  static constexpr bool range_of_records =
+      iterator_of_records<detail::maybe_range_const_iterator_t<I>>;
+
+  // constructors -----
+
+  tape() = default;
+
+  template <
+      typename I,
+      typename S,
+      typename = std::enable_if_t<iterator_of_records<I>>>
+  explicit tape(I f, S l) {
+    range_constructor(f, l);
+  }
+
+  template <
+      typename R,
+      typename = std::enable_if_t<
+          std::is_convertible_v<R, const_reference> || range_of_records<R>>>
+  explicit tape(std::initializer_list<R> il) {
+    range_constructor(il.begin(), il.end());
+  }
+
+  // access ------
+
+  [[nodiscard]] const_reference operator[](size_type i) const {
+    return ref_traits::make(
+        data_.begin() + markers_[i], data_.begin() + markers_[i + 1]);
+  }
+
+  [[nodiscard]] bool empty() const { return size() == 0; }
+  [[nodiscard]] size_type size() const { return markers_.size() - 1; }
+  [[nodiscard]] size_type size_flat() const { return data_.size(); }
+
+  [[nodiscard]] const_reference front() const { return operator[](0); }
+  [[nodiscard]] const_reference back() const { return operator[](size() - 1); }
+
+  // iterators ----
+
+  [[nodiscard]] const_iterator begin() const { return {*this, 0}; }
+  [[nodiscard]] const_iterator cbegin() const { return begin(); }
+
+  [[nodiscard]] const_iterator end() const { return {*this, size()}; }
+  [[nodiscard]] const_iterator cend() const { return end(); }
+
+  [[nodiscard]] auto rbegin() const { return const_reverse_iterator{end()}; }
+  [[nodiscard]] auto crbegin() const { return rbegin(); }
+
+  [[nodiscard]] auto rend() const { return const_reverse_iterator{begin()}; }
+  [[nodiscard]] auto crend() const { return rend(); }
+
+  // push / emplace_back --------
+
+  template <typename I, typename S>
+  auto push_back(I f, S l) -> std::enable_if_t<iterator_of_scalars<I>> {
+    data_.insert(data_.end(), f, l);
+    markers_.push_back(static_cast<difference_type>(data_.size()));
+  }
+
+  template <typename R>
+  auto push_back(R&& r) -> std::enable_if_t<
+      range_of_scalars<R> &&
+      !std::is_convertible_v<R, const_reference>> // !convertible to handle \0
+  {
+    push_back(std::begin(r), std::end(r));
+  }
+
+  void push_back(const_reference r) { push_back(r.begin(), r.end()); }
+
+  void push_back(std::initializer_list<scalar_value_type> r) {
+    push_back(r.begin(), r.end());
+  }
+
+  void emplace_back() { push_back({}); }
+
+  template <typename... Args>
+  void emplace_back(Args&&... args) {
+    push_back(std::forward<decltype(args)>(args)...);
+  }
+
+  // push_back_unsafe --------
+  // like push_back but requires you to have enough capacity for added range.
+  // happened to give a 2x performance improvements on certain benchmarks.
+
+  // requires to have enough capacity
+  template <typename I, typename S>
+  auto push_back_unsafe(I f, S l) -> std::enable_if_t<iterator_of_scalars<I>> {
+    detail::append_range_unsafe(data_, f, l);
+    markers_.push_back(static_cast<difference_type>(data_.size()));
+  }
+
+  template <typename R>
+  auto push_back_unsafe(R&& r) -> std::enable_if_t<
+      range_of_scalars<R> &&
+      !std::is_convertible_v<R, const_reference>> // !convertible to handle \0
+  {
+    push_back_unsafe(std::begin(r), std::end(r));
+  }
+
+  void push_back_unsafe(const_reference r) {
+    push_back_unsafe(r.begin(), r.end());
+  }
+
+  // record builder (constructing last record) -------
+
+  class scoped_record_builder;
+  [[nodiscard]] scoped_record_builder record_builder();
+
+  // insert one record ----------
+
+  template <typename I, typename S>
+  auto insert(const_iterator pos, I f, S l)
+      -> std::enable_if_t<iterator_of_scalars<I>, iterator>;
+
+  template <std::ranges::input_range R>
+  auto insert(const_iterator pos, R&& r) -> std::enable_if_t<
+      range_of_scalars<R> && !std::is_convertible_v<R, const_reference>,
+      iterator> {
+    return insert(pos, std::ranges::begin(r), std::ranges::end(r));
+  }
+
+  iterator insert(
+      const_iterator pos, std::initializer_list<scalar_value_type> r) {
+    return insert(pos, r.begin(), r.end());
+  }
+
+  iterator insert(const_iterator pos, const_reference r) {
+    return insert(pos, r.begin(), r.end());
+  }
+
+  // capacity ------
+
+  void reserve(size_type records, size_type elements) {
+    markers_.reserve(records + 1);
+    data_.reserve(elements);
+  }
+
+  // assumes that 1 element per record. This is likely to help a bit.
+  void reserve(size_type records) {
+    markers_.reserve(records + 1);
+    data_.reserve(records);
+  }
+
+  // resize/clear -------
+
+  // same args as for push_back/emplace back are accepted
+  template <typename... Args>
+  void resize(size_type new_size, const Args&... args);
+
+  void clear() {
+    markers_.resize(1);
+    data_.clear();
+  }
+
+  // erase -------
+
+  void pop_back() {
+    data_.resize(data_.size() - back().size());
+    markers_.pop_back();
+  }
+
+  // note: same behaviour as for std::vector, erasing end() is UB
+  iterator erase(const_iterator pos) {
+    assert(pos != end());
+    return erase(pos, pos + 1);
+  }
+
+  iterator erase(const_iterator f, const_iterator l);
+
+  // ordering --------
+
+  friend bool operator==(const tape& x, const tape& y) {
+    return x.markers_ == y.markers_ && x.data_ == y.data_;
+  }
+
+  friend bool operator!=(const tape& x, const tape& y) { return !(x == y); }
+
+  friend bool operator<(const tape& x, const tape& y) {
+    return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
+  }
+
+  friend bool operator>(const tape& x, const tape& y) { return y < x; }
+  friend bool operator<=(const tape& x, const tape& y) { return !(y < x); }
+  friend bool operator>=(const tape& x, const tape& y) { return !(x < y); }
+
+ private:
+  template <typename I, typename S>
+  void range_constructor(I f, S l);
+
+  // NOTE: using container difference_type might be too much here but,
+  // on the other hand, there should be reasonably few items on the tape and
+  // this makes interface simpler.
+  std::vector<difference_type> markers_ = {0};
+  container_type data_;
+};
+
+// Allows you an easy to construct a last record in a similar way
+// you would an std::vector.
+template <FOLLY_TAPE_CONTAINER_REQUIRES Container>
+class tape<Container>::scoped_record_builder {
+ public:
+  scoped_record_builder(const scoped_record_builder&) = delete;
+  scoped_record_builder(scoped_record_builder&&) = delete;
+  scoped_record_builder& operator=(const scoped_record_builder&) = delete;
+  scoped_record_builder& operator=(scoped_record_builder&&) = delete;
+
+  using iterator = typename container_type::iterator;
+  using const_iterator = typename container_type::const_iterator;
+  using reference = std::iter_reference_t<iterator>;
+  using const_reference = std::iter_reference_t<const_iterator>;
+  using size_type = typename container_type::size_type;
+  using difference_type = std::iter_difference_t<iterator>;
+
+  // iterators -----
+
+  [[nodiscard]] iterator begin() {
+    return self_->data_.begin() + self_->markers_.back();
+  }
+  [[nodiscard]] const_iterator begin() const {
+    return self_->data_.cbegin() + self_->markers_.back();
+  }
+  [[nodiscard]] const_iterator cbegin() const { return begin(); }
+
+  [[nodiscard]] iterator end() { return self_->data_.end(); }
+  [[nodiscard]] const_iterator end() const { return self_->data_.cend(); }
+  [[nodiscard]] const_iterator cend() const { return end(); }
+
+  // sometimes functions (like fmt) optimize for vector back inserter.
+  // so better expose that.
+  [[nodiscard]] auto back_inserter() {
+    return std::back_inserter(self_->data_);
+  }
+
+  // access ---
+
+  [[nodiscard]] bool empty() const { return begin() == end(); }
+
+  [[nodiscard]] size_type size() const {
+    return static_cast<size_type>(end() - begin());
+  }
+
+  [[nodiscard]] reference operator[](size_type i) {
+    return begin()[static_cast<difference_type>(i)];
+  }
+
+  [[nodiscard]] const_reference operator[](size_type i) const {
+    return begin()[static_cast<difference_type>(i)];
+  }
+
+  [[nodiscard]] reference back() { return self_->data_.back(); }
+  [[nodiscard]] const_reference back() const { return self_->data_.back(); }
+
+  // mutators ---
+
+  void push_back(scalar_value_type x) { self_->data_.push_back(std::move(x)); }
+
+  template <typename... Args>
+  void emplace_back(Args&&... args) {
+    self_->data_.emplace_back(std::forward<Args>(args)...);
+  }
+
+  ~scoped_record_builder() { self_->markers_.push_back(self_->data_.size()); }
+
+ private:
+  friend class tape;
+
+  explicit scoped_record_builder(tape& self) : self_(&self) {}
+
+  tape* self_;
+};
+
+template <FOLLY_TAPE_CONTAINER_REQUIRES Container>
+auto tape<Container>::record_builder() -> scoped_record_builder {
+  return scoped_record_builder{*this};
+}
+
+template <FOLLY_TAPE_CONTAINER_REQUIRES Container>
+template <typename I, typename S>
+void tape<Container>::range_constructor(I f, S l) {
+  if constexpr (auto maybe = detail::compute_total_tape_len_if_possible(f, l);
+                std::is_same_v<decltype(maybe), detail::fake_type>) {
+    while (f != l) {
+      push_back(*f);
+      ++f;
+    }
+  } else {
+    auto [nrecords, total_len] = maybe;
+    reserve(nrecords, total_len);
+
+    while (f != l) {
+      push_back_unsafe(*f);
+      ++f;
+    }
+  }
+}
+
+template <FOLLY_TAPE_CONTAINER_REQUIRES Container>
+template <typename... Args>
+void tape<Container>::resize(size_type new_size, const Args&... args) {
+  if (new_size >= size()) {
+    new_size -= size();
+    while (new_size--) {
+      emplace_back(args...);
+    }
+    return;
+  }
+
+  data_.resize(markers_[new_size]);
+  markers_.resize(new_size + 1);
+}
+
+template <FOLLY_TAPE_CONTAINER_REQUIRES Container>
+template <typename I, typename S>
+auto tape<Container>::insert(const_iterator pos, I f, S l)
+    -> std::enable_if_t<iterator_of_scalars<I>, iterator> {
+  auto data_pos = data_.begin() + markers_[pos.get_index()];
+  size_type old_size = data_.size();
+  data_.insert(data_pos, f, l);
+
+  auto inserted_len = static_cast<difference_type>(data_.size() - old_size);
+
+  difference_type start = markers_[pos.get_index()];
+
+  auto markers_tail =
+      markers_.insert(markers_.begin() + pos.get_index(), start);
+  ++markers_tail;
+
+  std::transform(
+      markers_tail, markers_.end(), markers_tail, [&](difference_type m) {
+        return m + inserted_len;
+      });
+
+  // both tape* and index stayed the same
+  return pos;
+}
+
+template <FOLLY_TAPE_CONTAINER_REQUIRES Container>
+auto tape<Container>::erase(const_iterator f, const_iterator l) -> iterator {
+  difference_type from = f.get_index();
+  difference_type to = l.get_index();
+
+  auto markers_f = markers_.begin() + from;
+  auto markers_l = markers_.begin() + to;
+  auto data_f = data_.begin() + *markers_f;
+  auto data_l = data_.begin() + *markers_l;
+
+  std::ptrdiff_t removed_length = data_l - data_f;
+  std::transform(markers_l, markers_.end(), markers_l, [&](difference_type m) {
+    return m - removed_length;
+  });
+
+  markers_.erase(markers_f, markers_l);
+  data_.erase(data_f, data_l);
+
+  // both tape* and index stayed the same
+  return f;
+}
+
+#undef FOLLY_TAPE_CONTAINER_REQUIRES
+
+} // namespace folly

--- a/folly/container/test/tape_bench.cpp
+++ b/folly/container/test/tape_bench.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/container/tape.h>
+
+#include <random>
+#include <string>
+#include <vector>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+namespace {
+
+using vec_str = std::vector<std::string>;
+using st_tape = folly::string_tape;
+using vv_int = std::vector<std::vector<int>>;
+using tv_int = folly::tape<std::vector<int>>;
+
+template <typename Cont>
+struct ContGenerator {
+  ContGenerator(std::size_t minLen, std::size_t maxLen)
+      : g(minLen + maxLen), len(minLen, maxLen) {}
+
+  const Cont& operator()() {
+    buf.resize(len(g));
+    return buf; // we don't care for contents
+  }
+
+  std::mt19937 g;
+  std::uniform_int_distribution<std::size_t> len;
+
+  Cont buf;
+};
+
+template <typename Cont, std::size_t n, std::size_t minLen, std::size_t maxLen>
+const std::vector<Cont>& generateContainers() {
+  static const std::vector<Cont> res = [] {
+    ContGenerator<Cont> gen{minLen, maxLen};
+    std::vector<Cont> r;
+    r.reserve(n);
+    for (std::size_t i = 0; i != n; ++i) {
+      r.push_back(gen());
+    }
+    return r;
+  }();
+
+  return res;
+}
+
+template <
+    typename StringContainer,
+    std::size_t n,
+    std::size_t minLen,
+    std::size_t maxLen>
+void constructorStrings(std::size_t iters) {
+  const auto& strings = generateContainers<std::string, n, minLen, maxLen>();
+
+  while (iters--) {
+    StringContainer cont{strings.begin(), strings.end()};
+    folly::doNotOptimizeAway(cont);
+  }
+}
+
+template <typename T>
+void pushBackByOne(
+    std::vector<std::vector<T>>& cont, const std::vector<std::vector<T>>& in) {
+  for (const auto& v : in) {
+    cont.emplace_back();
+    for (const auto& x : v) {
+      cont.back().push_back(x);
+    }
+  }
+}
+
+template <typename T>
+void pushBackByOne(
+    folly::tape<std::vector<T>>& cont, const std::vector<std::vector<T>>& in) {
+  for (const auto& v : in) {
+    auto builder = cont.record_builder();
+    for (const auto& x : v) {
+      builder.push_back(x);
+    }
+  }
+}
+
+template <
+    typename Container,
+    std::size_t n,
+    std::size_t minLen,
+    std::size_t maxLen>
+void pushBackInts(std::size_t iters) {
+  const auto& vecs = generateContainers<std::vector<int>, n, minLen, maxLen>();
+
+  while (iters--) {
+    Container r;
+    pushBackByOne(r, vecs);
+    folly::doNotOptimizeAway(r);
+  }
+}
+
+// Disabling clang format for table formatting
+// clang-format off
+BENCHMARK(PushBackVecInts_20_0_15,   n) { pushBackInts<vv_int, 20, 0, 15>(n); }
+BENCHMARK(PushBackTapeInts_20_0_15,  n) { pushBackInts<tv_int, 20, 0, 15>(n); }
+BENCHMARK_DRAW_LINE();
+BENCHMARK(ConstructVecSmallStrings_20_0_15,   n) { constructorStrings<vec_str, 20, 0, 15>(n); }
+BENCHMARK(ConstructTapeSmallStrings_20_0_15,  n) { constructorStrings<st_tape, 20, 0, 15>(n); }
+BENCHMARK(ConstructVecLargeStrings_20_16_32,  n) { constructorStrings<vec_str, 20, 16, 32>(n); }
+BENCHMARK(ConstructTapeLargeStrings_20_16_32, n) { constructorStrings<st_tape, 20, 16, 32>(n); }
+BENCHMARK_DRAW_LINE();
+BENCHMARK(ConstructVec2SmallStrings,    n) { constructorStrings<vec_str, 2, 0, 15>(n); }
+BENCHMARK(ConstructTape2SmallStrings,   n) { constructorStrings<st_tape, 2, 0, 15>(n); }
+// clang-format on
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/folly/container/test/tape_test.cpp
+++ b/folly/container/test/tape_test.cpp
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/container/tape.h>
+
+#include <forward_list>
+#include <iterator>
+#include <vector>
+#include <folly/portability/GMock.h>
+#include <folly/portability/GTest.h>
+#include <folly/small_vector.h>
+
+namespace {
+
+template <typename I>
+struct InputIter {
+  I wrapped;
+
+  using value_type = typename std::iterator_traits<I>::value_type;
+  using reference = typename std::iterator_traits<I>::reference;
+  using difference_type = typename std::iterator_traits<I>::difference_type;
+  using pointer = typename std::iterator_traits<I>::pointer;
+  using iterator_category = std::input_iterator_tag;
+
+  InputIter& operator++() {
+    ++wrapped;
+    return *this;
+  }
+
+  reference operator*() const { return *wrapped; }
+
+  auto operator++(int) { operator++(); }
+
+  friend bool operator==(const InputIter& x, const InputIter& y) {
+    return x.wrapped == y.wrapped;
+  }
+  friend bool operator!=(const InputIter& x, const InputIter& y) {
+    return !(x == y);
+  }
+};
+
+template <typename T>
+struct InputRange {
+  std::vector<T> c_;
+  using iterator = InputIter<typename std::vector<T>::const_iterator>;
+
+  iterator begin() const { return iterator{c_.begin()}; }
+  iterator end() const { return iterator{c_.end()}; }
+};
+
+#if FOLLY_HAS_RANGES
+static_assert(!std::forward_iterator<InputIter<int*>>);
+static_assert(std::input_iterator<InputIter<int*>>);
+#endif
+
+template <typename T>
+auto asRange(const std::vector<T>& c, std::input_iterator_tag) {
+  return InputRange<T>{c};
+}
+
+template <typename T>
+auto asRange(const std::vector<T>& c, std::forward_iterator_tag) {
+  return std::forward_list<T>{c.begin(), c.end()};
+}
+
+template <typename T>
+auto asRange(const std::vector<T>& c, std::random_access_iterator_tag) {
+  return c;
+}
+
+} // namespace
+
+// tape types
+
+static_assert(
+    std::is_same_v<folly::StringPiece, folly::string_tape::reference>, "");
+static_assert(
+    std::is_same_v<folly::StringPiece, folly::string_tape::value_type>, "");
+static_assert(
+    std::is_same_v<
+        folly::Range<const int*>,
+        folly::tape<std::vector<int>>::reference>,
+    "");
+static_assert(
+    std::is_same_v<
+        folly::Range<const int*>,
+        folly::tape<std::vector<int>>::value_type>,
+    "");
+static_assert(
+    std::is_same_v<
+        folly::Range<const int*>,
+        folly::tape<folly::small_vector<int, 4>>::reference>,
+    "");
+
+#if FOLLY_HAS_RANGES
+static_assert(std::ranges::random_access_range<folly::string_tape>);
+#endif
+
+TEST(Tape, SmokeTest) {
+  folly::string_tape st;
+
+  st.push_back("abc");
+  st.push_back("def");
+
+  ASSERT_EQ("abc", st[0]);
+  ASSERT_EQ("def", st[1]);
+  ASSERT_EQ("abc", st.front());
+  ASSERT_EQ("def", st.back());
+}
+
+TEST(Tape, IntTape) {
+  folly::tape<std::vector<int>> t;
+  t.push_back({1, 2});
+  t.emplace_back(std::vector{3});
+
+  ASSERT_EQ(1, t[0][0]);
+  ASSERT_EQ(2, t[0][1]);
+  ASSERT_EQ(3, t[1][0]);
+}
+
+TEST(Tape, Count) {
+  folly::string_tape st{"abc", "def", "bla", "abc"};
+
+  ASSERT_EQ(2U, (std::count(st.begin(), st.end(), "abc")));
+  ASSERT_EQ(2U, (std::count(st.cbegin(), st.cend(), "abc")));
+  ASSERT_EQ(2U, (std::count(st.rbegin(), st.rend(), "abc")));
+  ASSERT_EQ(2U, (std::count(st.crbegin(), st.crend(), "abc")));
+}
+
+TEST(Tape, TwoItersConstructor) {
+  auto tst = [&](auto tag) {
+    {
+      const std::vector<std::vector<int>> a{{1, 2}, {3, 4, 5}};
+
+      auto input = asRange(a, tag);
+      folly::tape<std::vector<int>> t{input.begin(), input.end()};
+      ASSERT_EQ(2, t.size());
+      ASSERT_EQ(folly::crange(a[0]), t[0]);
+      ASSERT_EQ(folly::crange(a[1]), t[1]);
+    }
+    {
+      const std::vector<std::vector<int>> empty;
+      auto input = asRange(empty, tag);
+      folly::tape<std::vector<int>> t{input.begin(), input.end()};
+      ASSERT_EQ(0, t.size());
+      ASSERT_TRUE(t.empty());
+    }
+    {
+      const std::vector<std::vector<int>> emptyRow{{1, 2}, {}, {3, 4, 5}};
+      auto input = asRange(emptyRow, tag);
+      folly::tape<std::vector<int>> t{input.begin(), input.end()};
+      ASSERT_EQ(3, t.size());
+      ASSERT_EQ(folly::crange(emptyRow[0]), t[0]);
+      ASSERT_EQ(folly::crange(emptyRow[1]), t[1]);
+      ASSERT_EQ(folly::crange(emptyRow[2]), t[2]);
+    }
+  };
+
+  tst(std::input_iterator_tag{});
+  tst(std::forward_iterator_tag{});
+  tst(std::random_access_iterator_tag{});
+}
+
+TEST(Tape, InitListNotStrings) {
+  std::vector<int> a[] = {{1, 2}, {3, 4, 5}, {6, 7}};
+
+  folly::tape<std::vector<int>> t{a[0], a[1], a[2]};
+  ASSERT_EQ(3, t.size());
+  ASSERT_EQ(folly::crange(a[0]), t[0]);
+  ASSERT_EQ(folly::crange(a[1]), t[1]);
+  ASSERT_EQ(folly::crange(a[2]), t[2]);
+}
+
+TEST(Tape, Ordering) {
+  const folly::string_tape st1{"abc", "def"};
+  const folly::string_tape st2{"abcd", "ef"};
+
+  ASSERT_EQ(st1, st1);
+  ASSERT_NE(st1, st2);
+
+  ASSERT_LT(st1, st2);
+  ASSERT_LE(st1, st2);
+  ASSERT_LE(st1, st1);
+
+  ASSERT_GT(st2, st1);
+  ASSERT_GE(st2, st1);
+  ASSERT_GE(st1, st1);
+}
+
+TEST(Tape, RecordBuilder) {
+  folly::string_tape st;
+
+  {
+    auto builder = st.record_builder();
+    ASSERT_TRUE(builder.empty());
+    ASSERT_EQ(0U, builder.size());
+    builder.push_back('a');
+    builder.push_back('b');
+    ASSERT_FALSE(builder.empty());
+    ASSERT_EQ(2U, builder.size());
+
+    ASSERT_EQ('b', builder.back());
+    ASSERT_EQ('b', std::as_const(builder).back());
+
+    ASSERT_EQ(std::string_view(builder.begin(), builder.end()), "ab");
+    ASSERT_EQ(std::string_view(builder.cbegin(), builder.cend()), "ab");
+    *builder.begin() = 'c';
+  }
+  {
+    auto builder = st.record_builder();
+    builder.emplace_back('d');
+    builder[0] = 'e';
+    ASSERT_EQ(std::as_const(builder)[0], 'e');
+  }
+  {
+    auto builder = st.record_builder();
+    builder.emplace_back(); // test emplace with default constructor
+    builder[0] = 'a';
+    ASSERT_EQ(std::as_const(builder)[0], 'a');
+  }
+  {
+    auto builder = st.record_builder();
+    constexpr std::string_view s = "abc";
+    std::copy(s.begin(), s.end(), builder.back_inserter());
+  }
+
+  ASSERT_EQ("cb", st[0]);
+  ASSERT_EQ("e", st[1]);
+  ASSERT_EQ("a", st[2]);
+  ASSERT_EQ("abc", st[3]);
+  ASSERT_EQ(7U, st.size_flat());
+  ASSERT_EQ(4U, st.size());
+
+  st.pop_back();
+  ASSERT_EQ("cb", st[0]);
+  ASSERT_EQ("e", st[1]);
+  ASSERT_EQ("a", st[2]);
+  ASSERT_EQ(4U, st.size_flat());
+  ASSERT_EQ(3U, st.size());
+
+  st.pop_back();
+  ASSERT_EQ("cb", st[0]);
+  ASSERT_EQ("e", st[1]);
+  ASSERT_EQ(2U, st.size());
+  ASSERT_EQ(3U, st.size_flat());
+
+  st.pop_back();
+  ASSERT_EQ("cb", st[0]);
+  ASSERT_EQ(1U, st.size());
+  ASSERT_EQ(2U, st.size_flat());
+
+  st.pop_back();
+  ASSERT_EQ(0U, st.size());
+  ASSERT_EQ(0U, st.size_flat());
+}
+
+TEST(Tape, PushBack) {
+  folly::tape<std::vector<int>> t;
+
+  auto tst = [&](auto tag) mutable {
+    t.clear();
+    ASSERT_EQ(0, t.size());
+
+    std::vector<int> a{1, 2, 3}, b{4, 5}, c;
+    t.push_back(asRange(a, tag));
+    ASSERT_EQ(1, t.size());
+    ASSERT_EQ(folly::crange(a), t[0]);
+
+    t.push_back(asRange(b, tag));
+    ASSERT_EQ(2, t.size());
+    ASSERT_EQ(folly::crange(a), t[0]);
+    ASSERT_EQ(folly::crange(b), t[1]);
+
+    t.push_back(c);
+    ASSERT_EQ(3, t.size());
+    ASSERT_EQ(folly::crange(a), t[0]);
+    ASSERT_EQ(folly::crange(b), t[1]);
+    ASSERT_EQ(folly::crange(c), t[2]);
+  };
+
+  tst(std::input_iterator_tag{});
+  tst(std::forward_iterator_tag{});
+  tst(std::random_access_iterator_tag{});
+}
+
+TEST(Tape, PushBackStr) {
+  folly::string_tape st;
+
+  st.push_back("abc");
+  st.push_back({'d', 'e'});
+
+  constexpr std::string_view c = "fgh";
+  st.push_back(c);
+  constexpr std::string_view d = "ijklm";
+  st.push_back(d.begin(), d.end());
+  ASSERT_THAT(st, testing::ElementsAre("abc", "de", "fgh", "ijklm"));
+}
+
+TEST(Tape, EmptyRecord) {
+  folly::tape<std::vector<int>> t;
+
+  t.push_back({});
+  t.push_back({});
+
+  ASSERT_EQ(2U, t.size());
+  ASSERT_TRUE(t[0].empty());
+  ASSERT_TRUE(t[1].empty());
+}
+
+TEST(Tape, Resize) {
+  folly::string_tape st{"ab", "abc", "abcd", "de"};
+
+  st.resize(6U);
+  ASSERT_THAT(st, testing::ElementsAre("ab", "abc", "abcd", "de", "", ""));
+
+  st.resize(2U);
+  ASSERT_THAT(st, testing::ElementsAre("ab", "abc"));
+
+  st.resize(2U);
+  ASSERT_THAT(st, testing::ElementsAre("ab", "abc"));
+
+  st.push_back("abcd");
+  ASSERT_THAT(st, testing::ElementsAre("ab", "abc", "abcd"));
+
+  st.resize(0U);
+  ASSERT_TRUE(st.empty());
+
+  st.push_back("ab");
+  ASSERT_THAT(st, testing::ElementsAre("ab"));
+}
+
+TEST(Tape, EmptyStrings) {
+  folly::string_tape st{"a"};
+  st.push_back("");
+  ASSERT_THAT(st, testing::ElementsAre("a", ""));
+
+  st.emplace_back();
+
+  ASSERT_THAT(st, testing::ElementsAre("a", "", ""));
+
+  st.erase(st.begin() + 1, st.end());
+
+  ASSERT_THAT(st, testing::ElementsAre("a"));
+  st.emplace_back();
+  st.emplace_back("bd");
+  ASSERT_THAT(st, testing::ElementsAre("a", "", "bd"));
+}
+
+TEST(Tape, InsertOne) {
+  auto tst = [](auto tag) {
+    folly::tape<std::vector<int>> t;
+
+    std::vector<int> a{1, 2, 3}, b{4, 5}, c{6, 7, 8}, d{};
+
+    {
+      auto pos = t.insert(t.end(), asRange(a, tag));
+      ASSERT_EQ(pos - t.begin(), 0);
+      ASSERT_THAT(t, testing::ElementsAre(a));
+    }
+    {
+      auto pos = t.insert(t.end(), asRange(c, tag));
+
+      ASSERT_EQ(pos - t.begin(), 1);
+      ASSERT_THAT(t, testing::ElementsAre(a, c));
+    }
+    {
+      auto pos = t.insert(t.begin() + 1, asRange(b, tag));
+
+      ASSERT_EQ(pos - t.begin(), 1);
+      ASSERT_THAT(t, testing::ElementsAre(a, b, c));
+    }
+    {
+      auto pos = t.insert(t.begin() + 2, asRange(d, tag));
+
+      ASSERT_EQ(pos - t.begin(), 2);
+      ASSERT_THAT(t, testing::ElementsAre(a, b, d, c));
+    }
+  };
+
+  tst(std::input_iterator_tag{});
+  tst(std::forward_iterator_tag{});
+  tst(std::random_access_iterator_tag{});
+}
+
+TEST(Tape, InsertOneStr) {
+  folly::string_tape st;
+  auto pos = st.insert(st.end(), "ab");
+  ASSERT_EQ(pos - st.begin(), 0);
+  ASSERT_THAT(st, testing::ElementsAre("ab"));
+
+  {
+    std::string s("cde");
+    pos = st.insert(st.end(), s.begin(), s.end());
+    ASSERT_EQ(pos - st.begin(), 1);
+    ASSERT_THAT(st, testing::ElementsAre("ab", "cde"));
+  }
+
+  {
+    pos = st.insert(st.begin() + 1, {'0', '1'});
+    ASSERT_EQ(pos - st.begin(), 1);
+    ASSERT_THAT(st, testing::ElementsAre("ab", "01", "cde"));
+  }
+
+  {
+    std::forward_list<char> in{'1', '2', '3'};
+    pos = st.insert(st.begin(), in);
+    ASSERT_EQ(pos - st.begin(), 0);
+    ASSERT_THAT(st, testing::ElementsAre("123", "ab", "01", "cde"));
+  }
+}
+
+TEST(Tape, EraseOne) {
+  folly::string_tape st{"ab", "abc", "abcd", "de"};
+  folly::string_tape::iterator pos = st.erase(st.cbegin() + 1);
+
+  ASSERT_EQ(1, pos - st.begin());
+  ASSERT_THAT(st, testing::ElementsAre("ab", "abcd", "de"));
+
+  // tape is still functional
+  st.push_back("ef");
+  ASSERT_THAT(st, testing::ElementsAre("ab", "abcd", "de", "ef"));
+
+  ASSERT_EQ(st.erase(st.cbegin()) - st.cbegin(), 0);
+  ASSERT_THAT(st, testing::ElementsAre("abcd", "de", "ef"));
+
+  ASSERT_EQ(st.erase(st.begin() + 1) - st.cbegin(), 1);
+  ASSERT_THAT(st, testing::ElementsAre("abcd", "ef"));
+
+  ASSERT_EQ(st.erase(st.cend() - 1) - st.cbegin(), 1);
+  ASSERT_THAT(st, testing::ElementsAre("abcd"));
+
+  ASSERT_EQ(st.erase(st.cbegin()) - st.cbegin(), 0);
+  ASSERT_TRUE(st.empty());
+}
+
+TEST(Tape, EraseRange) {
+  folly::string_tape st{"ab", "abc", "abcd", "de"};
+
+  folly::string_tape::iterator pos = st.erase(st.cbegin() + 1, st.cend() - 1);
+  ASSERT_THAT(st, testing::ElementsAre("ab", "de"));
+  ASSERT_EQ(pos - st.begin(), 1);
+
+  pos = st.erase(st.end(), st.end());
+  ASSERT_THAT(st, testing::ElementsAre("ab", "de"));
+  ASSERT_EQ(pos - st.begin(), 2);
+}
+
+TEST(Tape, Iteration) {
+  folly::string_tape st{"0", "10", "100", "1000"};
+  ASSERT_THAT(st, testing::ElementsAre("0", "10", "100", "1000"));
+
+  folly::string_tape st2(st.rbegin(), st.rend());
+  ASSERT_THAT(st2, testing::ElementsAre("1000", "100", "10", "0"));
+}

--- a/folly/portability/Constexpr.h
+++ b/folly/portability/Constexpr.h
@@ -23,11 +23,6 @@
 #include <cstring>
 #include <type_traits>
 
-// On MSVC an incorrect <version> header get's picked up
-#if !defined(_MSC_VER) && __has_include(<version>)
-#include <version>
-#endif
-
 namespace folly {
 
 namespace detail {

--- a/folly/test/PortabilityTest.cpp
+++ b/folly/test/PortabilityTest.cpp
@@ -20,6 +20,10 @@
 #include <string_view> // @manual
 #endif
 
+#if FOLLY_HAS_RANGES
+#include <ranges>
+#endif
+
 #include <memory>
 
 #include <folly/portability/GTest.h>
@@ -50,3 +54,7 @@ TEST(Portability, Final) {
   EXPECT_EQ(3, fooBase(p.get()));
   EXPECT_EQ(3, fooDerived(p.get()));
 }
+
+#if FOLLY_HAS_RANGES
+static_assert(std::ranges::random_access_range<std::vector<int>>);
+#endif


### PR DESCRIPTION
Summary:
A better version of `vector<vector>` for some scenarios.
Can also be an ok `vector<string>` if not everything is small vectors


Basic usecase: building vector<vector> by pushing one element at a time, no reserve.
```
PushBackVecInts_20_0_15                                     1.28us   782.19K
PushBackTapeInts_20_0_15                                  317.49ns     3.15M
```

Constructing a vector of strings (20 strings). When  everything is SSO, there is no point in tape. However, when we allocate, tape begins to win big.

```
ConstructVecSmallStrings_20_0_15                          122.31ns     8.18M
ConstructTapeSmallStrings_20_0_15                         129.04ns     7.75M
ConstructVecLargeStrings_20_16_32                         319.24ns     3.13M
ConstructTapeLargeStrings_20_16_32                        147.52ns     6.78M
```

Worst case scenario - 2 small strings. Overhead of tape makes this slower. We could tackle this but it requires very complicated code and so far, not the use case encountered.
```
ConstructVec2SmallStrings                                  20.95ns    47.74M
ConstructTape2SmallStrings                                 38.83ns    25.75M
```

Differential Revision: D52260714


