### PR TITLE
fix: compatible with lower clang version

### DIFF
--- a/folly/chrono/Hardware.h
+++ b/folly/chrono/Hardware.h
@@ -91,7 +91,11 @@ inline std::uint64_t hardware_timestamp_measurement_start() noexcept {
   return ret;
 #elif defined(__GNUC__) && FOLLY_X64
   uint64_t ret = 0;
-  asm volatile inline(
+  #if __clang_major__ >= 11
+    asm volatile inline(
+  #else 
+    asm volatile(
+  #endif
       "lfence\n"
       "rdtsc\n" // loads 64-bit tsc into edx:eax
       "shl $32, %%rdx\n" // prep rdx for combine into rax
@@ -124,7 +128,11 @@ inline std::uint64_t hardware_timestamp_measurement_stop() noexcept {
   return ret;
 #elif defined(__GNUC__) && FOLLY_X64
   uint64_t ret = 0;
-  asm volatile inline(
+  #if __clang_major__ >= 11
+    asm volatile inline(
+  #else 
+    asm volatile(
+  #endif
       "rdtscp\n" // loads 64-bit tsc into edx:eax, clobbers ecx
       "shl $32, %%rdx\n" // prep rdx for combine into rax
       "or %%rdx, %[ret]\n" // combine rdx into rax


### PR DESCRIPTION
* At least the Clang 11.0.0 can support "asm volatile inline", the lower version (e.g. 9.0.1) can only support "asm volatile".