### PR TITLE
Fix consistent with the demo in JSON RFC

### DIFF
--- a/folly/json.cpp
+++ b/folly/json.cpp
@@ -828,7 +828,7 @@ template <bool EnableExtraAsciiEscapes>
 void escapeStringImpl(
     StringPiece input, std::string& out, const serialization_opts& opts) {
   auto hexDigit = [](uint8_t c) -> char {
-    return c < 10 ? c + '0' : c - 10 + 'a';
+    return c < 10 ? c + '0' : c - 10 + 'A';
   };
 
   out.push_back('\"');


### PR DESCRIPTION
Although this is defined in the JSON RFC: `The hexadecimal letters A through F can be uppercase or lowercase`, many implementations use the uppercase solution. Would it be better to change it to uppercase?

```
[7].  Strings

   The representation of strings is similar to conventions used in the C
   family of programming languages.  A string begins and ends with
   quotation marks.  All Unicode characters may be placed within the
   quotation marks, except for the characters that MUST be escaped:
   quotation mark, reverse solidus, and the control characters (U+0000
   through U+001F).

   Any character may be escaped.  If the character is in the Basic
   Multilingual Plane (U+0000 through U+FFFF), then it may be
   represented as a six-character sequence: a reverse solidus, followed
   by the lowercase letter u, followed by four hexadecimal digits that
   encode the character's code point.  The hexadecimal letters A through
   F can be uppercase or lowercase.  So, for example, a string
   containing only a single reverse solidus character may be represented
   as "\u005C".
```