### PR TITLE
fix linux cmake test disablement and related OOM

### DIFF
--- a/folly/test/AtomicUnorderedMapTest.cpp
+++ b/folly/test/AtomicUnorderedMapTest.cpp
@@ -198,7 +198,7 @@ TEST(UnorderedInsertMap, valueMutation) {
 
 // This test is too expensive to run automatically.  On my dev server it
 // takes about 10 minutes for dbg build, 2 for opt.
-TEST(AtomicUnorderedInsertMap, DISABLEDMegaMap) {
+TEST(AtomicUnorderedInsertMap, DISABLED_MegaMap) {
   size_t capacity = 2000000000;
   AtomicUnorderedInsertMap64<size_t, size_t> big(capacity);
   for (size_t i = 0; i < capacity * 2; i += 2) {

--- a/folly/test/ThreadLocalTest.cpp
+++ b/folly/test/ThreadLocalTest.cpp
@@ -754,7 +754,7 @@ TEST(ThreadLocal, Fork2) {
 #define SHARED_LIBRARY_TEST_NAME SharedLibrary
 #endif
 
-TEST(ThreadLocal, SHAREDLibraryTestName) {
+TEST(ThreadLocal, SHARED_LIBRARY_TEST_NAME) {
   auto const lib =
       folly::test::find_resource("folly/test/thread_local_test_lib.so");
   auto handle = dlopen(lib.string().c_str(), RTLD_LAZY);


### PR DESCRIPTION
fix linux cmake test disablement and related OOM

Summary:

Fix the folly linux github CI:

   * fix disabling the failing AtomicUnorderedInsertMap.DISABLEDMegaMap test as ctest wasn't filtering it out
   * fix disabling ThreadLocal.SHAREDLibraryTestName when not building shared lib

The first one also fixes OOM that reliably OOM killed my terminal when running tests locally with > 2 jobs

Test Plan:

Run tests locally with:
```
./build/fbcode_builder/getdeps.py --allow-system-packages test --num-jobs 2 --src-dir=. folly
```

Before:
```
Start 1883: atomic_unordered_map_test.AtomicUnorderedInsertMap.DISABLEDMegaMap
1882/3090 Test #1883: atomic_unordered_map_test.AtomicUnorderedInsertMap.DISABLEDMegaMap ...................................***Failed    0.00 sec
Note: Google Test filter = AtomicUnorderedInsertMap.DISABLEDMegaMap
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from AtomicUnorderedInsertMap
[ RUN      ] AtomicUnorderedInsertMap.DISABLEDMegaMap
unknown file: Failure
C++ exception with description "Cannot allocate memory" thrown in the test body.
[  FAILED  ] AtomicUnorderedInsertMap.DISABLEDMegaMap (0 ms)
[----------] 1 test from AtomicUnorderedInsertMap (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] AtomicUnorderedInsertMap.DISABLEDMegaMap

 1 FAILED TEST
...
1/1 Test #2774: thread_local_test.ThreadLocal.SHAREDLibraryTestName ...***Failed    0.00 sec
Note: Google Test filter = ThreadLocal.SHAREDLibraryTestName
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ThreadLocal
[ RUN      ] ThreadLocal.SHAREDLibraryTestName
unknown file: Failure
C++ exception with description "missing: folly/test/thread_local_test_lib.so" thrown in the test body.
[  FAILED  ] ThreadLocal.SHAREDLibraryTestName (0 ms)
[----------] 1 test from ThreadLocal (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ThreadLocal.SHAREDLibraryTestName

```

After, works

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/facebook/folly/pull/2146).
* #2084
* #2074
* #2068
* __->__ #2146