### PR TITLE
Add missing scaffolding to mcrouter manifest

### DIFF
--- a/build/fbcode_builder/manifests/mcrouter
+++ b/build/fbcode_builder/manifests/mcrouter
@@ -1,5 +1,8 @@
 [manifest]
 name = mcrouter
+fbsource_path = fbcode/mcrouter
+shipit_project = mcrouter
+shipit_fbcode_builder = true
 
 [git]
 repo_url = https://github.com/facebook/mcrouter.git
@@ -21,3 +24,6 @@ BUILD_TESTS=ON
 
 [cmake.defines.test=off]
 BUILD_TESTS=OFF
+
+[shipit.pathmap]
+fbcode/mcrouter = mcrouter


### PR DESCRIPTION
This seems to be necessary in order for the project to be correctly recognized as a Meta first-party project and is likely required to resolve #2281.