### PR TITLE
folly: fix github ci tests on macos arm

### DIFF
--- a/folly/memory/test/ArenaTest.cpp
+++ b/folly/memory/test/ArenaTest.cpp
@@ -77,6 +77,10 @@ TEST(Arena, SizeSanity) {
   minimum_size += 10 * requestedBlockSize;
   maximum_size +=
       goodMallocSize(10 * requestedBlockSize + SysArena::kBlockOverhead);
+#if defined(__APPLE__) && defined(FOLLY_AARCH64)
+  // expectation is a bit too small
+  maximum_size += 8;
+#endif
   EXPECT_GE(arena.totalSize(), minimum_size);
   EXPECT_LE(arena.totalSize(), maximum_size);
   VLOG(4) << minimum_size << " < " << arena.totalSize() << " < "

--- a/folly/test/ConstexprMathTest.cpp
+++ b/folly/test/ConstexprMathTest.cpp
@@ -987,7 +987,13 @@ TEST_F(ConstexprMathTest, constexpr_exp_floating) {
   }
   {
     constexpr auto a = folly::constexpr_exp(471.L);
+#if defined(__APPLE__) && defined(FOLLY_AARCH64)
+  EXPECT_LT( // too inexact for expect-double-eq
+        std::exp(471.L) / a - 1,
+        16 * lim::epsilon());
+#else
     EXPECT_DOUBLE_EQ(std::exp(471.L), a);
+#endif
   }
   {
     constexpr auto a = folly::constexpr_exp(600.);


### PR DESCRIPTION
These were [failing on github](https://github.com/facebook/folly/actions/runs/9923539774/job/27413784309#step:48:6919)

I think the problem was the macos runner changed from intel to arm, expectations needed updating for arm.

Test Plan:

```
./build/fbcode_builder/getdeps.py --allow-system-packages build --src-dir=. folly

./build/fbcode_builder/getdeps.py --allow-system-packages --no-facebook-internal test --no-testpilot folly
```

Before, broken
```
+ /opt/homebrew/opt/cmake/bin/ctest \
+      --output-on-failure \
+      -j \
+      3 \
+      --rerun-failed
Test project /private/var/folders/xz/lz5thm6s3vb1vdkk77vmkgbr0000gn/T/fbcode_builder_getdeps-ZUsersZrunnerZworkZfollyZfollyZbuildZfbcode_builder/build/folly
    Start 1646: arena_test.Arena.SizeSanity
    Start 2039: constexpr_math_test.ConstexprMathTest.constexpr_exp_floating
1/2 Test #1646: arena_test.Arena.SizeSanity ....................................***Failed    0.01 sec
Note: Google Test filter = Arena.SizeSanity
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Arena
[ RUN      ] Arena.SizeSanity
/Users/runner/work/folly/folly/folly/memory/test/ArenaTest.cpp:81: Failure
Expected: (arena.totalSize()) <= (maximum_size), actual: 1544 vs 1536

/Users/runner/work/folly/folly/folly/memory/test/ArenaTest.cpp:91: Failure
Expected: (arena.totalSize()) <= (maximum_size), actual: 1544 vs 1536

[  FAILED  ] Arena.SizeSanity (0 ms)
[----------] 1 test from Arena (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] Arena.SizeSanity

 1 FAILED TEST

2/2 Test #2039: constexpr_math_test.ConstexprMathTest.constexpr_exp_floating ...***Failed    0.01 sec
Note: Google Test filter = ConstexprMathTest.constexpr_exp_floating
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ConstexprMathTest
[ RUN      ] ConstexprMathTest.constexpr_exp_floating
/Users/runner/work/folly/folly/folly/test/ConstexprMathTest.cpp:990: Failure
Expected equality of these values:
  std::exp(471.L)
    Which is: 3.5702693074778485e+204
  a
    Which is: 3.5702693074778518e+204

[  FAILED  ] ConstexprMathTest.constexpr_exp_floating (0 ms)
[----------] 1 test from ConstexprMathTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ConstexprMathTest.constexpr_exp_floating

 1 FAILED TEST


0% tests passed, 2 tests failed out of 2

Total Test time (real) =   0.13 sec

The following tests FAILED:
	1646 - arena_test.Arena.SizeSanity (Failed)
	2039 - constexpr_math_test.ConstexprMathTest.constexpr_exp_floating (Failed)
```

After, works:
```
...
3067/3067 Test #2213: fbstring_test.FBString.testFixedBugsD4355440 .........................................................***Skipped   0.03 sec

100% tests passed, 0 tests failed out of 3066

Total Test time (real) =  36.02 sec

The following tests did not run:
	1934 - small_locks_test.SmallLocks.PicoSpinLockThreadSanitizer (Skipped)
	1946 - small_locks_test.SmallLocksk.MicroSpinLockThreadSanitizer (Skipped)
	1993 - atomic_unordered_map_test.AtomicUnorderedInsertMap.MegaMap (Disabled)
	2213 - fbstring_test.FBString.testFixedBugsD4355440 (Skipped)
```