### PR TITLE
fix github CI tests on windows

### DIFF
--- a/folly/io/FsUtil.cpp
+++ b/folly/io/FsUtil.cpp
@@ -24,6 +24,10 @@
 #include <mach-o/dyld.h> // @manual
 #endif
 
+#if defined(_WIN32)
+#include <folly/portability/Windows.h>
+#endif
+
 namespace bsys = ::boost::system;
 
 namespace folly {
@@ -82,6 +86,10 @@ path executable_path() {
   std::string buf(size - 1, '\0');
   auto data = const_cast<char*>(&*buf.data());
   _NSGetExecutablePath(data, &size);
+  return path(std::move(buf));
+#elif defined(_WIN32)
+  WCHAR buf[MAX_PATH];
+  GetModuleFileNameW(NULL, buf, MAX_PATH);
   return path(std::move(buf));
 #else
   return read_symlink("/proc/self/exe");

--- a/folly/io/test/FsUtilTest.cpp
+++ b/folly/io/test/FsUtilTest.cpp
@@ -26,6 +26,7 @@
 #include <folly/String.h>
 #include <folly/portability/GMock.h>
 #include <folly/portability/GTest.h>
+#include <folly/testing/TestUtil.h>
 
 using namespace folly;
 using namespace folly::fs;
@@ -100,11 +101,11 @@ TEST(Simple, UniquePath) {
   constexpr auto tags =
       std::array{"foo", "bar", "baz", "cat", "dog", "bat", "rat", "tar", "bar"};
   auto const model = join("-%%-", tags);
-  auto const match = testing::MatchesRegex(join("-[0-9a-f]{2}-", tags));
+  auto const pattern = join("-[0-9a-f]{2}-", tags);
   std::unordered_set<std::string> paths;
   for (size_t i = 0; i < size; ++i) {
     auto res = std_fs_unique_path(std_fs::path(model)).string();
-    EXPECT_THAT(res, match);
+    EXPECT_PCRE_MATCH(pattern, res);
     paths.insert(std::move(res));
   }
   EXPECT_EQ(size, paths.size());
@@ -112,11 +113,11 @@ TEST(Simple, UniquePath) {
 
 TEST(Simple, UniquePathDefaultModel) {
   constexpr auto size = size_t(1) << 10;
-  auto const match = testing::MatchesRegex("([0-9a-f]{4}-){3}[0-9a-f]{4}");
+  auto const pattern = "([0-9a-f]{4}-){3}[0-9a-f]{4}";
   std::unordered_set<std::string> paths;
   for (size_t i = 0; i < size; ++i) {
     auto res = std_fs_unique_path().string();
-    EXPECT_THAT(res, match);
+    EXPECT_PCRE_MATCH(pattern, res);
     paths.insert(std::move(res));
   }
   EXPECT_EQ(size, paths.size());

--- a/folly/lang/test/ExceptionTest.cpp
+++ b/folly/lang/test/ExceptionTest.cpp
@@ -235,7 +235,14 @@ TEST_F(ExceptionTest, current_exception) {
     throw std::exception();
   } catch (...) {
     // primary exception?
+#if defined(_CPPLIB_VER)
+    // As per https://learn.microsoft.com/en-us/cpp/standard-library/exception-functions?view=msvc-170
+    // current_exception() returns a new value each time, so its not directly comparable on MSVC
+    EXPECT_NE(nullptr, std::current_exception());
+    EXPECT_NE(nullptr, folly::current_exception());
+#else
     EXPECT_EQ(std::current_exception(), folly::current_exception());
+#endif
   }
   try {
     throw std::exception();
@@ -244,7 +251,12 @@ TEST_F(ExceptionTest, current_exception) {
       throw;
     } catch (...) {
       // dependent exception?
+#if defined(_CPPLIB_VER)
+      EXPECT_NE(nullptr, std::current_exception());
+      EXPECT_NE(nullptr, folly::current_exception());
+#else
       EXPECT_EQ(std::current_exception(), folly::current_exception());
+#endif
     }
   }
 }


### PR DESCRIPTION
Summary:

These were [failing on github](https://github.com/facebook/folly/actions/runs/9923539772/job/27413784313#step:43:30071)

 * Fix use of regex in test in FsUtilTest.cpp
 * MSVC exception_ptrs are not comparable, was breaking ExceptionTest
 * Fix lookup of executable path on windows, which was breaking SSL test

Test Plan:
```
python build/fbcode_builder/getdeps.py build --src-dir=. folly
python build/fbcode_builder/getdeps.py test folly
```

before, broken:
```
1/6 Test  #941: ssl_session_test.SSLSessionTest.BasicTest ...................***Failed    0.03 sec
Note: Google Test filter = SSLSessionTest.BasicTest
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SSLSessionTest
[ RUN      ] SSLSessionTest.BasicTest
unknown file: error: C++ exception with description "boost::filesystem::read_symlink: The system cannot find the path specified [system:3]: "/proc/self/exe"" thrown in SetUp().
[  FAILED  ] SSLSessionTest.BasicTest (4 ms)
[----------] 1 test from SSLSessionTest (4 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (4 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] SSLSessionTest.BasicTest

 1 FAILED TEST

    Start  942: ssl_session_test.SSLSessionTest.NullSessionResumptionTest
2/6 Test  #936: HHWheelTimerTest.HHWheelTimerTest.GetTimeRemaining ..........   Passed    0.06 sec
    Start 1029: lang_exception_test.ExceptionTest.current_exception
3/6 Test  #942: ssl_session_test.SSLSessionTest.NullSessionResumptionTest ...***Failed    0.04 sec
Note: Google Test filter = SSLSessionTest.NullSessionResumptionTest
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SSLSessionTest
[ RUN      ] SSLSessionTest.NullSessionResumptionTest
unknown file: error: C++ exception with description "boost::filesystem::read_symlink: The system cannot find the path specified [system:3]: "/proc/self/exe"" thrown in SetUp().
[  FAILED  ] SSLSessionTest.NullSessionResumptionTest (6 ms)
[----------] 1 test from SSLSessionTest (6 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (7 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] SSLSessionTest.NullSessionResumptionTest

 1 FAILED TEST

4/6 Test  #839: fs_util_test.Simple.UniquePathDefaultModel ..................***Failed    0.08 sec
Note: Google Test filter = Simple.UniquePathDefaultModel
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Simple
[ RUN      ] Simple.UniquePathDefaultModel
5/6 Test #1029: lang_exception_test.ExceptionTest.current_exception .........***Failed    0.02 sec
Note: Google Test filter = ExceptionTest.current_exception
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from ExceptionTest
[ RUN      ] ExceptionTest.current_exception
D:\a\folly\folly\folly\lang\test\ExceptionTest.cpp(238): error: Expected equality of these values:
  std::current_exception()
    Which is: 16-byte object <20-44 C1-6B 9B-01 00-00 10-44 C1-6B 9B-01 00-00>
  folly::current_exception()
    Which is: 16-byte object <30-3B C1-6B 9B-01 00-00 20-3B C1-6B 9B-01 00-00>
D:\a\folly\folly\folly\lang\test\ExceptionTest.cpp(247): error: Expected equality of these values:
  std::current_exception()
    Which is: 16-byte object <40-3F C1-6B 9B-01 00-00 30-3F C1-6B 9B-01 00-00>
  folly::current_exception()
    Which is: 16-byte object <20-44 C1-6B 9B-01 00-00 10-44 C1-6B 9B-01 00-00>
[  FAILED  ] ExceptionTest.current_exception (0 ms)
[----------] 1 test from ExceptionTest (0 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (0 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] ExceptionTest.current_exception

 1 FAILED TEST

6/6 Test  #838: fs_util_test.Simple.UniquePath ..............................***Failed    0.12 sec
Note: Google Test filter = Simple.UniquePath
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from Simple
[ RUN      ] Simple.UniquePath
```

After, works:
```
1920/1920 Test  #813: parallel_test.ParallelTest.PSum ......................................................................   Passed   66.92 sec

100% tests passed, 0 tests failed out of 1919

Total Test time (real) =  67.02 sec

The following tests did not run:
        1348 - atomic_unordered_map_test.AtomicUnorderedInsertMap.MegaMap (Disabled)
```