### PR TITLE
fix -Wshadow issue

### DIFF
--- a/folly/futures/ThreadWheelTimekeeper.cpp
+++ b/folly/futures/ThreadWheelTimekeeper.cpp
@@ -58,8 +58,9 @@ SemiFuture<Unit> ThreadWheelTimekeeper::after(HighResDuration dur) {
   // canceling timeout is executed in EventBase thread, the actual timeout
   // callback has either been executed, or will never be executed. So we are
   // fine here.
-  eventBase_.runInEventBaseThread([this, cob = std::move(cob), dur] {
-    wheelTimer_->scheduleTimeout(cob.get(), folly::chrono::ceil<Duration>(dur));
+  eventBase_.runInEventBaseThread([this, cob2 = std::move(cob), dur] {
+    wheelTimer_->scheduleTimeout(
+        cob2.get(), folly::chrono::ceil<Duration>(dur));
   });
   return std::move(sf);
 }


### PR DESCRIPTION
Summary:
-Wshadow triggered in LLVM-17:
```
fbcode/folly/futures/ThreadWheelTimekeeper.cpp:61:42: error: declaration shadows a structured binding [-Werror,-Wshadow]                                                                      
   61 |   eventBase_.runInEventBaseThread([this, cob = std::move(cob), dur] {                                                                                                                 
      |                                          ^                                                                                                                                            
fbcode/folly/futures/ThreadWheelTimekeeper.cpp:47:9: note: previous declaration is here        
   47 |   auto [cob, sf] = WTCallback<HHWheelTimer>::create(&eventBase_);                                                                                                                     
      |         ^
```

This seems to only be triggered in llvm-17, llvm-15 doesn't pick it up:
```
$ buck2 build -c cxx.extra_cxxflags=-Wshadow folly/futures:core
...                                                                                                                                              
BUILD SUCCEEDE
```

Differential Revision: D54112254


