### PR TITLE
migrate simdForEach #2: remove unroll step

### DIFF
--- a/folly/algorithm/simd/BUCK
+++ b/folly/algorithm/simd/BUCK
@@ -27,6 +27,7 @@ cpp_library(
     headers = ["SimdForEach.h"],
     exported_deps = [
         "//folly:c_portability",
+        "//folly:traits",
         "//folly/algorithm/simd/detail:unroll_utils",
     ],
 )

--- a/folly/algorithm/simd/detail/BUCK
+++ b/folly/algorithm/simd/detail/BUCK
@@ -10,5 +10,6 @@ cpp_library(
     headers = ["UnrollUtils.h"],
     exported_deps = [
         "//folly:portability",
+        "//folly:traits",
     ],
 )

--- a/folly/algorithm/simd/detail/test/UnrollUtilsTest.cpp
+++ b/folly/algorithm/simd/detail/test/UnrollUtilsTest.cpp
@@ -51,20 +51,26 @@ TEST(UnrollUtilsTest, ArrayReduce) {
   static_assert(10 == reduceValues<1, 2, 3, 4>(), "");
 }
 
-template <int stopAt>
+template <std::size_t stopAt>
 struct UnrollUntilTestOp {
-  int* lastStep;
+  std::size_t* lastStep;
 
-  template <int i>
-  constexpr bool operator()(UnrollStep<i>) const {
+  template <std::size_t i>
+  constexpr bool operator()(folly::index_constant<i>) const {
     *lastStep = i;
     return i == stopAt;
   }
 };
 
-template <int N, int stopAt, bool expectedRes, int expectedLastStep>
+constexpr std::size_t kNoStop = std::numeric_limits<std::size_t>::max();
+
+template <
+    std::size_t N,
+    std::size_t stopAt,
+    bool expectedRes,
+    std::size_t expectedLastStep>
 constexpr bool unrollUntilTest() {
-  int lastStep = -1;
+  std::size_t lastStep = kNoStop;
   UnrollUntilTestOp<stopAt> op{&lastStep};
   bool res = UnrollUtils::unrollUntil<N>(op);
 
@@ -77,14 +83,14 @@ TEST(UnrollUtilsTest, UnrollUntil) {
           /*N*/ 0,
           /*stopAt*/ 0,
           /*expectedRes*/ false,
-          /*ExpectedLastStep*/ -1>(),
+          /*ExpectedLastStep*/ kNoStop>(),
       "");
   static_assert(
       unrollUntilTest<
           /*N*/ 0,
           /*stopAt*/ 1,
           /*expectedRes*/ false,
-          /*ExpectedLastStep*/ -1>(),
+          /*ExpectedLastStep*/ kNoStop>(),
       "");
   static_assert(
       unrollUntilTest<

--- a/folly/algorithm/simd/test/SimdForEachTest.cpp
+++ b/folly/algorithm/simd/test/SimdForEachTest.cpp
@@ -71,7 +71,7 @@ struct TestDelegate {
           return step(
               unrolled[unrollI()],
               ignore_none{},
-              detail::UnrollStep<decltype(unrollI)::value + ('A' - 'a')>{});
+              folly::index_constant<decltype(unrollI)::value + ('A' - 'a')>{});
         });
   }
 };


### PR DESCRIPTION
Summary: detail::UnrollStep should go away, because otherwise it would be exposed to the user of `simdForEach`.

Reviewed By: yfeldblum

Differential Revision: D60587842
