### PR TITLE
remove_const from value_type of Range::value_type

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -247,8 +247,7 @@ class Range {
   using size_type = std::size_t;
   using iterator = Iter;
   using const_iterator = Iter;
-  using value_type = typename std::remove_reference<
-      typename std::iterator_traits<Iter>::reference>::type;
+  using value_type = typename std::iterator_traits<Iter>::value_type;
   using difference_type = typename std::iterator_traits<Iter>::difference_type;
   using reference = typename std::iterator_traits<Iter>::reference;
 
@@ -592,11 +591,11 @@ class Range {
   constexpr Iter end() const { return e_; }
   constexpr Iter cbegin() const { return b_; }
   constexpr Iter cend() const { return e_; }
-  value_type& front() {
+  reference front() {
     assert(b_ < e_);
     return *b_;
   }
-  value_type& back() {
+  reference back() {
     assert(b_ < e_);
     return *std::prev(e_);
   }
@@ -745,7 +744,8 @@ class Range {
     return r;
   }
 
-  value_type& operator[](size_t i) {
+  std::enable_if_t<!std::is_const<reference>::value, reference>
+  operator[](size_t i) {
     assert(i < size());
     return b_[i];
   }
@@ -755,7 +755,8 @@ class Range {
     return b_[i];
   }
 
-  value_type& at(size_t i) {
+  std::enable_if_t<!std::is_const<reference>::value, reference>
+  at(size_t i) {
     if (i >= size()) {
       throw_exception<std::out_of_range>("index out of range");
     }


### PR DESCRIPTION
in general, value_type in a range-alike type should not be qualified with const specifier. the `reference` type does.

before this change, when formatting `StringPiece`, fmt 11 does not consider it as a formattable type, as it falls into the string-alike category, but its value_type is `const char` which is different from the `Char` type of the context, which is `char` when formatting using `fmt::format("{}", ipSlashCidr)`.

hence we have the build failure like:

```
/usr/include/fmt/base.h: In instantiation of ‘constexpr fmt::v11::detail::value<Context> fmt::v11::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v11::context; T = folly::Range<const char*>; typename std::enable_if<PACKED, int>::type <anonymous> = 0]’:
/usr/include/fmt/base.h:2002:74:   required from ‘constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {folly::Range<const char*>}; long unsigned int NUM_ARGS = 1; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 15; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]’
 2002 |   return {{detail::make_arg<NUM_ARGS <= detail::max_packed_args, Context>(
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2003 |       args)...}};
      |       ~~~~~
/usr/include/fmt/format.h:4357:44:   required from ‘std::string fmt::v11::format(format_string<T ...>, T&& ...) [with T = {folly::Range<const char*>&}; std::string = std::__cxx11::basic_string<char>; format_string<T ...> = basic_format_string<char, folly::Range<const char*>&>]’
 4357 |   return vformat(fmt, fmt::make_format_args(args...));
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/home/kefu/folly/folly/IPAddress.cpp:100:47:   required from here
  100 |     throw IPAddressFormatException(fmt::format(
      |                                    ~~~~~~~~~~~^
  101 |         "Invalid ipSlashCidr specified. Expected IP/CIDR format, got '{}'",
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  102 |         ipSlashCidr));
      |         ~~~~~~~~~~~~
/usr/include/fmt/base.h:1611:17: error: static assertion failed: Mixing character types is disallowed.
 1611 |   static_assert(formattable_char, "Mixing character types is disallowed.");
      |                 ^~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1611:17: note: ‘formattable_char’ evaluates to false
/usr/include/fmt/base.h: In instantiation of ‘constexpr fmt::v11::detail::value<Context> fmt::v11::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v11::context; T = const folly::Range<const char*>; typename std::enable_if<PACKED, int>::type <anonymous> = 0]’:
/usr/include/fmt/base.h:2002:74:   required from ‘constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = context; T = {const folly::Range<const char*>}; long unsigned int NUM_ARGS = 1; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 15; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]’
 2002 |   return {{detail::make_arg<NUM_ARGS <= detail::max_packed_args, Context>(
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 2003 |       args)...}};
      |       ~~~~~
/usr/include/fmt/format.h:4357:44:   required from ‘std::string fmt::v11::format(format_string<T ...>, T&& ...) [with T = {const folly::Range<const char*>&}; std::string = std::__cxx11::basic_string<char>; format_string<T ...> = basic_format_string<char, const folly::Range<const char*>&>]’
 4357 |   return vformat(fmt, fmt::make_format_args(args...));
      |                       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
/home/kefu/folly/folly/IPAddress.cpp:113:22:   required from here
  113 |           fmt::format("Invalid IP address {}", vec.at(0)));
      |           ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1611:17: error: static assertion failed: Mixing character types is disallowed.
 1611 |   static_assert(formattable_char, "Mixing character types is disallowed.");
      |                 ^~~~~~~~~~~~~~~~
/usr/include/fmt/base.h:1611:17: note: ‘formattable_char’ evaluates to false
```

in this change, we use the non-const value type, and update the some methods where the `reference` type is supposed to be used.

Fixes #2172
Signed-off-by: Kefu Chai <tchaikov@gmail.com>