### PR TITLE
folly::findFixed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,6 +598,9 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
   apply_folly_compile_options_to_target(folly_test_support)
 
   folly_define_tests(
+    DIRECTORY algorithm/simd/test/
+      TEST find_fixed_test SOURCES FindFixedTest.cpp
+
     DIRECTORY chrono/test/
       TEST chrono_conv_test WINDOWS_DISABLED
         SOURCES ConvTest.cpp

--- a/folly/BUCK
+++ b/folly/BUCK
@@ -524,6 +524,11 @@ cpp_library(
 )
 
 cpp_library(
+    name = "findFixed",
+    headers = ["FindFixed.h"],
+)
+
+cpp_library(
     name = "fingerprint",
     srcs = ["Fingerprint.cpp"],
     headers = ["Fingerprint.h"],

--- a/folly/algorithm/simd/BUCK
+++ b/folly/algorithm/simd/BUCK
@@ -1,0 +1,23 @@
+######################################################################
+# Libraries
+
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+
+oncall("fbcode_entropy_wardens_folly")
+
+cpp_library(
+    name = "movemask",
+    headers = ["Movemask.h"],
+    exported_deps = [
+        "//folly:portability",
+    ],
+)
+
+cpp_library(
+    name = "findFixed",
+    headers = ["FindFixed.h"],
+    exported_deps = [
+        ":movemask",
+        "//folly:portability",
+    ],
+)

--- a/folly/algorithm/simd/FindFixed.h
+++ b/folly/algorithm/simd/FindFixed.h
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <concepts>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <type_traits>
+
+#include <folly/Portability.h>
+#include <folly/algorithm/simd/Movemask.h>
+
+#if FOLLY_X64
+#include <immintrin.h>
+#endif
+
+#if FOLLY_AARCH64
+#include <arm_neon.h>
+#endif
+
+namespace folly {
+
+namespace detail {
+
+// Note: using std::same_as will just be slower to compile than is_same_v
+template <typename T>
+concept SimdFriendlyType =
+    (std::is_same_v<std::int8_t, T> || std::is_same_v<std::uint8_t, T> ||
+     std::is_same_v<std::int16_t, T> || std::is_same_v<std::uint16_t, T> ||
+     std::is_same_v<std::int32_t, T> || std::is_same_v<std::uint32_t, T> ||
+     std::is_same_v<std::int64_t, T> || std::is_same_v<std::uint64_t, T>);
+
+} // namespace detail
+
+template <typename T>
+concept FollyFindFixedSupportedType = detail::SimdFriendlyType<T> ||
+    (std::is_enum_v<T> && detail::SimdFriendlyType<std::underlying_type_t<T>>);
+
+/*
+ * # folly::findFixed
+ *
+ * A function to linear search in number of elements, known at compiled time.
+ *
+ * Example:
+ *   std::vector<int> v {1, 3, 1, 2};
+ *   std::span<const int, 4> vspan(v.data(), 4);
+ *   auto m0 = folly::findFixed(vspan, 3); // m0 == 1;
+ *   auto m1 = folly::findFixed(vspan, 5); // m0 == std::nullopt;
+ *
+ * Supported types:
+ *  any 8,16,32,64 bit integers
+ *  enums
+ *
+ * Max supported size of the range is 64 bytes.
+ */
+template <
+    FollyFindFixedSupportedType T,
+    std::convertible_to<T> U,
+    std::size_t N>
+constexpr std::optional<std::size_t> findFixed(std::span<const T, N> where, U x)
+  requires(sizeof(T) * N <= 64);
+
+// implementation ---------------------------------------------------------
+
+namespace find_fixed_detail {
+template <typename U, typename T, std::size_t N>
+std::optional<std::size_t> findFixedCast(std::span<const T, N>& where, T x) {
+  std::span<const U, N> whereU{reinterpret_cast<const U*>(where.data()), N};
+  return findFixed(whereU, static_cast<U>(x));
+}
+
+template <typename T>
+constexpr std::optional<std::size_t> findFixedConstexpr(
+    std::span<const T> where, T x) {
+  std::size_t res = 0;
+  for (T e : where) {
+    if (e == x) {
+      return res;
+    }
+    ++res;
+  }
+  return std::nullopt;
+}
+
+// clang just checks all elements one by one, without any vectorization.
+// even for not very friendly to SIMD cases we could do better but for
+// now only special powers of 2 were interesting.
+template <typename T, std::size_t N>
+std::optional<std::size_t> findFixedLetTheCompilerDoIt(
+    std::span<const T, N> where, T x) {
+  // this get's unrolled by both clang and gcc.
+  // Experimenting with more complex ways of writing this code
+  // didn't yield any results.
+  return findFixedConstexpr(std::span<const T>(where), x);
+}
+
+#if FOLLY_X64
+#if defined(__AVX2__)
+constexpr std::size_t kMaxSimdRegister = 32;
+#else
+constexpr std::size_t kMaxSimdRegister = 16;
+#endif
+#elif FOLLY_AARCH64
+constexpr std::size_t kMaxSimdRegister = 16;
+#else
+constexpr std::size_t kMaxSimdRegister = 1;
+#endif
+
+template <typename T>
+std::optional<std::size_t> find8bytes(const T* from, T x);
+template <typename T>
+std::optional<std::size_t> find16bytes(const T* from, T x);
+template <typename T>
+std::optional<std::size_t> find32bytes(const T* from, T x);
+
+template <typename T, std::size_t N>
+std::optional<std::size_t> find2Overlaping(std::span<const T, N> where, T x);
+
+template <typename T, std::size_t N>
+std::optional<std::size_t> findSplitFirstRegister(
+    std::span<const T, N> where, T x);
+
+template <typename T, std::size_t N>
+std::optional<std::size_t> findFixedDispatch(std::span<const T, N> where, T x) {
+  constexpr std::size_t kNumBytes = N * sizeof(T);
+
+  if constexpr (N == 0) {
+    return std::nullopt;
+  } else if constexpr (N <= 2 || kNumBytes < 8 || kMaxSimdRegister == 1) {
+    return findFixedLetTheCompilerDoIt(where, x);
+  } else if constexpr (kNumBytes == 8) {
+    return find8bytes(where.data(), x);
+  } else if constexpr (kNumBytes == 16) {
+    return find16bytes(where.data(), x);
+  } else if constexpr (kMaxSimdRegister >= 32 && kNumBytes == 32) {
+    return find32bytes(where.data(), x);
+  } else if constexpr (kMaxSimdRegister * 2 <= kNumBytes) {
+    return findSplitFirstRegister(where, x);
+  } else {
+    // we can maybe do one better here probably with either out of bounds
+    // loads or combined two register search but it's ok for now.
+    return find2Overlaping(where, x);
+  }
+}
+
+template <typename T, std::size_t N>
+std::optional<std::size_t> find2Overlaping(std::span<const T, N> where, T x) {
+  constexpr std::size_t kRegSize = std::bit_floor(N);
+
+  std::span<const T, kRegSize> firstOverlap(where.data(), kRegSize);
+  if (auto res = findFixed(firstOverlap, x)) {
+    return res;
+  }
+
+  std::span<const T, kRegSize> secondOverlap(
+      where.data() + (N - kRegSize), kRegSize);
+  if (auto res = findFixed(secondOverlap, x)) {
+    return *res + (N - kRegSize);
+  }
+  return std::nullopt;
+}
+
+template <typename T, std::size_t N>
+std::optional<std::size_t> findSplitFirstRegister(
+    std::span<const T, N> where, T x) {
+  constexpr std::size_t kRegSize = kMaxSimdRegister / sizeof(T);
+
+  std::span<const T, kRegSize> head(where.data(), kRegSize);
+  if (auto res = findFixed(head, x)) {
+    return res;
+  }
+
+  std::span<const T, N - kRegSize> tail(where.data() + kRegSize, N - kRegSize);
+  if (auto res = findFixed(tail, x)) {
+    return *res + kRegSize;
+  }
+  return std::nullopt;
+}
+
+template <typename Scalar, typename Reg>
+std::optional<std::size_t> firstTrue(Reg reg) {
+  auto [bits, bitsPerElement] = folly::movemask<Scalar>(reg);
+  if (bits) {
+    return std::countr_zero(bits) / bitsPerElement();
+  }
+  return std::nullopt;
+}
+
+#if FOLLY_X64
+
+template <typename T>
+std::optional<std::size_t> find16ByteReg(__m128i reg, T x) {
+  if constexpr (sizeof(T) == 1) {
+    return firstTrue<T>(_mm_cmpeq_epi8(reg, _mm_set1_epi8(x)));
+  } else if constexpr (sizeof(T) == 2) {
+    return firstTrue<T>(_mm_cmpeq_epi16(reg, _mm_set1_epi16(x)));
+  } else if constexpr (sizeof(T) == 4) {
+    return firstTrue<T>(_mm_cmpeq_epi32(reg, _mm_set1_epi32(x)));
+  }
+}
+
+template <typename T>
+std::optional<std::size_t> find8bytes(const T* from, T x) {
+  std::uint64_t reg;
+  std::memcpy(&reg, from, 8);
+  return find16ByteReg(_mm_set1_epi64x(reg), x);
+}
+
+template <typename T>
+std::optional<std::size_t> find16bytes(const T* from, T x) {
+  __m128i reg = _mm_loadu_si128(reinterpret_cast<const __m128i*>(from));
+  return find16ByteReg(reg, x);
+}
+
+#if defined(__AVX2__)
+template <typename T>
+std::optional<std::size_t> find32ByteReg(__m256i reg, T x) {
+  if constexpr (sizeof(T) == 1) {
+    return firstTrue<T>(_mm256_cmpeq_epi8(reg, _mm256_set1_epi8(x)));
+  } else if constexpr (sizeof(T) == 2) {
+    return firstTrue<T>(_mm256_cmpeq_epi16(reg, _mm256_set1_epi16(x)));
+  } else if constexpr (sizeof(T) == 4) {
+    return firstTrue<T>(_mm256_cmpeq_epi32(reg, _mm256_set1_epi32(x)));
+  } else if constexpr (sizeof(T) == 8) {
+    return firstTrue<T>(_mm256_cmpeq_epi64(reg, _mm256_set1_epi64x(x)));
+  }
+}
+
+template <typename T>
+std::optional<std::size_t> find32bytes(const T* from, T x) {
+  __m256i reg = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(from));
+  return find32ByteReg(reg, x);
+}
+
+#endif
+#endif
+
+#if FOLLY_AARCH64
+
+template <typename T>
+std::optional<std::size_t> find8bytes(const T* from, T x) {
+  if constexpr (std::same_as<T, std::uint8_t>) {
+    return firstTrue<T>(vceq_u8(vld1_u8(from), vdup_n_u8(x)));
+  } else if constexpr (std::same_as<T, std::uint16_t>) {
+    return firstTrue<T>(vceq_u16(vld1_u16(from), vdup_n_u16(x)));
+  } else {
+    return firstTrue<T>(vceq_u32(vld1_u32(from), vdup_n_u32(x)));
+  }
+}
+
+template <typename T>
+std::optional<std::size_t> find16bytes(const T* from, T x) {
+  if constexpr (std::same_as<T, std::uint8_t>) {
+    return firstTrue<T>(vceqq_u8(vld1q_u8(from), vdupq_n_u8(x)));
+  } else if constexpr (std::same_as<T, std::uint16_t>) {
+    return firstTrue<T>(vceqq_u16(vld1q_u16(from), vdupq_n_u16(x)));
+  } else if constexpr (std::same_as<T, std::uint32_t>) {
+    return firstTrue<T>(vceqq_u32(vld1q_u32(from), vdupq_n_u32(x)));
+  } else {
+    return firstTrue<T>(vceqq_u64(vld1q_u64(from), vdupq_n_u64(x)));
+  }
+}
+
+#endif
+
+} // namespace find_fixed_detail
+
+template <
+    FollyFindFixedSupportedType T,
+    std::convertible_to<T> U,
+    std::size_t N>
+constexpr std::optional<std::size_t> findFixed(std::span<const T, N> where, U x)
+  requires(sizeof(T) * N <= 64)
+{
+  if constexpr (!std::is_same_v<T, U>) {
+    return findFixed(where, static_cast<T>(x));
+  } else if (std::is_constant_evaluated()) {
+    return find_fixed_detail::findFixedConstexpr(std::span<const T>(where), x);
+  } else if constexpr (std::is_enum_v<T>) {
+    return find_fixed_detail::findFixedCast<std::underlying_type_t<T>>(
+        where, x);
+  } else if constexpr (std::is_signed_v<T>) {
+    return find_fixed_detail::findFixedCast<std::make_unsigned_t<T>>(where, x);
+  } else {
+    return find_fixed_detail::findFixedDispatch(where, x);
+  }
+}
+
+} // namespace folly

--- a/folly/algorithm/simd/Movemask.h
+++ b/folly/algorithm/simd/Movemask.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Portability.h>
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+#if FOLLY_X64
+#include <immintrin.h>
+#endif
+
+#if FOLLY_AARCH64
+#include <arm_neon.h>
+#endif
+
+FOLLY_PUSH_WARNING
+FOLLY_GCC_DISABLE_WARNING("-Wignored-attributes")
+
+namespace folly {
+
+/*
+ * This is a low level utility used for simd search algorithms.
+ * At the moment used in folly::findFixed and folly::split.
+ *
+ * Logical extension of _mm_movemask_epi8 for different types
+ * for both x86 and arm.
+ *
+ * Interface looks like this:
+ * folly::movemask<-scalar type->(nativeRegister)
+ *   -> std::pair<Bits, BitsPerElement>;
+ *
+ *  Bits - unsigned integral, containing the bitmask (first is lowest bit).
+ *  BitsPerElement - std::integral_constant with number of bits per element
+ *
+ * Example:
+ *
+ *  std::optional<std::uint32_t> firstTrueUint16(auto simdRegister) {
+ *    auto [bits, bitsPerElement] =
+ *        folly::movemask<std::uint16_t>(simdRegister);
+ *    if (!bits) {
+ *      return std::nullopt;
+ *    }
+ *    return std::countl_zero(bits) / bitsPerElement();
+ *  }
+ *
+ * Arm implementation is based on:
+ * https://github.com/jfalcou/eve/blob/a2e2cf539e36e9a3326800194ad5206a8ef3f5b7/include/eve/detail/function/simd/arm/neon/movemask.hpp#L48
+ *
+ */
+
+#if FOLLY_X64
+
+template <typename Scalar, typename Reg>
+auto movemask(Reg reg) {
+  std::integral_constant<std::uint32_t, sizeof(Scalar) == 2 ? 2 : 1>
+      bitsPerElement;
+  auto mmask = static_cast<std::uint32_t>([&] {
+    if constexpr (std::is_same_v<Reg, __m128i>) {
+      if constexpr (sizeof(Scalar) <= 2) {
+        return _mm_movemask_epi8(reg);
+      } else if constexpr (sizeof(Scalar) == 4) {
+        return _mm_movemask_ps(_mm_castsi128_ps(reg));
+      } else if constexpr (sizeof(Scalar) == 8) {
+        return _mm_movemask_pd(_mm_castsi128_pd(reg));
+      }
+    }
+#if defined(__AVX2__)
+    else if constexpr (std::is_same_v<Reg, __m256i>) {
+      if constexpr (sizeof(Scalar) <= 2) {
+        return _mm256_movemask_epi8(reg);
+      } else if constexpr (sizeof(Scalar) == 4) {
+        return _mm256_movemask_ps(_mm256_castsi256_ps(reg));
+      } else if constexpr (sizeof(Scalar) == 8) {
+        return _mm256_movemask_pd(_mm256_castsi256_pd(reg));
+      }
+    }
+#endif
+  }());
+  return std::pair{mmask, bitsPerElement};
+}
+
+#endif
+
+#if FOLLY_AARCH64
+
+namespace detail {
+
+inline auto movemaskChars16Aarch64(uint8x16_t reg) {
+  uint16x8_t u16s = vreinterpretq_u16_u8(reg);
+  u16s = vshrq_n_u16(u16s, 4);
+  uint8x8_t packed = vmovn_u16(u16s);
+  std::uint64_t bits = vget_lane_u64(vreinterpret_u64_u8(packed), 0);
+  return std::pair{bits, std::integral_constant<std::uint32_t, 4>{}};
+}
+
+template <typename Reg>
+uint64x1_t asUint64x1Aarch64(Reg reg) {
+  if constexpr (std::is_same_v<Reg, uint32x2_t>) {
+    return vreinterpret_u64_u32(reg);
+  } else if constexpr (std::is_same_v<Reg, uint16x4_t>) {
+    return vreinterpret_u64_u16(reg);
+  } else {
+    return vreinterpret_u64_u8(reg);
+  }
+}
+
+} // namespace detail
+
+template <typename Scalar, typename Reg>
+auto movemask(Reg reg) {
+  if constexpr (std::is_same_v<Reg, uint64x2_t>) {
+    return movemask<std::uint32_t>(vmovn_u64(reg));
+  } else if constexpr (std::is_same_v<Reg, uint32x4_t>) {
+    return movemask<std::uint16_t>(vmovn_u32(reg));
+  } else if constexpr (std::is_same_v<Reg, uint16x8_t>) {
+    return movemask<std::uint8_t>(vmovn_u16(reg));
+  } else if constexpr (std::is_same_v<Reg, uint8x16_t>) {
+    return detail::movemaskChars16Aarch64(reg);
+  } else {
+    std::uint64_t mmask = vget_lane_u64(detail::asUint64x1Aarch64(reg), 0);
+    return std::pair{
+        mmask, std::integral_constant<std::uint32_t, sizeof(Scalar) * 8>{}};
+  }
+}
+
+#endif
+
+} // namespace folly
+
+FOLLY_POP_WARNING

--- a/folly/algorithm/simd/test/BUCK
+++ b/folly/algorithm/simd/test/BUCK
@@ -1,0 +1,38 @@
+load("@fbcode_macros//build_defs:cpp_benchmark.bzl", "cpp_benchmark")
+load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+
+oncall("fbcode_entropy_wardens_folly")
+
+cpp_unittest(
+    name = "momemask_test",
+    srcs = ["MovemaskTest.cpp"],
+    headers = [],
+    deps = [
+        "//folly:portability",
+        "//folly/algorithm/simd:movemask",
+        "//folly/portability:gtest",
+    ],
+)
+
+cpp_unittest(
+    name = "findfixed_test",
+    srcs = ["FindFixedTest.cpp"],
+    headers = [],
+    deps = [
+        "fbsource//third-party/fmt:fmt",
+        "//folly:portability",
+        "//folly/algorithm/simd:findFixed",
+        "//folly/portability:gtest",
+    ],
+)
+
+cpp_benchmark(
+    name = "findfixed_bench",
+    srcs = ["FindFixedBenchmark.cpp"],
+    deps = [
+        "fbsource//third-party/fmt:fmt",
+        "//folly:benchmark",
+        "//folly/algorithm/simd:findFixed",
+        "//folly/init:init",
+    ],
+)

--- a/folly/algorithm/simd/test/FindFixedBenchmark.cpp
+++ b/folly/algorithm/simd/test/FindFixedBenchmark.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/algorithm/simd/FindFixed.h>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <numeric>
+#include <span>
+#include <vector>
+
+namespace folly {
+namespace {
+
+template <typename T, std::size_t N>
+const auto kInput = [] {
+  std::vector<T> res(N, T{0});
+  std::iota(res.begin(), res.end(), T{0});
+  return res;
+}();
+
+template <std::size_t N>
+using IndexConstant = std::integral_constant<std::size_t, N>;
+
+template <typename T, std::size_t N>
+void stdFindBenchmark(unsigned n) {
+  const auto& in = kInput<T, N>;
+
+  while (n--) {
+    for (auto x : in) {
+      folly::doNotOptimizeAway(std::ranges::find(in, x));
+    }
+  }
+}
+
+template <typename T, std::size_t N>
+void follyFindFixedBenchmark(unsigned n) {
+  const auto& in = kInput<T, N>;
+
+  while (n--) {
+    for (auto x : in) {
+      std::span<const T, N> s(in.data(), N);
+      folly::doNotOptimizeAway(folly::findFixed(s, x));
+    }
+  }
+}
+
+template <typename T, std::size_t N>
+void registerBenchmark(T, IndexConstant<N>) {
+  (void)kInput<T, N>;
+
+  folly::addBenchmark(
+      __FILE__,
+      fmt::format(
+          "total size:{}, sizeof(T):{} std::find", N * sizeof(T), sizeof(T)),
+      [](unsigned n) -> unsigned {
+        stdFindBenchmark<T, N>(n);
+        return n;
+      });
+  folly::addBenchmark(
+      __FILE__,
+      fmt::format(
+          "total size:{}, sizeof(T):{} folly::findFixed",
+          N * sizeof(T),
+          sizeof(T)),
+      [](unsigned n) -> unsigned {
+        follyFindFixedBenchmark<T, N>(n);
+        return n;
+      });
+}
+
+void drawLine() {
+  folly::addBenchmark(__FILE__, "-", []() -> unsigned { return 0; });
+}
+
+void registerAllBenchmarks() {
+  // 8 bytes
+  registerBenchmark(std::int8_t{}, IndexConstant<8>{});
+  registerBenchmark(std::int16_t{}, IndexConstant<4>{});
+  registerBenchmark(std::int32_t{}, IndexConstant<2>{});
+  drawLine();
+  // 16 bytes
+  registerBenchmark(std::int8_t{}, IndexConstant<16>{});
+  registerBenchmark(std::int16_t{}, IndexConstant<8>{});
+  registerBenchmark(std::int32_t{}, IndexConstant<4>{});
+  registerBenchmark(std::int64_t{}, IndexConstant<2>{});
+  drawLine();
+  // 32 bytes
+  registerBenchmark(std::int8_t{}, IndexConstant<32>{});
+  registerBenchmark(std::int16_t{}, IndexConstant<16>{});
+  registerBenchmark(std::int32_t{}, IndexConstant<8>{});
+  registerBenchmark(std::int64_t{}, IndexConstant<4>{});
+  drawLine();
+  // 40 bytes
+  registerBenchmark(std::int8_t{}, IndexConstant<40>{});
+  registerBenchmark(std::int16_t{}, IndexConstant<20>{});
+  registerBenchmark(std::int32_t{}, IndexConstant<10>{});
+  registerBenchmark(std::int64_t{}, IndexConstant<5>{});
+}
+
+} // namespace
+} // namespace folly
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv, true);
+  folly::registerAllBenchmarks();
+  folly::runBenchmarks();
+}

--- a/folly/algorithm/simd/test/FindFixedTest.cpp
+++ b/folly/algorithm/simd/test/FindFixedTest.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Portability.h>
+
+#ifdef __cpp_lib_concepts // these tests need C++ concepts
+
+#include <folly/algorithm/simd/FindFixed.h>
+
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+
+#include <folly/portability/GTest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace {
+
+template <typename T, std::size_t N>
+void allTestsForN(std::span<T, N> buf) {
+  auto errorMsg = [&] {
+    return fmt::format("looking in: {}, sizeof(T): {}", buf, sizeof(T));
+  };
+
+  T foundX = static_cast<T>(0);
+  T notFoundX = static_cast<T>(1);
+
+  std::fill_n(buf.begin(), N, foundX);
+  std::span<const T, N> cbuf = buf;
+  ASSERT_EQ(std::nullopt, folly::findFixed(cbuf, notFoundX)) << errorMsg();
+  if (N == 0) {
+    return;
+  }
+
+  ASSERT_EQ(0, folly::findFixed(cbuf, foundX)) << errorMsg();
+  for (std::size_t found = 1; found < N; ++found) {
+    buf[found - 1] = notFoundX;
+    ASSERT_EQ(found, folly::findFixed(cbuf, foundX)) << errorMsg();
+  }
+}
+
+template <typename T, std::size_t... idx>
+void allTestsForImpl(std::span<T> buf, std::index_sequence<idx...>) {
+  (allTestsForN(std::span<T, idx>(buf.data(), idx)), ...);
+}
+
+template <typename T>
+void allTestsFor() {
+  constexpr std::size_t kMaxSize = 64 / sizeof(T);
+  std::vector<T> buf;
+  buf.resize(2 * kMaxSize, static_cast<T>(0));
+
+  // simd code can depend on alignment, so we better test it
+  for (std::size_t offset = 0; offset != kMaxSize; ++offset) {
+    ASSERT_NO_FATAL_FAILURE(allTestsForImpl(
+        std::span(buf.data() + offset, kMaxSize),
+        std::make_index_sequence<kMaxSize + 1>{}))
+        << offset;
+  }
+}
+
+} // namespace
+
+TEST(FindFixed, Basic) {
+  // Int is an important case, it should work
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<int>());
+
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::int8_t>());
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::int16_t>());
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::int32_t>());
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::int64_t>());
+
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::uint8_t>());
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::uint16_t>());
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::uint32_t>());
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::uint64_t>());
+
+  // just a enum test
+  ASSERT_NO_FATAL_FAILURE(allTestsFor<std::byte>());
+}
+
+TEST(FindFixed, Interfaces) {
+  // constexpr
+  {
+    constexpr std::array<std::int64_t, 3> arr{1, 2, 3};
+    static_assert(folly::findFixed(std::span(std::as_const(arr)), 1) == 0);
+    static_assert(folly::findFixed(std::span(std::as_const(arr)), 3) == 2);
+    static_assert(
+        folly::findFixed(std::span(std::as_const(arr)), 4) == std::nullopt);
+  }
+
+  // array
+  {
+    std::array<int, 3> arr{1, 2, 3};
+    ASSERT_EQ(std::nullopt, folly::findFixed(std::span(std::as_const(arr)), 0));
+    ASSERT_EQ(1, folly::findFixed(std::span(std::as_const(arr)), 2));
+  }
+
+  // mutable span
+  {
+    std::array<int, 3> arr{1, 2, 3};
+    std::span<int, 3> s(arr);
+    ASSERT_EQ(std::nullopt, folly::findFixed(std::span<const int, 3>(s), 0));
+    ASSERT_EQ(1, folly::findFixed(std::span<const int, 3>(s), 2));
+  }
+}
+
+template <typename T>
+concept findFixedWorksFor = requires(const T& x) {
+  { folly::findFixed(x) };
+};
+
+TEST(FollyFindFixed, SfianeFriendlyUnsupportedTypes) {
+  EXPECT_FALSE(findFixedWorksFor<std::span<const int>>)
+      << "dynamic extend is not supported";
+  EXPECT_FALSE(findFixedWorksFor<std::vector<int>>)
+      << "vector is dynamic size by definition";
+  EXPECT_FALSE((findFixedWorksFor<std::span<const std::vector<int>, 3>>))
+      << "find fixed works only for some trivial types.";
+}
+
+#endif

--- a/folly/algorithm/simd/test/MovemaskTest.cpp
+++ b/folly/algorithm/simd/test/MovemaskTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/algorithm/simd/Movemask.h>
+
+#include <folly/Portability.h>
+#include <folly/portability/GTest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+#if FOLLY_X64
+#include <immintrin.h>
+#endif
+
+#if FOLLY_AARCH64
+#include <arm_neon.h>
+#endif
+
+template <typename Reg, typename T, std::size_t N>
+Reg loadReg(const std::array<T, N>& arr) {
+  Reg res;
+  std::memcpy(&res, arr.data(), sizeof(T) * N);
+  return res;
+}
+
+std::uint64_t safeShift(std::uint64_t what, std::uint32_t shift) {
+  if (!shift) {
+    return what;
+  }
+  what <<= shift - 1;
+  what <<= 1;
+  return what;
+}
+
+template <typename Reg, typename T, std::size_t N>
+void allOneTrueTests() {
+  constexpr auto kTrue = static_cast<T>(-1);
+  constexpr auto kFalse = static_cast<T>(0);
+
+  std::array<T, N> arr;
+  arr.fill(kFalse);
+
+  ASSERT_EQ(0, folly::movemask<T>(loadReg<Reg>(arr)).first);
+
+  for (std::size_t i = 0; i != N; ++i) {
+    arr[i] = kTrue;
+    auto [bits, bitsPerElement] = folly::movemask<T>(loadReg<Reg>(arr));
+    std::uint64_t oneElement = safeShift(1, bitsPerElement()) - 1;
+    std::uint64_t expectedBits = safeShift(oneElement, i * bitsPerElement());
+
+    ASSERT_EQ(expectedBits, bits) << "sizeof(T): " << sizeof(T) << " i: " << i;
+    arr[i] = kFalse;
+  }
+}
+
+#if FOLLY_X64
+
+TEST(Movemask, Sse2) {
+  allOneTrueTests<__m128i, std::uint8_t, 16>();
+  allOneTrueTests<__m128i, std::uint16_t, 8>();
+  allOneTrueTests<__m128i, std::uint32_t, 4>();
+  allOneTrueTests<__m128i, std::uint64_t, 2>();
+}
+
+#if defined(__AVX2__)
+
+TEST(Movemask, Avx2) {
+  allOneTrueTests<__m256i, std::uint8_t, 32>();
+  allOneTrueTests<__m256i, std::uint16_t, 16>();
+  allOneTrueTests<__m256i, std::uint32_t, 8>();
+  allOneTrueTests<__m256i, std::uint64_t, 4>();
+}
+
+#endif
+
+#endif
+
+#if FOLLY_AARCH64
+
+TEST(Movemask, AARCH64) {
+  allOneTrueTests<uint8x8_t, std::uint8_t, 8>();
+  allOneTrueTests<uint16x4_t, std::uint16_t, 4>();
+  allOneTrueTests<uint32x2_t, std::uint32_t, 2>();
+  allOneTrueTests<uint64x1_t, std::uint64_t, 1>();
+
+  allOneTrueTests<uint8x16_t, std::uint8_t, 16>();
+  allOneTrueTests<uint16x8_t, std::uint16_t, 8>();
+  allOneTrueTests<uint32x4_t, std::uint32_t, 4>();
+  allOneTrueTests<uint64x2_t, std::uint64_t, 2>();
+}
+
+#endif

--- a/folly/detail/BUCK
+++ b/folly/detail/BUCK
@@ -246,6 +246,7 @@ cpp_library(
     exported_deps = [
         ":simd_for_each",
         "//folly:portability",
+        "//folly/algorithm/simd:movemask",
         "//folly/lang:bits",
     ],
 )


### PR DESCRIPTION
Summary:
folly::findFixed - a utility for doing a linear search in up to 64 bytes very fast.

Current version optimize 16 and 32 bytes very well - that's the ones I really need.

Other are reasonably OK, also with experimentation we can maybe squeeze out more.

Differential Revision: D56714024
