### PR TITLE
fix: gcc uninitialized warnings triggered by unsafe_default_initialized

### DIFF
--- a/folly/Utility.h
+++ b/folly/Utility.h
@@ -493,8 +493,8 @@ struct unsafe_default_initialized_cv {
 #if __cpp_lib_is_constant_evaluated >= 201811L
 #if !defined(__MSVC_RUNTIME_CHECKS)
     if (!std::is_constant_evaluated()) {
-      T uninit;
-      return uninit;
+      aligned_storage_for_t<T> uninit;
+      return reinterpret_cast<T&>(uninit);
     }
 #endif // !defined(__MSVC_RUNTIME_CHECKS)
 #endif


### PR DESCRIPTION
Despite all the `FOLLY_*_DISABLE_WARNING`, the implementation of `unsafe_default_initialized_cv` triggers hundreds of `-Wuninitialized` and `-Wmaybe-uninitialized` warnings when building with GCC 12, 13, 14. As much as I've tried, it seems impossible to silence the warnings purely by diagnostic pragmas.

This change, however, eliminates all warnings, and the new code should otherwise have the exact same effect as before. At least, I can see that clang / gcc both produce identical code before and after this change when using `unsafe_default_initialized` to initialize variables.