### PR TITLE
fix path conversion to c-str in SSLSessionTest

### DIFF
--- a/folly/io/async/test/SSLSessionTest.cpp
+++ b/folly/io/async/test/SSLSessionTest.cpp
@@ -61,11 +61,11 @@ class SSLSessionTest : public testing::Test {
       std::shared_ptr<folly::SSLContext> clientCtx,
       std::shared_ptr<folly::SSLContext> serverCtx) {
     clientCtx->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
-    clientCtx->loadTrustedCertificates(find_resource(kTestCA).c_str());
+    clientCtx->loadTrustedCertificates(find_resource(kTestCA).string().c_str());
 
     serverCtx->ciphers("ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH");
-    serverCtx->loadCertificate(find_resource(kTestCert).c_str());
-    serverCtx->loadPrivateKey(find_resource(kTestKey).c_str());
+    serverCtx->loadCertificate(find_resource(kTestCert).string().c_str());
+    serverCtx->loadPrivateKey(find_resource(kTestKey).string().c_str());
   }
 
   folly::EventBase eventBase_;


### PR DESCRIPTION
Summary: On Windows, `boost::filesystem::path::c_str()` has type `wchar_t const*` and not `char const*`; passing the result to `SSLContext` members does not compile.

Reviewed By: vitaut

Differential Revision: D57167715


