### PR TITLE
fix(cmake): prefer `folly-config.h` from build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,8 +392,8 @@ gen_pkgconfig_vars(FOLLY_PKGCONFIG folly_deps)
 target_include_directories(folly_deps
   BEFORE
   INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 target_include_directories(folly_deps
   INTERFACE


### PR DESCRIPTION
After 1866c47b0 and 45f3a6cc80, (some) cmake builds break because they'll pick up the newly committed `folly-config.h` from the source directory instead of the one created by cmake in the build directory.

This change fixes this by prioritizing the build directory include path.