### PR TITLE
symbolizer: cache each DWARF DIE's nextOffset and nextSiblingOffset

### DIFF
--- a/folly/experimental/symbolizer/DwarfUtil.cpp
+++ b/folly/experimental/symbolizer/DwarfUtil.cpp
@@ -782,8 +782,13 @@ size_t forEachAttribute(
     if (!f(attr)) {
       return static_cast<size_t>(-1);
     }
+    if (spec.name == DW_AT_sibling && !die.nextSiblingOffset &&
+        spec.form != DW_FORM_ref_addr) {
+      die.nextSiblingOffset = cu.offset + boost::get<uint64_t>(attr.attrValue);
+    }
   }
-  return values.data() - cu.debugSections.debugInfo.data();
+  die.nextOffset = values.data() - cu.debugSections.debugInfo.data();
+  return die.nextOffset;
 }
 
 folly::StringPiece getFunctionNameFromDie(

--- a/folly/experimental/symbolizer/DwarfUtil.h
+++ b/folly/experimental/symbolizer/DwarfUtil.h
@@ -133,6 +133,23 @@ struct Die {
   uint8_t attrOffset = 0;
   // Offset within debug info.
   uint32_t offset = 0;
+
+  // If nonzero, nextOffset is the offset within .debug_info
+  // corresponding to the beginning of this DIE's first child or next
+  // sibling (depending on whether abbr.hasChildren). This is what
+  // forEachAttribute() would return. So nextOffset - offset is the
+  // length of this DIE. If this points to a zero byte then there
+  // are no children or no further siblings. If the offset itself
+  // is zero, we don't know yet what it should be.
+  mutable uint32_t nextOffset = 0;
+
+  // If nonzero, nextSiblingOffset is the offset within .debug_info
+  // corresponding to the beginning of this DIE's next sibling.
+  // This is what forEachChild() would return. If this points to
+  // a zero byte then there are no further siblings. If the offset
+  // itself is zero, we don't know yet what it should be.
+  mutable uint32_t nextSiblingOffset = 0;
+
   uint64_t code = 0;
   DIEAbbreviation abbr;
 };


### PR DESCRIPTION
This avoids exponential growth in runtime when parsing deeply nested debug info. The scenario that would otherwise lead to exponential growth involves `forEachChild()` with an argument lambda that itself recurses into children. At each layer of depth, `forEachChild()` iterates over all indirect children (to skip them) and so does the argument lambda (to process the top-level ones and recurse on their children). So each top-level DIE is visited twice, each second-level is visited four times, each third-level one is visited eight times, and so on.