### PR TITLE
enable more brew system deps

### DIFF
--- a/build/fbcode_builder/manifests/fmt
+++ b/build/fbcode_builder/manifests/fmt
@@ -12,3 +12,6 @@ subdir = fmt-9.1.0
 [cmake.defines]
 FMT_TEST = OFF
 FMT_DOC = OFF
+
+[homebrew]
+fmt

--- a/build/fbcode_builder/manifests/gflags
+++ b/build/fbcode_builder/manifests/gflags
@@ -15,5 +15,8 @@ BUILD_STATIC_LIBS = ON
 #BUILD_gflags_nothreads_LIB = OFF
 BUILD_gflags_LIB = ON
 
+[homebrew]
+gflags
+
 [debs]
 libgflags-dev

--- a/build/fbcode_builder/manifests/glog
+++ b/build/fbcode_builder/manifests/glog
@@ -21,5 +21,8 @@ WITH_PKGCONFIG=ON
 HAVE_TR1_UNORDERED_MAP=OFF
 HAVE_TR1_UNORDERED_SET=OFF
 
+[homebrew]
+glog
+
 [debs]
 libgoogle-glog-dev

--- a/build/fbcode_builder/manifests/googletest
+++ b/build/fbcode_builder/manifests/googletest
@@ -17,6 +17,9 @@ gtest_force_shared_crt=ON
 [cmake.defines.os=windows]
 BUILD_SHARED_LIBS=ON
 
+[homebrew]
+googletest
+
 # packaged googletest is too old
 [debs.not(all(distro=ubuntu,any(distro_vers="18.04",distro_vers="20.04",distro_vers="22.04")))]
 libgtest-dev

--- a/build/fbcode_builder/manifests/snappy
+++ b/build/fbcode_builder/manifests/snappy
@@ -1,6 +1,9 @@
 [manifest]
 name = snappy
 
+[homebrew]
+snappy
+
 [debs]
 libsnappy-dev
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/zstrong/pull/844

Save a bit of time on each github build. Enable homebrew system deps for fmt, gflags, glog, googletest, snappy

Differential Revision: D57967014


