### PR TITLE
Add fbcode_builder manifests for mcrouter and ragel

### DIFF
--- a/build/fbcode_builder/manifests/mcrouter
+++ b/build/fbcode_builder/manifests/mcrouter
@@ -1,0 +1,23 @@
+[manifest]
+name = mcrouter
+
+[git]
+repo_url = https://github.com/facebook/mcrouter.git
+
+[dependencies]
+folly
+wangle
+fizz
+fbthrift
+mvfst
+ragel
+
+[build]
+builder = cmake
+subdir = .
+
+[cmake.defines.test=on]
+BUILD_TESTS=ON
+
+[cmake.defines.test=off]
+BUILD_TESTS=OFF

--- a/build/fbcode_builder/manifests/ragel
+++ b/build/fbcode_builder/manifests/ragel
@@ -1,0 +1,19 @@
+[manifest]
+name = ragel
+
+[debs]
+ragel
+
+[homebrew]
+ragel
+
+[rpms]
+ragel
+
+[download]
+url = https://www.colm.net/files/ragel/ragel-6.10.tar.gz
+sha256 = 5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f
+
+[build]
+builder = autoconf
+subdir = ragel-6.10


### PR DESCRIPTION
https://github.com/facebook/mcrouter currently uses a legacy autotools-based build system, which forces third parties to rely on a collection of scripts hosted in the repository to build it with all required dependencies. This is brittle and has lead to many issue reports about build problems.

In https://github.com/facebook/mcrouter/pull/449, I've prepared a working CMake-based build system for mcrouter that could replace the legacy autotools setup. This patch adds the necessary manifests for mcrouter and its ragel dependency so that fbcode_builder itself will be setup for the repo without having to do it in the PR.