### PR TITLE
Fix 3 bugs related to libc++

### DIFF
--- a/folly/experimental/coro/Traits.h
+++ b/folly/experimental/coro/Traits.h
@@ -152,8 +152,8 @@ template <
             folly::Negation<detail::_has_member_operator_co_await<Awaitable>>>::
             value,
         int> = 0>
-Awaitable&& get_awaiter(Awaitable&& awaitable) {
-  return std::forward<Awaitable>(awaitable);
+Awaitable& get_awaiter(Awaitable&& awaitable) {
+  return static_cast<Awaitable&>(awaitable);
 }
 
 template <

--- a/folly/experimental/coro/Traits.h
+++ b/folly/experimental/coro/Traits.h
@@ -152,8 +152,8 @@ template <
             folly::Negation<detail::_has_member_operator_co_await<Awaitable>>>::
             value,
         int> = 0>
-Awaitable& get_awaiter(Awaitable&& awaitable) {
-  return awaitable;
+Awaitable&& get_awaiter(Awaitable&& awaitable) {
+  return std::forward<Awaitable>(awaitable);
 }
 
 template <

--- a/folly/experimental/coro/Traits.h
+++ b/folly/experimental/coro/Traits.h
@@ -147,6 +147,7 @@ template <
     typename Awaitable,
     std::enable_if_t<
         folly::Conjunction<
+            !std::is_rvalue_reference<Awaitable&&>::value,
             is_awaiter<Awaitable>,
             folly::Negation<detail::_has_free_operator_co_await<Awaitable>>,
             folly::Negation<detail::_has_member_operator_co_await<Awaitable>>>::

--- a/folly/fibers/GuardPageAllocator.cpp
+++ b/folly/fibers/GuardPageAllocator.cpp
@@ -271,6 +271,24 @@ void installSignalHandler() {
 
 #endif
 
+/*
+ * RAII Wrapper around a StackCache that calls
+ * CacheManager::giveBack() on destruction.
+ */
+class StackCacheEntry {
+ public:
+  explicit StackCacheEntry(size_t stackSize, size_t guardPagesPerStack)
+      : stackCache_(
+            std::make_unique<StackCache>(stackSize, guardPagesPerStack)) {}
+
+  StackCache& cache() const noexcept { return *stackCache_; }
+
+  ~StackCacheEntry();
+
+ private:
+  std::unique_ptr<StackCache> stackCache_;
+};
+
 class CacheManager {
  public:
   static CacheManager& instance() {
@@ -309,25 +327,9 @@ class CacheManager {
   }
 };
 
-/*
- * RAII Wrapper around a StackCache that calls
- * CacheManager::giveBack() on destruction.
- */
-class StackCacheEntry {
- public:
-  explicit StackCacheEntry(size_t stackSize, size_t guardPagesPerStack)
-      : stackCache_(
-            std::make_unique<StackCache>(stackSize, guardPagesPerStack)) {}
-
-  StackCache& cache() const noexcept { return *stackCache_; }
-
-  ~StackCacheEntry() {
+StackCacheEntry::~StackCacheEntry() {
     CacheManager::instance().giveBack(std::move(stackCache_));
-  }
-
- private:
-  std::unique_ptr<StackCache> stackCache_;
-};
+}
 
 GuardPageAllocator::GuardPageAllocator(size_t guardPagesPerStack)
     : guardPagesPerStack_(guardPagesPerStack) {

--- a/folly/tracing/AsyncStack.cpp
+++ b/folly/tracing/AsyncStack.cpp
@@ -18,8 +18,8 @@
 
 #include <atomic>
 #include <cassert>
-#include <mutex>
 #include <exception>
+#include <mutex>
 
 #include <glog/logging.h>
 #include <glog/raw_logging.h>

--- a/folly/tracing/AsyncStack.cpp
+++ b/folly/tracing/AsyncStack.cpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cassert>
 #include <mutex>
+#include <exception>
 
 #include <glog/logging.h>
 #include <glog/raw_logging.h>


### PR DESCRIPTION
1. `std::terminate()` is declared in `<exception>`; if not `#include <exception>`, the compiler cannot recognize `std::terminate()`.

2. return a local variable to an l-value reference is an error.

3. `std::unique_ptr<T>` requires T must not be an incomplete type.