### PR TITLE
tape: buider rework

### DIFF
--- a/folly/container/test/tape_bench.cpp
+++ b/folly/container/test/tape_bench.cpp
@@ -109,11 +109,12 @@ void pushBackByOne(
 template <typename T>
 void pushBackByOne(
     folly::tape<std::vector<T>>& cont, const std::vector<std::vector<T>>& in) {
+  auto builder = cont.new_record_builder();
   for (const auto& v : in) {
-    auto builder = cont.record_builder();
     for (const auto& x : v) {
       builder.push_back(x);
     }
+    builder.commit();
   }
 }
 


### PR DESCRIPTION
Summary:
There was some feedback about current design:
* it would be great for a commit to be explicit.
* conditionally extending or starting a new record sometimes useful.

## Alternative

* Explicit autocommit on destructor

We can continue to do this. The problem is: empty range, at the moment empty range is the same as any other. If you have a commit function then

```
builder =  ...;
builder.push_back('a');
builder.commit();
```
should only add "a".

I don't think it's a good idea basically.

* Move semantics to builder.

Like unique_ptr - builder. When goes out of scope - commit happens.
Downside: no explicit commit call. A bit "too clever".

* Nothing on destructor.

Easy to leave a tape in a broken state.

Differential Revision: D53311830


