### PR TITLE
Replace usage of std::latch with folly::Latch

### DIFF
--- a/folly/concurrency/test/BUCK
+++ b/folly/concurrency/test/BUCK
@@ -97,6 +97,7 @@ cpp_unittest(
         "//folly/hash:hash",
         "//folly/portability:gflags",
         "//folly/portability:gtest",
+        "//folly/synchronization:latch",
         "//folly/test:deterministic_schedule",
     ],
 )

--- a/folly/test/BUCK
+++ b/folly/test/BUCK
@@ -1490,6 +1490,7 @@ cpp_unittest(
         "//folly/experimental/io:fs_util",
         "//folly/lang:keep",
         "//folly/portability:gtest",
+        "//folly/synchronization:latch",
         "//folly/testing:test_util",
     ],
     external_deps = [
@@ -1722,6 +1723,7 @@ cpp_binary(
         "//folly:thread_local",
         "//folly/lang:keep",
         "//folly/portability:gflags",
+        "//folly/synchronization:latch",
     ],
     external_deps = [
         "glog",

--- a/folly/test/SingletonThreadLocalTest.cpp
+++ b/folly/test/SingletonThreadLocalTest.cpp
@@ -18,7 +18,6 @@
 #include <dlfcn.h>
 #endif
 
-#include <latch>
 #include <thread>
 #include <unordered_set>
 #include <vector>
@@ -31,6 +30,7 @@
 #include <folly/experimental/io/FsUtil.h>
 #include <folly/lang/Keep.h>
 #include <folly/portability/GTest.h>
+#include <folly/synchronization/Latch.h>
 #include <folly/testing/TestUtil.h>
 
 using namespace folly;
@@ -60,7 +60,7 @@ TEST(SingletonThreadLocalTest, TryGet) {
 
 TEST(SingletonThreadLocalTest, OneSingletonPerThread) {
   static constexpr std::size_t targetThreadCount{64};
-  std::latch allSingletonsCreated(targetThreadCount);
+  folly::Latch allSingletonsCreated(targetThreadCount);
   Synchronized<std::unordered_set<Foo*>> fooAddresses{};
   std::vector<std::thread> threads{};
   auto threadFunction = [&fooAddresses, &allSingletonsCreated] {

--- a/folly/test/ThreadLocalBenchmark.cpp
+++ b/folly/test/ThreadLocalBenchmark.cpp
@@ -18,7 +18,6 @@
 
 #include <sys/types.h>
 
-#include <latch>
 #include <numeric>
 #include <thread>
 
@@ -28,6 +27,7 @@
 #include <folly/Benchmark.h>
 #include <folly/lang/Keep.h>
 #include <folly/portability/GFlags.h>
+#include <folly/synchronization/Latch.h>
 
 using namespace folly;
 
@@ -137,9 +137,9 @@ BENCHMARK(BM_tlp_access_all_threads_iterate, iters) {
   folly::ThreadLocalPtr<int, tag> var;
   folly::BenchmarkSuspender braces;
   std::vector<std::jthread> threads{folly::to_unsigned(FLAGS_num_threads)};
-  std::latch prep{FLAGS_num_threads};
-  std::latch work{FLAGS_num_threads + 1};
-  std::latch done{1};
+  folly::Latch prep(FLAGS_num_threads);
+  folly::Latch work(FLAGS_num_threads + 1);
+  folly::Latch done(1);
   for (auto& th : threads) {
     th = std::jthread([&] {
       var.reset(new int(3));


### PR DESCRIPTION
Summary:
Reworking PR #2073 - use `folly::Latch` instead of having to fix ungated
use of `std::latch`, which breaks open source builds that are still using
CMake since `CMAKE_CXX_STANDARD` is still set to `17` (and bumping it to
`20` might mean having to stop supporting the default compiler on some
enterprise distributions).

Differential Revision: D59985585
