### PR TITLE
Fix logger test to build with fmt 11

### DIFF
--- a/folly/logging/test/LoggerTest.cpp
+++ b/folly/logging/test/LoggerTest.cpp
@@ -151,12 +151,12 @@ class FormattableButNoToString {
 namespace fmt {
 template <>
 struct formatter<ToStringFailure> : formatter<std::string> {
-  auto format(ToStringFailure, format_context& ctx) { return ctx.out(); }
+  auto format(ToStringFailure, format_context& ctx) const { return ctx.out(); }
 };
 
 template <>
 struct formatter<FormattableButNoToString> : formatter<std::string> {
-  auto format(FormattableButNoToString, format_context& ctx) {
+  auto format(FormattableButNoToString, format_context& ctx) const {
     throw std::runtime_error("test");
     return ctx.out();
   }


### PR DESCRIPTION
otherwise we'd have following build failure when building with fmt 11:

```
/usr/include/fmt/base.h: In instantiation of ‘static void fmt::v11::detail::value<Context>::format_custom_arg(void*, typename Context::parse_context_type&, Context&) [with T = ToStringFailure; Formatter = fmt::v11::formatter<ToStringFailure>; Context = fmt::v11::context; typename Context::parse_context_type = fmt::v11::basic_format_parse_context<char>]’:
/usr/include/fmt/base.h:1373:19:   required from ‘fmt::v11::detail::value<Context>::value(T&) [with T = const ToStringFailure; Context = fmt::v11::context]’
 1373 |     custom.format = format_custom_arg<
      |     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
 1374 |         value_type, typename Context::template formatter_type<value_type>>;
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1631:41:   required from ‘constexpr fmt::v11::detail::value<Context> fmt::v11::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v11::context; T = const ToStringFailure; typename std::enable_if<PACKED, int>::type <anonymous> = 0]’
 1631 |   return {arg_mapper<Context>().map(val)};
      |                                         ^
/usr/include/fmt/base.h:2002:74:   required from ‘constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {const int, const ToStringFailure}; long unsigned int NUM_ARGS = 2; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 241; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]’
 2002 |   return {{detail::make_arg<NUM_ARGS <= detail::max_packed_args, Context>(
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2003 |       args)...}};
      |       ~~~~~
/home/kefu/dev/folly/folly/logging/LogStreamProcessor.h:371:52:   required from ‘std::string folly::LogStreamProcessor::formatLogString(folly::StringPiece, const Args& ...) [with Args = {int, ToStringFailure}; std::string = std::__cxx11::basic_string<char>; folly::StringPiece = folly::Range<const char*>]’
  371 |         vformatLogString(fmt, fmt::make_format_args(args...), failed);
      |                               ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/home/kefu/dev/folly/folly/logging/LogStreamProcessor.h:125:28:   required from ‘folly::LogStreamProcessor::LogStreamProcessor(const folly::LogCategory*, folly::LogLevel, folly::StringPiece, unsigned int, folly::StringPiece, FormatType, folly::StringPiece, Args&& ...) [with Args = {int, ToStringFailure&}; folly::StringPiece = folly::Range<const char*>]’
  125 |             formatLogString(fmt, std::forward<Args>(args)...)) {}
      |             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kefu/dev/folly/folly/logging/test/LoggerTest.cpp:202:3:   required from here
  118 |               ##__VA_ARGS__}                                           \
      |                            ^
/usr/include/fmt/base.h:1392:29: error: passing ‘const fmt::v11::formatter<ToStringFailure>’ as ‘this’ argument discards qualifiers [-fpermissive]
 1392 |     ctx.advance_to(cf.format(*static_cast<qualified_type*>(arg), ctx));
      |                    ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kefu/dev/folly/folly/logging/test/LoggerTest.cpp:154:8: note:   in call to ‘auto fmt::v11::formatter<ToStringFailure>::format(ToStringFailure, fmt::v11::format_context&)’
  154 |   auto format(ToStringFailure, format_context& ctx) { return ctx.out(); }
      |        ^~~~~~
```