### PR TITLE
[NFC] Remove IsRelocatable's TODO; it's more of a WONTDO

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -614,9 +614,6 @@ struct IsRelocatable
     : std::conditional<
           sizeof(T) && is_detected_v<traits_detail::detect_IsRelocatable, T>,
           traits_detail::has_true_IsRelocatable<T>,
-          // TODO add this line (and some tests for it) when we
-          // upgrade to gcc 4.7
-          // std::is_trivially_move_constructible<T>::value ||
           is_trivially_copyable<T>>::type {};
 
 template <class T>


### PR DESCRIPTION
(attn @JoeLoser, @mengz0, @yfeldblum)

See 93b0f543f2 (introducing the TODO comment, 2012-12-05); bb19b3016d (implementing it in code, 2019-02-27, GitHub PR #1035); 3f7a734cee (reverting it back to a comment, 2019-02-28). My understanding is that the revert was for toolchain reasons, not semantic reasons. My argument below is for semantic reasons.

As I understand the comment, it's saying that we can productively assume that any type that's trivially move-constructible is also trivially relocatable; thus we could change

     : std::conditional<
           sizeof(T) && is_detected_v<traits_detail::detect_IsRelocatable, T>,
           traits_detail::has_true_IsRelocatable<T>,
    -      is_trivially_copyable<T>>::type {};
    +      std::is_trivially_move_constructible<T>>::type {};

- Pro: I can't think of a _non-contrived_ example of a type which is trivially move-constructible but not trivially relocatable. That is, the proposed change would be mostly harmless.

However:

- Con: The most common trivially-relocatable types (vector, unique_ptr) are not trivially move-constructible, so this would be a no-op on all types except very contrived ones.

- In fact, I would go so far as to say that any type which is trivially move-constructible yet NOT trivially copyable is probably a bug!

- Con: An RAII type such as `struct S { S(); ~S(); }` is trivially move-constructible, but not trivially copyable because it's not trivially destructible; and without further annotation, we should NOT assume that `S` is trivially relocatable (because that non-trivial destructor might be significant to the user).

- Suppose `S` were (Platonically) trivially relocatable after all. Then adding `S(S&&) = delete` to it shouldn't change the fact that it's trivially relocatable (e.g. in `vector<S>::erase`, which doesn't require move-construction, just move-assignment and destruction). Therefore anything based on `is_*_constructible` seems like the wrong tool for the job; it'll report `false` for some types that we could in fact trivially relocate. (`is_trivially_copyable` and the proposed `is_trivially_relocatable` will still report `true` for types with deleted special members.)

Conclusion: The current code is already at a (local) optimum; replacing `is_trivially_copyable` with anything involving `is_trivially_move_constructible` would be a regression. Replacing it with `__is_trivially_relocatable(T)` on compilers that support it (currently just Clang) could be a good idea. For now, simply removing the TODO seems like a step in the right direction.