### PR TITLE
symbolizer: add support for looking up CUs using the .gdb_index if present

### DIFF
--- a/folly/experimental/symbolizer/DwarfUtil.cpp
+++ b/folly/experimental/symbolizer/DwarfUtil.cpp
@@ -478,7 +478,8 @@ CompilationUnits getCompilationUnits(
       .debugRanges = cu.mainCompilationUnit.debugSections.debugRanges,
       .debugRnglists = getElfSection(elf, ".debug_rnglists.dwo"),
       .debugStr = getElfSection(elf, ".debug_str.dwo"),
-      .debugStrOffsets = getElfSection(elf, ".debug_str_offsets.dwo")};
+      .debugStrOffsets = getElfSection(elf, ".debug_str_offsets.dwo"),
+      .gdbIndex = {}};
   if (splitCU.debugSections.debugInfo.empty() ||
       splitCU.debugSections.debugAbbrev.empty() ||
       splitCU.debugSections.debugLine.empty() ||

--- a/folly/experimental/symbolizer/DwarfUtil.h
+++ b/folly/experimental/symbolizer/DwarfUtil.h
@@ -56,6 +56,7 @@ struct DebugSections {
   folly::StringPiece debugRnglists; // .debug_rnglists (DWARF 5)
   folly::StringPiece debugStr; // .debug_str
   folly::StringPiece debugStrOffsets; // .debug_str_offsets (DWARF 5)
+  folly::StringPiece gdbIndex; // .gdb_index (GNU extension)
 };
 
 // Abbreviation for a Debugging Information Entry.


### PR DESCRIPTION
This provides similar information as `.debug_aranges` but is better supported on DWARFv4 and with clang. Since it is generated at link time, it has the additional benefit that it is complete, meaning it can return negative results (for symbols such as `_start` that may be implemented in assembly and thus have no associated debug info) without walking the full debuginfo list.
