### PR TITLE
fix: drop std::unexpected_handler code removed in C++17

### DIFF
--- a/folly/experimental/exception_tracer/ExceptionTracer.cpp
+++ b/folly/experimental/exception_tracer/ExceptionTracer.cpp
@@ -208,7 +208,6 @@ std::vector<ExceptionInfo> getCurrentExceptions() {
 namespace {
 
 std::terminate_handler origTerminate = abort;
-std::unexpected_handler origUnexpected = abort;
 
 void dumpExceptionStack(const char* prefix) {
   auto exceptions = getCurrentExceptions();
@@ -227,18 +226,12 @@ void terminateHandler() {
   origTerminate();
 }
 
-void unexpectedHandler() {
-  dumpExceptionStack("Unexpected exception");
-  origUnexpected();
-}
-
 } // namespace
 
 void installHandlers() {
   struct Once {
     Once() {
       origTerminate = std::set_terminate(terminateHandler);
-      origUnexpected = std::set_unexpected(unexpectedHandler);
     }
   };
   static Once once;


### PR DESCRIPTION
This was deprecated in C++11 and has been removed in C++17. Now that folly requires C++17, this code can be dropped. This code prevented folly from building with (at least) libstdc++ and `-std=c++23`.