### PR TITLE
getdeps: support GETDEPS_WGET_ARGS in wget version

### DIFF
--- a/build/fbcode_builder/getdeps/fetcher.py
+++ b/build/fbcode_builder/getdeps/fetcher.py
@@ -683,15 +683,18 @@ def download_url_to_file_with_progress(url: str, file_name) -> None:
     start = time.time()
     try:
         if os.environ.get("GETDEPS_USE_WGET") is not None:
-            subprocess.run(
+            procargs = (
                 [
                     "wget",
+                ]
+                + os.environ.get("GETDEPS_WGET_ARGS", "").split()
+                + [
                     "-O",
                     file_name,
                     url,
                 ]
             )
-
+            subprocess.run(procargs, capture_output=True)
             headers = None
 
         elif os.environ.get("GETDEPS_USE_LIBCURL") is not None:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/zstrong/pull/748

I found it useful to be able to set `GETDEPS_WGET_ARGS` to change some of the flags to `wget` while it's in that fetch mode :)

Differential Revision: D56263907


