### PR TITLE
symbolizer: don't crash if SymbolizedFrame::name is nullptr on entry to Dwarf::findAddress()

### DIFF
--- a/folly/experimental/symbolizer/DwarfImpl.cpp
+++ b/folly/experimental/symbolizer/DwarfImpl.cpp
@@ -238,7 +238,7 @@ bool DwarfImpl::findLocation(
     // - e.g. coroutines may add .resume/.destroy/.cleanup suffixes
     //   to the symbol name, but not to DW_AT_linkage_name.
     // - If names share a common prefix, prefer the more specific name.
-    if (!folly::StringPiece(frame.name).startsWith(name)) {
+    if (!frame.name || !folly::StringPiece(frame.name).startsWith(name)) {
       frame.name = name.data();
     }
   }


### PR DESCRIPTION
This can occur when using `Dwarf::findAddress()` directly, rather than through the folly symbolizer.