### PR TITLE
fix quoting in succeed.bat

### DIFF
--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -70,7 +70,7 @@ class BuilderBase(object):
                 wrapper = os.path.join(self.build_dir, "succeed.bat")
                 with open(wrapper, "w") as f:
                     f.write("@echo off\n")
-                    f.write(f"call {vcvarsall} amd64\n")
+                    f.write(f"call \"{vcvarsall}\" amd64\n")
                     f.write("set ERRORLEVEL=0\n")
                     f.write("exit /b 0\n")
                 return [wrapper, "&&"]


### PR DESCRIPTION
fix quoting in succeed.bat

Summary:

Windows builds are failing due to a some missing quoting in the batch file generation from 66f05b0b861a7278693f3c9ee345a543159bc9d6

Add the necessary quotes.

Test Plan:

Run a build that loads vcvarsall:
```
python build/fbcode_builder/getdeps.py build double-conversion
```

Before, fails with
```
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.
```

After, works
