### PR TITLE
Fix bug in `constexpr_ceil`

### DIFF
--- a/folly/ConstexprMath.h
+++ b/folly/ConstexprMath.h
@@ -420,7 +420,7 @@ template <typename T>
 constexpr T constexpr_ceil(T t, T round) {
   return round == T(0)
       ? t
-      : ((t + (t < T(0) ? T(0) : round - T(1))) / round) * round;
+      : ((t + (t <= T(0) ? T(0) : round - T(1))) / round) * round;
 }
 
 /// constexpr_mult

--- a/folly/test/ConstexprMathTest.cpp
+++ b/folly/test/ConstexprMathTest.cpp
@@ -762,6 +762,12 @@ TEST_F(ConstexprMathTest, constexpr_ceil_integral_round) {
     constexpr auto rounded = folly::constexpr_ceil(roundable, round);
     EXPECT_EQ(-20ll, rounded);
   }
+  {
+    constexpr auto roundable = 0ll;
+    constexpr auto round = std::numeric_limits<long long>::min();
+    constexpr auto rounded = folly::constexpr_ceil(roundable, round);
+    EXPECT_EQ(0ll, rounded);
+  }
 }
 
 TEST_F(ConstexprMathTest, constexpr_mult_floating) {


### PR DESCRIPTION
`constexpr_ceil(0, X)` should always be `0`. If `X` is the signed min value (and `T` is signed) `constexpr_ceil(0, SIGNED_MIN) == SIGNED_MIN`. Fix is to just return `0` if `t <= 0` instead of just `t < 0`.