### PR TITLE
Fix `using` directive in `Unistd.h` to fix react native compilation error

### DIFF
--- a/folly/portability/Unistd.h
+++ b/folly/portability/Unistd.h
@@ -21,7 +21,7 @@
 #include <unistd.h>
 
 #if defined(__APPLE__) || defined(__EMSCRIPTEN__)
-using off64_t = off_t;
+typedef off_t off64_t;
 
 off64_t lseek64(int fh, off64_t off, int orig);
 


### PR DESCRIPTION
- When using React Native 0.74.x, RCT-Folly is installed as a `Pod` dependency.
- When compiling the app for iOS using `xcodebuild`, the file `Unistd.h` gives compilation error "Unexpected type name 'off_t': expected expression".

![image](https://github.com/facebook/folly/assets/11807135/753a6147-ec74-44df-851d-e5f17190a0b6)


- Changing it to typedef makes this error go away, and the app compiles and runs correctly.

This might also fix: https://github.com/facebook/folly/issues/2167#issuecomment-2196249001

Note: CLA is signed ✅ 