### PR TITLE
Add delete for SparseByteSet.

### DIFF
--- a/folly/container/SparseByteSet.h
+++ b/folly/container/SparseByteSet.h
@@ -31,6 +31,7 @@ namespace folly {
  *
  *  Operations:
  *  - add(byte)
+ *  - remove(byte)
  *  - contains(byte)
  *  - clear()
  *
@@ -72,6 +73,25 @@ class SparseByteSet {
   }
 
   /***
+   *  remove(byte)
+   *
+   *  O(1), non-amortized.
+   */
+  inline bool remove(uint8_t i) {
+    assert(size_ > 0);
+    bool r = contains(i);
+    if (r) {
+      if (dense_[size_ - 1] != i) {
+        int last_element_pos = dense_[size_ - 1];
+        swap(dense_[size_ - 1], dense_[sparse_[i]]);
+        swap(sparse_[i], sparse_[last_element_pos]);
+      }
+      --size_;      
+    }
+    return r;
+  }
+
+  /***
    *  contains(byte)
    *
    *  O(1), non-amortized.
@@ -92,6 +112,12 @@ class SparseByteSet {
                   // possible values were inserted.
   uint8_t sparse_[kCapacity];
   uint8_t dense_[kCapacity];
+
+  void swap(uint8_t& lhs, uint8_t& rhs) {
+    uint8_t tmp = lhs;
+    lhs = rhs;
+    rhs = tmp;
+  }
 };
 
 } // namespace folly

--- a/folly/container/test/SparseByteSetTest.cpp
+++ b/folly/container/test/SparseByteSetTest.cpp
@@ -77,3 +77,24 @@ TEST_F(SparseByteSetTest, clear) {
     EXPECT_TRUE(s.add(c));
   }
 }
+
+TEST_F(SparseByteSetTest, remove) {
+  for (auto c = lims::min(); c < lims::max(); ++c) {
+    EXPECT_TRUE(s.add(c));
+  }
+  for (auto c = lims::min(); c < lims::max() / 2; ++c) {
+    EXPECT_TRUE(s.remove(c));
+    EXPECT_FALSE(s.contains(c));
+  }
+  
+  // did not corrupt rest data
+  for (auto c = lims::max() / 2; c < lims::max(); ++c) {
+    EXPECT_TRUE(s.contains(c));
+  }
+
+  // check deleting last elements
+  for (auto c = lims::max() - 1; c >= lims::max() / 2; --c) {
+    EXPECT_TRUE(s.remove(c));
+    EXPECT_FALSE(s.contains(c));
+  }
+}


### PR DESCRIPTION
Added the `delete` method for SparseByteSet class. 

Notes on how it works. Assume we have next operations done:
```
add(0)
add(1)
add(2)
add(3)
add(4)
```
So now we have next structure:
```
dense:  0 1 2 3 4 |
sparse: 0 1 2 3 4
```
And `size_` equals to 5.

We have two options when deleting. 
1. Deleted element are in the end of our `dense` array. Here we need to decrease `size_`. F.e. let's try to delete `4`:
```
dense:  0 1 2 3 | 4
sparse: 0 1 2 3 4
```
2. Deleted element are not in the end of `dense`. Here we need to swap it with the last element and decrease `size_`. Let's try to delete `1`. After swap:
```
dense:  0 3 2 1 | 4
sparse: 0 3 2 1 4
```
After `size_` decrease:
```
dense:  0 3 2 | 1 4
sparse: 0 3 2 1 4
```

That's all : )