### PR TITLE
Build fast_float from source on Ubuntu < 24.04

### DIFF
--- a/.github/workflows/getdeps_linux.yml
+++ b/.github/workflows/getdeps_linux.yml
@@ -38,6 +38,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch double-conversion
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
+    - name: Fetch fast_float
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch fmt
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch gflags
@@ -80,6 +82,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
     - name: Build double-conversion
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
+    - name: Build fast_float
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
     - name: Build fmt
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
     - name: Build gflags

--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -36,6 +36,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests cmake
     - name: Fetch double-conversion
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests double-conversion
+    - name: Fetch fast_float
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fast_float
     - name: Fetch fmt
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fetch --no-tests fmt
     - name: Fetch gflags
@@ -74,6 +76,8 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests cmake
     - name: Build double-conversion
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests double-conversion
+    - name: Build fast_float
+      run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fast_float
     - name: Build fmt
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages build --free-up-disk --no-tests fmt
     - name: Build gflags

--- a/.github/workflows/getdeps_windows.yml
+++ b/.github/workflows/getdeps_windows.yml
@@ -35,6 +35,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py fetch --no-tests cmake
     - name: Fetch double-conversion
       run: python build/fbcode_builder/getdeps.py fetch --no-tests double-conversion
+    - name: Fetch fast_float
+      run: python build/fbcode_builder/getdeps.py fetch --no-tests fast_float
     - name: Fetch fmt
       run: python build/fbcode_builder/getdeps.py fetch --no-tests fmt
     - name: Fetch gflags
@@ -69,6 +71,8 @@ jobs:
       run: python build/fbcode_builder/getdeps.py build --free-up-disk --no-tests cmake
     - name: Build double-conversion
       run: python build/fbcode_builder/getdeps.py build --free-up-disk --no-tests double-conversion
+    - name: Build fast_float
+      run: python build/fbcode_builder/getdeps.py build --free-up-disk --no-tests fast_float
     - name: Build fmt
       run: python build/fbcode_builder/getdeps.py build --free-up-disk --no-tests fmt
     - name: Build gflags

--- a/build/fbcode_builder/manifests/fast_float
+++ b/build/fbcode_builder/manifests/fast_float
@@ -13,7 +13,7 @@ subdir = fast_float-2.0.0
 FASTFLOAT_TEST = OFF
 FASTFLOAT_SANITIZE = OFF
 
-[debs]
+[debs.not(all(distro=ubuntu,any(distro_vers="18.04",distro_vers="20.04",distro_vers="22.04")))]
 libfast-float-dev
 
 [rpms.distro=fedora]


### PR DESCRIPTION
libfast-float-dev only exists on Ubuntu 24.04 and newer, causing build failures on older releases.