### PR TITLE
Hide fb-isms from OSS buck2 graph

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -8,10 +8,11 @@ none = none
 [cell_aliases]
 config = prelude
 ovr_config = prelude
-fbcode = none
-fbsource = none
+fbcode = shim
+fbsource = shim
 fbcode_macros = shim
 buck = none
+bazel_skylib = shim
 
 [parser]
 target_platform_detector_spec = target:root//...->prelude//platforms:default

--- a/folly/experimental/BUCK
+++ b/folly/experimental/BUCK
@@ -356,7 +356,7 @@ cpp_library(
         "//folly:memory",
         "//folly:string",
         "//folly/ext:test_ext",
-        "//folly/facebook:test_ext",
+        # @fb-only: "//folly/facebook:test_ext",
         "//folly/portability:fcntl",
     ],
     exported_deps = [

--- a/folly/experimental/exception_tracer/BUCK
+++ b/folly/experimental/exception_tracer/BUCK
@@ -75,17 +75,17 @@ cpp_library(
     headers = ["ExceptionTracerLib.h"],
     compiler_flags = select({
         "DEFAULT": [],
-        "ovr_config//third-party/libgcc:11.x": ["-DFOLLY_STATIC_LIBSTDCXX=1"],
+        # @fb-only: "ovr_config//third-party/libgcc:11.x": ["-DFOLLY_STATIC_LIBSTDCXX=1"],
     }),
     exported_linker_flags = select({
         "DEFAULT": [],
-        "ovr_config//third-party/libgcc:11.x": [
-            "-Wl,--wrap=__cxa_throw",
-            "-Wl,--wrap=__cxa_rethrow",
-            "-Wl,--wrap=__cxa_begin_catch",
-            "-Wl,--wrap=__cxa_end_catch",
-            "-Wl,--wrap=_ZSt17rethrow_exceptionNSt15__exception_ptr13exception_ptrE",
-        ],
+        # @fb-only: "ovr_config//third-party/libgcc:11.x": [
+        # @fb-only:     "-Wl,--wrap=__cxa_throw",
+        # @fb-only:     "-Wl,--wrap=__cxa_rethrow",
+        # @fb-only:     "-Wl,--wrap=__cxa_begin_catch",
+        # @fb-only:     "-Wl,--wrap=__cxa_end_catch",
+        # @fb-only:     "-Wl,--wrap=_ZSt17rethrow_exceptionNSt15__exception_ptr13exception_ptrE",
+        # @fb-only: ],
     }),
     link_whole = True,
     supports_python_dlopen = True,

--- a/folly/experimental/symbolizer/tool/BUCK
+++ b/folly/experimental/symbolizer/tool/BUCK
@@ -1,6 +1,6 @@
 load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load("@fbcode_macros//build_defs:export_files.bzl", "export_file")
-load("//antlir/fbpkg:fbpkg.bzl", "fbpkg")
+load("@fbcode//antlir/fbpkg:fbpkg.bzl", "fbpkg")
 
 oncall("fbcode_entropy_wardens_folly")
 

--- a/folly/python/BUCK
+++ b/folly/python/BUCK
@@ -52,7 +52,7 @@ cpp_library(
     ],
     headers = [
         "executor.h",
-        ":executor__executor_api.h",
+        # @fb-only: ":executor__executor_api.h",
     ],
     # TODO(T36778537): Cython-generated `*_api.h` headers aren't modular.
     modular_headers = False,
@@ -124,7 +124,7 @@ cpp_library(
     exported_deps = [
         "fbsource//third-party/python:python",  # Python.h
         ":asyncio_executor",
-        ":executor__cython-lib",
+        # @fb-only: ":executor__cython-lib",
         "//folly:executor",
         "//folly/futures:core",
     ],
@@ -155,7 +155,7 @@ cpp_library(
     exported_deps = [
         "fbsource//third-party/python:python",  # Python.h
         ":asyncio_executor",
-        ":executor__cython-lib",
+        # @fb-only: ":executor__cython-lib",
         "//folly:cancellation_token",
         "//folly:executor",
         "//folly/experimental/coro:task",
@@ -182,7 +182,7 @@ cpp_library(
     srcs = ["fibers.cpp"],
     headers = [
         "fibers.h",
-        ":fibers__fiber_manager_api.h",
+        # @fb-only: ":fibers__fiber_manager_api.h",
     ],
     # TODO(T36778537): Cython-generated `*_api.h` headers aren't modular.
     modular_headers = False,
@@ -246,7 +246,7 @@ cpp_library(
     srcs = ["iobuf.cpp"],
     headers = [
         "iobuf.h",
-        ":iobuf__iobuf_api.h",
+        # @fb-only: ":iobuf__iobuf_api.h",
     ],
     # TODO(T36778537): Cython-generated `*_api.h` headers aren't modular.
     modular_headers = False,

--- a/folly/support/test/BUCK
+++ b/folly/support/test/BUCK
@@ -1,6 +1,6 @@
 load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
-load("//gdb/scripts/tests/common:gdb_unittest.bzl", "gdb_unittest")
+# @fb-only: load("//gdb/scripts/tests/common:gdb_unittest.bzl", "gdb_unittest")
 
 oncall("fbcode_entropy_wardens_folly")
 
@@ -27,12 +27,12 @@ cpp_binary(
 )
 
 # Test all of the printers in the folly gdb extension
-gdb_unittest(
-    name = "test",
-    binary = "main",
-    script = "runtest.gdb",
-    skip_modes = [
-        "dev",
-        "opt*",
-    ],
-)
+# @fb-only: gdb_unittest(
+# @fb-only:     name = "test",
+# @fb-only:     binary = "main",
+# @fb-only:     script = "runtest.gdb",
+# @fb-only:     skip_modes = [
+# @fb-only:         "dev",
+# @fb-only:         "opt*",
+# @fb-only:     ],
+# @fb-only: )


### PR DESCRIPTION
Test plan:
This, combined with several other changes, will eventually make folly build using buck2 in OSS