### PR TITLE
[getdeps] restore rpm system deps for fedora

### DIFF
--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -55,6 +55,10 @@ boost169-python3
 boost169-serialization
 boost169-program-options
 
+[rpms.distro=fedora]
+boost-devel
+boost-static
+
 [build]
 builder = boost
 job_weight_mib = 512

--- a/build/fbcode_builder/manifests/fmt
+++ b/build/fbcode_builder/manifests/fmt
@@ -15,3 +15,6 @@ FMT_DOC = OFF
 
 [homebrew]
 fmt
+
+[rpms.distro=fedora]
+fmt-devel

--- a/build/fbcode_builder/manifests/gflags
+++ b/build/fbcode_builder/manifests/gflags
@@ -20,3 +20,6 @@ gflags
 
 [debs]
 libgflags-dev
+
+[rpms.distro=fedora]
+gflags-devel

--- a/build/fbcode_builder/manifests/glog
+++ b/build/fbcode_builder/manifests/glog
@@ -26,3 +26,7 @@ glog
 
 [debs]
 libgoogle-glog-dev
+
+[rpms.distro=fedora]
+glog-devel
+

--- a/build/fbcode_builder/manifests/googletest
+++ b/build/fbcode_builder/manifests/googletest
@@ -24,3 +24,7 @@ googletest
 [debs.not(all(distro=ubuntu,any(distro_vers="18.04",distro_vers="20.04",distro_vers="22.04")))]
 libgtest-dev
 libgmock-dev
+
+[rpms.distro=fedora]
+gmock-devel
+gtest-devel

--- a/build/fbcode_builder/manifests/zlib
+++ b/build/fbcode_builder/manifests/zlib
@@ -7,9 +7,13 @@ zlib1g-dev
 [homebrew]
 zlib
 
-[rpms]
+[rpms.not(distro=fedora)]
 zlib-devel
 zlib-static
+
+[rpms.distro=fedora]
+zlib-ng-compat-devel
+zlib-ng-compat-static
 
 [download]
 url = https://zlib.net/zlib-1.3.1.tar.gz


### PR DESCRIPTION
[getdeps] restore rpm system deps for fedora

Summary:

centOS (even stream) tends to be quite old and thus ends up having its rpm system deps turned off, e.g. boost in D55758008 and glog and gtest in D51813855.  Unfortunate the rpm deps were removed entirely rather than limited by distro or distro_vers.

Lets restore the rpm deps but specify distro=fedora to reduce the risk of people removing them entirely.

Also:
   * fedora has up to date gtest & gmock, so use them
   * zlib-ng-compat added from fedora 38 with zlib removed from F40, so update zlib rpm names.  F37 is EOL

Test Plan:

Build locally on fedora 40:
```
./build/fbcode_builder/getdeps.py install-system-deps --recursive folly
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. folly
```
