### PR TITLE
AsyncFdSocket.h: fix for macOS < 11

### DIFF
--- a/folly/io/async/fdsock/AsyncFdSocket.h
+++ b/folly/io/async/fdsock/AsyncFdSocket.h
@@ -19,6 +19,16 @@
 #include <folly/io/async/AsyncSocket.h>
 #include <folly/io/async/fdsock/SocketFds.h>
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 110000
+#ifdef __DARWIN_ALIGN32
+#undef __DARWIN_ALIGN32
+#define __DARWIN_ALIGN32(p) ((__darwin_size_t)((__darwin_size_t)(p) + __DARWIN_ALIGNBYTES32) &~ __DARWIN_ALIGNBYTES32)
+#endif
+#endif
+#endif
+
 namespace folly {
 
 // Including `gtest/gtest_prod.h` would make gtest/gmock a hard dep


### PR DESCRIPTION
Fixes: https://github.com/facebook/folly/issues/2099

Credits to @sryze for pointing out the cause of the breakage in https://github.com/facebook/folly/issues/2031#issuecomment-1752127213
However, the problem is not specific to Catalina, but affects every macOS from 10.15 down to 10.5, and of course the solution is not to hack the SDK, but provide a fix in the code.