### PR TITLE
Fixes for 2 tests using deprecated std::is_literal_type causing build…

### DIFF
--- a/folly/test/FunctionRefTest.cpp
+++ b/folly/test/FunctionRefTest.cpp
@@ -28,7 +28,10 @@ int func_int_int_add_25(int x) {
 namespace folly {
 
 TEST(FunctionRef, Traits) {
+#if __cplusplus < 201703L
   static_assert(std::is_literal_type<FunctionRef<int(int)>>::value, "");
+#endif
+
   static_assert(
       std::is_trivially_copy_constructible<FunctionRef<int(int)>>::value, "");
   static_assert(

--- a/folly/test/FunctionRefTest.cpp
+++ b/folly/test/FunctionRefTest.cpp
@@ -28,10 +28,6 @@ int func_int_int_add_25(int x) {
 namespace folly {
 
 TEST(FunctionRef, Traits) {
-#if __cplusplus < 201703L
-  static_assert(std::is_literal_type<FunctionRef<int(int)>>::value, "");
-#endif
-
   static_assert(
       std::is_trivially_copy_constructible<FunctionRef<int(int)>>::value, "");
   static_assert(

--- a/folly/test/RangeTest.cpp
+++ b/folly/test/RangeTest.cpp
@@ -52,10 +52,6 @@ using namespace std;
 static_assert(folly::detail::range_is_char_type_v_<char*>, "");
 static_assert(folly::detail::range_is_byte_type_v_<unsigned char*>, "");
 
-#if __cplusplus < 201703L
-static_assert(std::is_literal_type<StringPiece>::value, "");
-#endif
-
 BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<StringPiece>));
 
 TEST(StringPiece, All) {

--- a/folly/test/RangeTest.cpp
+++ b/folly/test/RangeTest.cpp
@@ -52,7 +52,9 @@ using namespace std;
 static_assert(folly::detail::range_is_char_type_v_<char*>, "");
 static_assert(folly::detail::range_is_byte_type_v_<unsigned char*>, "");
 
+#if __cplusplus < 201703L
 static_assert(std::is_literal_type<StringPiece>::value, "");
+#endif
 
 BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<StringPiece>));
 


### PR DESCRIPTION
## Summary of Fixes

2 files are using deprecated features that cause Folly builds to fail in **C++17** and **C++20**

The method `std::is_literal_type` has been deprecated - adding this block makes the full library compile

```cpp
/* change line 31 in folly/folly/test/FunctionRefTest.cpp to: */

#if __cplusplus < 201703L
  static_assert(std::is_literal_type<FunctionRef<int(int)>>::value, "");
#endif


/* change line 55 in folly/folly/test/RangeTest.cpp to: */

#if __cplusplus < 201703L // fixes deprecated usage in c++17 and c++20
static_assert(std::is_literal_type<StringPiece>::value, "");
#endif

```

## Details


Full Steps and System Information

```bash
git clone https://github.com/facebook/folly

cd folly/build

# default config

cmake ..
make

# build success with default

17 warnings generated.
[100%] Linking CXX executable logging_example
[100%] Built target logging_example

# using c++20

cmake -DCMAKE_CXX_STANDARD=20 \
-DCMAKE_CXX_STANDARD_REQUIRED=ON \
..

# success with c++20 and no benchmarks specified

17 warnings generated.
[100%] Linking CXX executable logging_example
[100%] Built target logging_example

```

**BUILD_BENCHMARKS=ON** causes failures

```bash
cmake -DBUILD_BENCHMARKS=ON \
..

# or 20

cmake -DCMAKE_CXX_STANDARD=20 \
-DCMAKE_CXX_STANDARD_REQUIRED=ON \
-DBUILD_BENCHMARKS=ON \
..

```

First Error:

```bash
# errors when benchmarks specified for CMake

[ 84%] Linking CXX executable function_ref_benchmark
[ 84%] Built target function_ref_benchmark
[ 84%] Building CXX object CMakeFiles/function_ref_test.dir/folly/test/FunctionRefTest.cpp.o
/follycpp/folly/folly/test/FunctionRefTest.cpp:31:22: error: no member named 'is_literal_type' in namespace 'std'
  static_assert(std::is_literal_type<FunctionRef<int(int)>>::value, "");
                ~~~~~^
/follycpp/folly/folly/test/FunctionRefTest.cpp:31:59: error: expected '(' for function-style cast or type construction
  static_assert(std::is_literal_type<FunctionRef<int(int)>>::value, "");
                                     ~~~~~~~~~~~~~~~~~~~~~^
/follycpp/folly/folly/test/FunctionRefTest.cpp:31:62: error: no member named 'value' in the global namespace
  static_assert(std::is_literal_type<FunctionRef<int(int)>>::value, "");
                                                           ~~^
3 errors generated.
make[2]: *** [CMakeFiles/function_ref_test.dir/folly/test/FunctionRefTest.cpp.o] Error 1
make[1]: *** [CMakeFiles/function_ref_test.dir/all] Error 2
make: *** [all] Error 2

```

First Error Fix:

```cpp
// change line 31 in /folly/folly/test/FunctionRefTest.cpp to:

/*
 * Copyright (c) Meta Platforms, Inc. and affiliates.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

#include <list>

#include <folly/Function.h>
#include <folly/portability/GTest.h>

namespace {
int func_int_int_add_25(int x) {
  return x + 25;
}
} // namespace

namespace folly {

TEST(FunctionRef, Traits) {

#if __cplusplus < 201703L // fixes deprecated usage in c++17 and c++20

  static_assert(std::is_literal_type<FunctionRef<int(int)>>::value, "");

#endif

  static_assert(
      std::is_trivially_copy_constructible<FunctionRef<int(int)>>::value, "");
  static_assert(
      std::is_trivially_move_constructible<FunctionRef<int(int)>>::value, "");
  static_assert(
      std::is_trivially_constructible<
          FunctionRef<int(int)>,
          FunctionRef<int(int)>&>::value,
      "");
// ......
}
```

Running make again:

```bash
[ 91%] Built target range_find_benchmark
[ 91%] Building CXX object CMakeFiles/random_test.dir/folly/test/RandomTest.cpp.o
[ 91%] Linking CXX executable random_test
[ 91%] Built target random_test
[ 91%] Building CXX object CMakeFiles/range_test.dir/folly/test/RangeTest.cpp.o

follycpp/folly/folly/test/RangeTest.cpp:55:36: error: unexpected type name 'StringPiece': expected expression
static_assert(std::is_literal_type<StringPiece>::value, "");
                                   ^
follycpp/folly/folly/test/RangeTest.cpp:55:20: error: no member named 'is_literal_type' in namespace 'std'
static_assert(std::is_literal_type<StringPiece>::value, "");
              ~~~~~^
follycpp/folly/folly/test/RangeTest.cpp:55:50: error: no member named 'value' in the global namespace
static_assert(std::is_literal_type<StringPiece>::value, "");
                                               ~~^
3 errors generated.
make[2]: *** [CMakeFiles/range_test.dir/folly/test/RangeTest.cpp.o] Error 1
make[1]: *** [CMakeFiles/range_test.dir/all] Error 2
make: *** [all] Error 2

```

Second Fix:

```cpp

// change line 55 in folly/folly/test/RangeTest.cpp to:

/*
 * Copyright (c) Meta Platforms, Inc. and affiliates.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

// @author Kristina Holst (kholst@fb.com)
// @author Andrei Alexandrescu (andrei.alexandrescu@fb.com)

#include <folly/Range.h>

#include <array>
#include <deque>
#include <iterator>
#include <limits>
#include <random>
#include <string>
#include <type_traits>
#include <vector>

#include <boost/algorithm/string/trim.hpp>
#include <boost/range/concepts.hpp>

#include <folly/CppAttributes.h>
#include <folly/Memory.h>
#include <folly/portability/GMock.h>
#include <folly/portability/GTest.h>
#include <folly/portability/SysMman.h>

#if __has_include(<range/v3/range/concepts.hpp>)
#include <range/v3/range/concepts.hpp>

// Check conformance with the C++20 range concepts as specified
// by the range-v3 library.
CPP_assert(ranges::range<folly::StringPiece>);
CPP_assert(ranges::view_<folly::StringPiece>);
#endif

using namespace folly;
using namespace std;

static_assert(folly::detail::range_is_char_type_v_<char*>, "");
static_assert(folly::detail::range_is_byte_type_v_<unsigned char*>, "");

#if __cplusplus < 201703L // fixes deprecated usage in c++17 and c++20
static_assert(std::is_literal_type<StringPiece>::value, "");
#endif


BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<StringPiece>));

TEST(StringPiece, All) {
  const char* foo = "foo";
  const char* foo2 = "foo";
  string fooStr(foo);
  string foo2Str(foo2);

// ....

}

```

Running make again

```bash
[ 97%] Built target thread_local_test
[ 98%] Building CXX object CMakeFiles/timeout_queue_test.dir/folly/test/TimeoutQueueTest.cpp.o
[ 98%] Linking CXX executable timeout_queue_test
[ 98%] Built target timeout_queue_test
[ 98%] Building CXX object CMakeFiles/token_bucket_test.dir/folly/test/TokenBucketTest.cpp.o
[ 99%] Linking CXX executable token_bucket_test
[ 99%] Built target token_bucket_test
[ 99%] Building CXX object CMakeFiles/traits_test.dir/folly/test/TraitsTest.cpp.o
[ 99%] Linking CXX executable traits_test
[ 99%] Built target traits_test
[ 99%] Building CXX object CMakeFiles/try_test.dir/folly/test/TryTest.cpp.o
[ 99%] Linking CXX executable try_test
[ 99%] Built target try_test
[ 99%] Building CXX object CMakeFiles/unit_test.dir/folly/test/UnitTest.cpp.o
[ 99%] Linking CXX executable unit_test
[ 99%] Built target unit_test
[ 99%] Building CXX object CMakeFiles/uri_benchmark.dir/folly/test/UriBenchmark.cpp.o
[ 99%] Linking CXX executable uri_benchmark
[ 99%] Built target uri_benchmark
[ 99%] Building CXX object CMakeFiles/uri_test.dir/folly/test/UriTest.cpp.o
[ 99%] Linking CXX executable uri_test
[ 99%] Built target uri_test
[ 99%] Building CXX object CMakeFiles/varint_test.dir/folly/test/VarintTest.cpp.o
[100%] Linking CXX executable varint_test
[100%] Built target varint_test
[100%] Building CXX object CMakeFiles/blake2xb_test.dir/folly/experimental/crypto/test/Blake2xbTest.cpp.o
[100%] Linking CXX executable blake2xb_test
[100%] Built target blake2xb_test
[100%] Building CXX object CMakeFiles/lt_hash_test.dir/folly/experimental/crypto/test/LtHashTest.cpp.o
[100%] Linking CXX executable lt_hash_test
[100%] Built target lt_hash_test
[100%] Built target logging_example_lib
[100%] Built target logging_example

# success!

```

Installing the Library to System

```bash
make install

# success for all
```

After updating those two files - the builds are successful and the benchmarks are able to be built and used

### validation using built library

 
Using the library in a project to confirm:


```cpp
#include <folly/AtomicUnorderedMap.h>
#include <folly/Benchmark.h>
#include <folly/concurrency/ConcurrentHashMap.h>
#include <folly/init/Init.h>

/*

1 second:                         1
1 millisecond (ms):           0.001 seconds
1 microsecond (us):        0.000001 seconds
1 nanosecond  (ns):     0.000000001 seconds


*/

void mutexMapBenchmark(int threadCount, int insertionsPerThread) {
  std::unordered_map<int, std::string> map;
  std::mutex mapMutex;

  std::vector<std::thread> threads;
  for (int i = 0; i < threadCount; ++i) {
    threads.emplace_back([&map, &mapMutex, i, insertionsPerThread] {
      for (int j = 1; j <= insertionsPerThread; ++j) {
        int key = i * insertionsPerThread + j;
        std::string value = "Value " + std::to_string(key);

        std::lock_guard<std::mutex> lock(mapMutex);
        map[key] = std::move(value);
      }
    });
  }

  for (auto &t : threads) {
    t.join();
  }
}

void concurrentMapBenchmark(int threadCount, int insertionsPerThread) {
  folly::ConcurrentHashMap<int, std::string> map;

  std::vector<std::thread> threads;
  for (int i = 0; i < threadCount; ++i) {
    threads.emplace_back([&map, i, insertionsPerThread] {
      for (int j = 0; j < insertionsPerThread; ++j) {
        map.insert_or_assign(j, "Value " + std::to_string(i * 100 + j));
      }
    });
  }

  for (auto &t : threads) {
    t.join();
  }
}

void concurrentMapBenchmarkComplex(int threadCount, int insertionsPerThread) {
  auto v = std::vector<std::string>{"Complex", "Data", "Type"};

  folly::ConcurrentHashMap<std::string, std::vector<std::string>> map;

  std::vector<std::thread> threads;
  for (int i = 0; i < threadCount; ++i) {
    threads.emplace_back([&map, &v, i, insertionsPerThread] {
      for (int j = 1; j <= insertionsPerThread; ++j) {
        std::string key = "Key" + std::to_string(i * insertionsPerThread + j);
        map.insert_or_assign(std::move(key), v);
      }
    });
  }

  for (auto &t : threads) {
    t.join();
  }
}

void atomicMapBenchmark(int threadCount, int insertionsPerThread) {
  folly::AtomicUnorderedInsertMap<int, std::string> atomicMap(
      threadCount * insertionsPerThread);

  std::vector<std::thread> threads;
  for (int i = 0; i < threadCount; ++i) {
    threads.emplace_back([&atomicMap, i, insertionsPerThread] {
      for (int j = 1; j <= insertionsPerThread; ++j) {
        int key = i * insertionsPerThread + j;
        atomicMap.emplace(key, "Value " + std::to_string(key));
      }
    });
  }

  for (auto &t : threads) {
    t.join();
  }
}

void atomicMapBenchmarkComplex(int threadCount, int insertionsPerThread) {
  auto v = std::vector<std::string>{"Complex", "Data", "Type"};

  folly::AtomicUnorderedInsertMap<std::string, std::vector<std::string>>
      atomicMap(threadCount * insertionsPerThread);

  std::vector<std::thread> threads;
  for (int i = 0; i < threadCount; ++i) {
    threads.emplace_back([&atomicMap, &v, i, insertionsPerThread] {
      for (int j = 1; j <= insertionsPerThread; ++j) {
        std::string key = "Key" + std::to_string(i * insertionsPerThread + j);
        atomicMap.emplace(std::move(key), v);
      }
    });
  }

  for (auto &t : threads) {
    t.join();
  }
}

BENCHMARK(UnorderedMapMutexedSingleThreaded, n) { mutexMapBenchmark(1, n); }
BENCHMARK(UnorderedMapMutexedMultiThreaded, n) { mutexMapBenchmark(5, n); }
BENCHMARK(UnorderedMapMutexedMaxThreads, n) { mutexMapBenchmark(12, n); }

BENCHMARK(ConcurrentHashMapSingleThreaded, n) { concurrentMapBenchmark(1, n); }
BENCHMARK(ConcurrentHashMapMultiThreaded, n) { concurrentMapBenchmark(5, n); }
BENCHMARK(ConcurrentHashMapMaxThreads, n) { concurrentMapBenchmark(12, n); }

BENCHMARK(ConcurrentHashMapComplexSingleThreaded, n) {
  concurrentMapBenchmarkComplex(1, n);
}

BENCHMARK(ConcurrentHashMapComplexMultiThreaded, n) {
  concurrentMapBenchmarkComplex(5, n);
}

BENCHMARK(ConcurrentHashMapComplexMaxThreads, n) {
  concurrentMapBenchmarkComplex(12, n);
}

BENCHMARK(AtomicUnorderedMapSingleThreaded, n) { atomicMapBenchmark(1, n); }
BENCHMARK(AtomicUnorderedMapMultiThreaded, n) { atomicMapBenchmark(5, n); }
BENCHMARK(AtomicUnorderedMapMaxThreads, n) { atomicMapBenchmark(12, n); }

BENCHMARK(AtomicUnorderedMapComplexSingleThreaded, n) {
  atomicMapBenchmarkComplex(1, n);
}

BENCHMARK(AtomicUnorderedMapComplexMultiThreaded, n) {
  atomicMapBenchmarkComplex(5, n);
}

BENCHMARK(AtomicUnorderedMapComplexMaxThreads, n) {
  atomicMapBenchmarkComplex(12, n);
}

int main(int argc, char *argv[]) {
  folly::Init init(&argc, &argv);
  folly::runBenchmarks();
  return 0;
}

```

CMakeLists.txt file

```c
cmake_minimum_required(VERSION 3.20)
project(opencvOCR)

# change standard as required
set(CMAKE_CXX_STANDARD 20)
set(CMAKE_CXX_STANDARD_REQUIRED ON)
set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

include_directories(${CMAKE_SOURCE_DIR})
set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

find_package(Folly CONFIG REQUIRED)

add_executable(cache_benchmark  benchmarks/cache_benchmark.cc)

target_link_libraries(
  cache_benchmark
  PUBLIC Folly::folly
  PUBLIC Folly::follybenchmark
)
```

Building and Running using installed Folly lib

```bash
cmake ..
make

./cache_benchmark

============================================================================
[...]/benchmarks/cache_benchmark.cc            relative  time/iter   iters/s
============================================================================
UnorderedMapMutexedSingleThreaded                          61.54ns    16.25M
UnorderedMapMutexedMultiThreaded                          757.24ns     1.32M
UnorderedMapMutexedMaxThreads                               1.72us   580.80K
ConcurrentHashMapSingleThreaded                           211.18ns     4.74M
ConcurrentHashMapMultiThreaded                            819.41ns     1.22M
ConcurrentHashMapMaxThreads                                 3.63us   275.19K
ConcurrentHashMapComplexSingleThreaded                    281.33ns     3.55M
ConcurrentHashMapComplexMultiThreaded                       1.37us   729.48K
ConcurrentHashMapComplexMaxThreads                          7.81us   128.09K
AtomicUnorderedMapSingleThreaded                           40.70ns    24.57M
AtomicUnorderedMapMultiThreaded                            74.05ns    13.50M
AtomicUnorderedMapMaxThreads                              413.82ns     2.42M
AtomicUnorderedMapComplexSingleThreaded                   126.34ns     7.92M
AtomicUnorderedMapComplexMultiThreaded                    530.52ns     1.88M
AtomicUnorderedMapComplexMaxThreads                         3.34us   299.67K


# runs successfully

```

#### System Information

```bash
brew info llvm

==> llvm: stable 17.0.6 (bottled), HEAD [keg-only]
Next-gen compiler infrastructure

###############

clang --version

Homebrew clang version 17.0.6
Target: arm64-apple-darwin23.1.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm/bin

###############

clang++ --version

Homebrew clang version 17.0.6
Target: arm64-apple-darwin23.1.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm/bin

###############

system_profiler SPSoftwareDataType

Software:

    System Software Overview:

      System Version: macOS 14.1.2 (23B2091)
      Kernel Version: Darwin 23.1.0
      Boot Volume: Macintosh HD
      Boot Mode: Normal
      Secure Virtual Memory: Enabled
      System Integrity Protection: Enabled
      Time since boot: 5 hours, 20 minutes


###############

system_profiler SPHardwareDataType

Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: Mac15,9
      Chip: Apple M3 Max
      Total Number of Cores: 16 (12 performance and 4 efficiency)
      Memory: 128 GB
      System Firmware Version: 10151.41.12
      OS Loader Version: 10151.41.12
      Activation Lock Status: Enabled


```