### PR TITLE
Move the event callback to new item

### DIFF
--- a/folly/TimeoutQueue.cpp
+++ b/folly/TimeoutQueue.cpp
@@ -62,7 +62,7 @@ int64_t TimeoutQueue::runInternal(int64_t now, bool onceOnly) {
             {event.id,
              now + event.repeatInterval,
              event.repeatInterval,
-             event.callback});
+             std::move(event.callback)});
       }
     }
 


### PR DESCRIPTION
move the the event.callback can avoid a copy