### PR TITLE
make IndexedMemPoolTraits::initialize/cleanup if eagerRecycle constexpr

### DIFF
--- a/folly/IndexedMemPool.h
+++ b/folly/IndexedMemPool.h
@@ -52,7 +52,7 @@ struct IndexedMemPoolTraits {
   /// Called when the element pointed to by ptr is allocated for the
   /// first time.
   static void initialize(T* ptr) {
-    if (!eagerRecycle()) {
+    if constexpr (!eagerRecycle()) {
       new (ptr) T();
     }
   }
@@ -60,7 +60,7 @@ struct IndexedMemPoolTraits {
   /// Called when the element pointed to by ptr is freed at the pool
   /// destruction time.
   static void cleanup(T* ptr) {
-    if (!eagerRecycle()) {
+    if constexpr (!eagerRecycle()) {
       ptr->~T();
     }
   }


### PR DESCRIPTION
`IndexedMemPoolTraits::eagerRecycle` is a constexpr function, so `if (!eagerRecycle())` in `IndexedMemPoolTraits::initialize/cleanup` should be constexpr.


```c++
struct NonTrivialStruct {
  size_t elem_;

  NonTrivialStruct(size_t elem) : elem_(elem) {}
  ~NonTrivialStruct() {}
};

int main() {
  typedef folly::IndexedMemPool<NonTrivialStruct> Pool;
  Pool pool(100);
  auto b = pool.allocElem(int(1));
}
```
```
error: folly/folly/IndexedMemPool.h:56:17: error: no matching constructor for initialization of 'NonTrivialStruct'
      new (ptr) T();
```
If `EagerRecycleWhenNotTrivial = true` then `eagerRecycle()` always be true, `new (ptr) T();` never be called, but compiler complains.

