### PR TITLE
Traits.h: Use std::is_trivially_relocatable if P1144 is available

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -586,7 +586,12 @@ struct IsRelocatable
           !require_sizeof<T> ||
               is_detected_v<traits_detail::detect_IsRelocatable, T>,
           traits_detail::has_true_IsRelocatable<T>,
-          std::is_trivially_copyable<T>>::type {};
+#if defined(__cpp_lib_is_trivially_relocatable) // P1144
+          std::is_trivially_relocatable<T>
+#else
+          std::is_trivially_copyable<T>
+#endif
+    >::type {};
 
 template <class T>
 struct IsZeroInitializable


### PR DESCRIPTION
Well, https://github.com/llvm/llvm-project/pull/84621 isn't going anywhere in Clang, therefore https://github.com/facebook/folly/pull/2159 will presumably never be mergeable (in the foreseeable future, anyway).

So here's an alternative approach, for your consideration: If [P1144's feature-test macro](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1144r10.html#wording) is set, then use `std::is_trivially_relocatable<T>` in place of `std::is_trivially_copyable<T>`.
This will produce improved codegen for e.g. `fbvector<std::vector<int>>::erase`, when compiled on a compiler supporting P1144 semantics. https://godbolt.org/z/s6sa313h3

Compare https://github.com/charles-salvia/std_error/blob/3abc272/all_in_one.hpp#L180-L196