### PR TITLE
add missing exceptions helper under FreeBSD

### DIFF
--- a/folly/lang/Exception.cpp
+++ b/folly/lang/Exception.cpp
@@ -445,6 +445,13 @@ bool exception_ptr_access_rt_v_() noexcept {
   return true;
 }
 
+template <typename F>
+static decltype(auto) cxxabi_with_cxa_exception(void* object, F f) {
+  using cxa_exception = abi::__cxa_exception;
+  auto exception = object ? static_cast<cxa_exception*>(object) - 1 : nullptr;
+  return f(exception);
+}
+
 std::type_info const* exception_ptr_get_type_(
     std::exception_ptr const& ptr) noexcept {
   if (!ptr) {


### PR DESCRIPTION
Summary:
FreeBSD uses libc++ with libcxxrt, as v.s. libc++ with libc++'s cxxabi. The folly wrappers used a helper `cxxabi_with_cxa_exception` that we define only for libc++ with libc++'s cxxabi, so define it also for libc++ with libcxxrt under FreeBSD.

The breakage blames to {D57677424}, which introduced the call under libc++ unconditionally.

Fixes: https://github.com/facebook/folly/issues/2232.

Differential Revision: D58626578
