### PR TITLE
Fix hardcoded page size in test

### DIFF
--- a/folly/test/RangeTest.cpp
+++ b/folly/test/RangeTest.cpp
@@ -23,6 +23,7 @@
 #include <random>
 #include <string>
 #include <type_traits>
+#include <unistd.h>
 #include <vector>
 
 #include <boost/algorithm/string/trim.hpp>
@@ -1052,7 +1053,7 @@ TYPED_TEST(NeedleFinderTest, Base) {
   }
 }
 
-const size_t kPageSize = 4096;
+const size_t kPageSize = sysconf(_SC_PAGESIZE);
 // Updates contents so that any read accesses past the last byte will
 // cause a SIGSEGV.  It accomplishes this by changing access to the page that
 // begins immediately after the end of the contents (as allocators and mmap()


### PR DESCRIPTION
This test segfaults on Nvidia's grace cpus since the page size for them is 64kb. Replacing the hardcoded value fixes the issue.