### PR TITLE
bump repo ci to ubuntu-22.04

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Show disk space at start

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -931,7 +931,7 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
 
     def run_project_cmd(self, args, loader, manifest):
         platforms = [
-            HostType("linux", "ubuntu", "18"),
+            HostType("linux", "ubuntu", "22"),
             HostType("darwin", None, None),
             HostType("windows", None, None),
         ]
@@ -1216,7 +1216,7 @@ jobs:
             help="Allow CI to fire on all branches - Handy for testing",
         )
         parser.add_argument(
-            "--ubuntu-version", default="20.04", help="Version of Ubuntu to use"
+            "--ubuntu-version", default="22.04", help="Version of Ubuntu to use"
         )
         parser.add_argument(
             "--cron",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/zstrong/pull/782

Now that Ubuntu 24.04 LTS [has been released](https://ubuntu.com/blog/canonical-releases-ubuntu-24-04-noble-numbat), it is a suitable time to bump the version of Ubuntu used in CI to Ubuntu 22.04 LTS, which is the prior LTS.

Ubuntu 22.04 LTS ships with GCC 11.2, and is the first Ubuntu release to ship with a version of GCC that implements C++20 coroutines.

Reviewed By: chadaustin

Differential Revision: D57017204


