### PR TITLE
packing in the PicoSpinLock test does not seem to work under MSCV

### DIFF
--- a/folly/synchronization/test/SmallLocksTest.cpp
+++ b/folly/synchronization/test/SmallLocksTest.cpp
@@ -71,7 +71,7 @@ struct ignore2 {
   PicoSpinLock<uint32_t> psl;
   int16_t foo;
 } FOLLY_PACK_ATTR;
-static_assert(sizeof(ignore2) == 6, "Size check failed");
+static_assert(folly::kMscVer || sizeof(ignore2) == 6, "Size check failed");
 FOLLY_PACK_POP
 
 LockedVal v;


### PR DESCRIPTION
Summary:
This breaks some builds. So skip the static-assert which checks that it works.

Minimal repro: https://godbolt.org/z/bdEn648Gr. Seems that MSCV doesn't imbue packing into fields that explicitly have their own alignments while GCC does.

Reviewed By: DenisYaroshevskiy

Differential Revision: D57172836


