### PR TITLE
chore: Resolve missing memory alignment interfaces on macOS

### DIFF
--- a/folly/Memory.h
+++ b/folly/Memory.h
@@ -19,6 +19,7 @@
 #include <cassert>
 #include <cerrno>
 #include <cstddef>
+#include <cstdio>
 #include <cstdlib>
 #include <exception>
 #include <limits>


### PR DESCRIPTION
`memalign(3)` cannot be resolved on macOS in some configuration.

```cpp
  In file included from /path/include/folly/executors/FutureExecutor.h:20:
  In file included from /path/include/folly/futures/Future.h:30:
  In file included from /path/include/folly/Try.h:26:
  /path/include/folly/Memory.h:77:10: error: use of undeclared identifier 'memalign'
    return memalign(align, size);
```
