### PR TITLE
pop!_os synonym for ubuntu. Use deb package manager.

### DIFF
--- a/build/fbcode_builder/getdeps/platform.py
+++ b/build/fbcode_builder/getdeps/platform.py
@@ -270,7 +270,7 @@ class HostType(object):
             return "homebrew"
         if self.distro in ("fedora", "centos", "centos_stream"):
             return "rpm"
-        if self.distro.startswith(("debian", "ubuntu")):
+        if self.distro.startswith(("debian", "ubuntu", "pop!_os")):
             return "deb"
         return None
 


### PR DESCRIPTION
Use Deb package manager on Pop! OS. 