### PR TITLE
symbolizer: Fix missing unistd.h include.

### DIFF
--- a/folly/experimental/symbolizer/Elf.cpp
+++ b/folly/experimental/symbolizer/Elf.cpp
@@ -16,6 +16,7 @@
 
 #include <folly/experimental/symbolizer/Elf.h>
 
+#include <unistd.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Fixes `close`/`lseek`/`read`/`pread` not being in scope.

It only worked so far because `#include <glog/logging.h>` apparently brought them into scope; with glog >= 0.7.0 that does not work anymore.

See also https://github.com/facebook/folly/issues/2171#issuecomment-2185016596