### PR TITLE
clearing bit utils

### DIFF
--- a/folly/algorithm/simd/FindFixed.h
+++ b/folly/algorithm/simd/FindFixed.h
@@ -293,7 +293,8 @@ constexpr std::optional<std::size_t> findFixed(std::span<const T, N> where, U x)
     return find_fixed_detail::findFixedConstexpr(std::span<const T>(where), x);
   } else {
     return find_fixed_detail::findFixedDispatch(
-        detail::asSimdFriendlyUint(where), detail::asSimdFriendlyUint(x));
+        simd::detail::asSimdFriendlyUint(where),
+        simd::detail::asSimdFriendlyUint(x));
   }
 }
 

--- a/folly/algorithm/simd/detail/BUCK
+++ b/folly/algorithm/simd/detail/BUCK
@@ -40,6 +40,7 @@ cpp_library(
     name = "traits",
     headers = ["Traits.h"],
     exported_deps = [
+        "//folly:c_portability",
         "//folly:memory",
         "//folly:traits",
         "//folly/container:span",

--- a/folly/algorithm/simd/detail/Traits.h
+++ b/folly/algorithm/simd/detail/Traits.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/CPortability.h>
 #include <folly/Memory.h>
 #include <folly/Traits.h>
 #include <folly/container/span.h>
@@ -23,7 +24,7 @@
 #include <concepts>
 #include <type_traits>
 
-namespace folly::detail {
+namespace folly::simd::detail {
 
 template <typename T>
 auto findSimdFriendlyEquivalent() {
@@ -36,65 +37,75 @@ auto findSimdFriendlyEquivalent() {
       return double{};
     }
   } else if constexpr (std::is_signed_v<T>) {
-    if constexpr (sizeof(T) == 1) {
-      return std::int8_t{};
-    } else if constexpr (sizeof(T) == 2) {
-      return std::int16_t{};
-    } else if constexpr (sizeof(T) == 4) {
-      return std::int32_t{};
-    } else if constexpr (sizeof(T) == 8) {
-      return std::int64_t{};
-    }
+    return int_bits_t<sizeof(T) * 8>{};
   } else if constexpr (std::is_unsigned_v<T>) {
-    if constexpr (sizeof(T) == 1) {
-      return std::uint8_t{};
-    } else if constexpr (sizeof(T) == 2) {
-      return std::uint16_t{};
-    } else if constexpr (sizeof(T) == 4) {
-      return std::uint32_t{};
-    } else if constexpr (sizeof(T) == 8) {
-      return std::uint64_t{};
-    }
+    return uint_bits_t<sizeof(T) * 8>{};
   }
 }
 
 template <typename T>
-concept has_simd_friendly_equivalent =
+constexpr bool has_simd_friendly_equivalent_scalar =
     !std::is_same_v<void, decltype(findSimdFriendlyEquivalent<T>())>;
 
-template <has_simd_friendly_equivalent T>
-using simd_friendly_equivalent_t = folly::like_t< //
-    T,
-    decltype(findSimdFriendlyEquivalent<std::remove_const_t<T>>())>;
+template <typename T>
+using simd_friendly_equivalent_scalar_t = std::enable_if_t<
+    has_simd_friendly_equivalent_scalar<T>,
+    like_t<T, decltype(findSimdFriendlyEquivalent<std::remove_const_t<T>>())>>;
 
 template <typename T>
-concept has_integral_simd_friendly_equivalent =
-    has_simd_friendly_equivalent<T> && // have to explicitly specify this for
-                                       // subsumption to work
-    std::integral<simd_friendly_equivalent_t<T>>;
+constexpr bool has_integral_simd_friendly_equivalent_scalar =
+    std::is_integral_v< // void will return false
+        decltype(findSimdFriendlyEquivalent<std::remove_const_t<T>>())>;
 
-template <has_integral_simd_friendly_equivalent T>
-using integral_simd_friendly_equivalent = simd_friendly_equivalent_t<T>;
+template <typename T>
+using unsigned_simd_friendly_equivalent_scalar_t = std::enable_if_t<
+    has_integral_simd_friendly_equivalent_scalar<T>,
+    like_t<T, uint_bits_t<sizeof(T) * 8>>>;
 
-template <has_simd_friendly_equivalent T, std::size_t Extend>
-auto asSimdFriendly(folly::span<T, Extend> s) {
-  return folly::reinterpret_span_cast<simd_friendly_equivalent_t<T>>(s);
-}
+template <typename R>
+using span_for = decltype(folly::span(std::declval<const R&>()));
 
-template <has_simd_friendly_equivalent T>
-constexpr auto asSimdFriendly(T x) {
-  return static_cast<simd_friendly_equivalent_t<T>>(x);
-}
+struct AsSimdFriendlyFn {
+  template <typename T, std::size_t extent>
+  FOLLY_ERASE auto operator()(folly::span<T, extent> s) const
+      -> folly::span<simd_friendly_equivalent_scalar_t<T>, extent> {
+    return reinterpret_span_cast<simd_friendly_equivalent_scalar_t<T>>(s);
+  }
 
-template <has_simd_friendly_equivalent T, std::size_t Extend>
-auto asSimdFriendlyUint(folly::span<T, Extend> s) {
-  return folly::reinterpret_span_cast<
-      folly::like_t<T, uint_bits_t<sizeof(T) * 8>>>(s);
-}
+  template <typename R>
+  FOLLY_ERASE auto operator()(R&& r) const
+      -> decltype(operator()(span_for<R>(r))) {
+    return operator()(folly::span(r));
+  }
 
-template <has_simd_friendly_equivalent T>
-constexpr auto asSimdFriendlyUint(T x) {
-  return static_cast<uint_bits_t<sizeof(T) * 8>>(x);
-}
+  template <typename T>
+  FOLLY_ERASE constexpr auto operator()(T x) const
+      -> simd_friendly_equivalent_scalar_t<T> {
+    return static_cast<simd_friendly_equivalent_scalar_t<T>>(x);
+  }
+};
+inline constexpr AsSimdFriendlyFn asSimdFriendly;
 
-} // namespace folly::detail
+struct AsSimdFriendlyUintFn {
+  template <typename T, std::size_t extent>
+  FOLLY_ERASE auto operator()(folly::span<T, extent> s) const
+      -> folly::span<unsigned_simd_friendly_equivalent_scalar_t<T>, extent> {
+    return reinterpret_span_cast<unsigned_simd_friendly_equivalent_scalar_t<T>>(
+        s);
+  }
+
+  template <typename R>
+  FOLLY_ERASE auto operator()(R&& r) const
+      -> decltype(operator()(span_for<R>(r))) {
+    return operator()(folly::span(r));
+  }
+
+  template <typename T>
+  FOLLY_ERASE constexpr auto operator()(T x) const
+      -> unsigned_simd_friendly_equivalent_scalar_t<T> {
+    return static_cast<unsigned_simd_friendly_equivalent_scalar_t<T>>(x);
+  }
+};
+inline constexpr AsSimdFriendlyUintFn asSimdFriendlyUint;
+
+} // namespace folly::simd::detail

--- a/folly/algorithm/simd/detail/test/BUCK
+++ b/folly/algorithm/simd/detail/test/BUCK
@@ -27,6 +27,7 @@ cpp_unittest(
 cpp_unittest(
     name = "traits_test",
     srcs = ["TraitsTest.cpp"],
+    compiler_flags = ["--std=c++17"],
     deps = [
         "//folly/algorithm/simd/detail:traits",
         "//folly/portability:gmock",

--- a/folly/container/BUCK
+++ b/folly/container/BUCK
@@ -172,11 +172,12 @@ cpp_library(
     name = "span",
     headers = ["span.h"],
     exported_deps = [
+        ":access",
+        ":iterator",
         "//folly:cpp_attributes",
         "//folly:portability",
         "//folly:traits",
         "//folly:utility",
-        "//folly/container:access",
         "//folly/functional:invoke",
         "//folly/portability:constexpr",
     ],

--- a/folly/container/Iterator.h
+++ b/folly/container/Iterator.h
@@ -112,6 +112,12 @@ inline constexpr bool iterator_category_matches_v =
 template <typename Iter>
 using iterator_value_type_t = typename std::iterator_traits<Iter>::value_type;
 
+//  iterator_reference_type_t
+//
+//  Extracts reference from an iterator (C++20 iter_reference_t backported)
+template <typename Iter>
+using iterator_reference_t = decltype(*std::declval<Iter&>());
+
 //  iterator_key_type_t
 //
 //  Extracts a key type from an iterator, leverages the knowledge that

--- a/folly/container/span.h
+++ b/folly/container/span.h
@@ -27,6 +27,7 @@
 #include <folly/Traits.h>
 #include <folly/Utility.h>
 #include <folly/container/Access.h>
+#include <folly/container/Iterator.h>
 #include <folly/functional/Invoke.h>
 #include <folly/portability/Constexpr.h>
 
@@ -246,6 +247,22 @@ class span {
     return {data_ + size() - count, count};
   }
 };
+
+template <typename T, typename EndOrSize>
+span(T*, EndOrSize) -> span<T>;
+
+template <typename T, std::size_t N>
+span(T (&)[N]) -> span<T, N>;
+
+template <typename T, std::size_t N>
+span(std::array<T, N>&) -> span<T, N>;
+
+template <typename T, std::size_t N>
+span(const std::array<T, N>&) -> span<const T, N>;
+
+template <typename R>
+span(R&&) -> span<std::remove_reference_t<
+              iterator_reference_t<decltype(std::begin(std::declval<R&>()))>>>;
 
 } // namespace fallback_span
 

--- a/folly/container/test/span_test.cpp
+++ b/folly/container/test/span_test.cpp
@@ -324,6 +324,46 @@ TYPED_TEST_P(SpanTest, fix_as_bytes) {
   EXPECT_EQ(20, wbytes.size());
 }
 
+namespace fallback_span_ctad {
+
+namespace fallback = folly::detail::fallback_span;
+
+template <typename... Ts>
+using deduced_for = decltype(fallback::span(std::declval<Ts>()...));
+
+static_assert( //
+    std::is_same_v<
+        fallback::span<const int>,
+        deduced_for<const int*, std::size_t>>);
+
+static_assert( //
+    std::is_same_v<
+        fallback::span<const int>,
+        deduced_for<const std::vector<int>&>>);
+
+static_assert( //
+    std::is_same_v<fallback::span<int>, deduced_for<std::vector<int>&>>);
+
+static_assert(
+    std::is_same_v<fallback::span<int, 3>, deduced_for<std::array<int, 3>&>>);
+
+static_assert( //
+    std::is_same_v<
+        fallback::span<const int, 3>,
+        deduced_for<const std::array<int, 3>&>>);
+
+int arr1[3];
+static_assert( //
+    std::is_same_v<fallback::span<int, 3>, decltype(fallback::span(arr1))>);
+
+constexpr int arr2[3]{0, 1, 2};
+static_assert( //
+    std::is_same_v<
+        fallback::span<const int, 3>,
+        decltype(fallback::span(arr2))>);
+
+} // namespace fallback_span_ctad
+
 // clang-format off
 REGISTER_TYPED_TEST_SUITE_P(
     SpanTest


### PR DESCRIPTION
Summary:
make_maskl
make_maskr
set_lzero
set_lone
set_rzero
set_lone

Simple utils that correctly handle corner cases, such as shift == 64.
I looked at the assembly a bit, probably that's ok.
For x86 I used bmi2 where was appropriate.

Differential Revision: D63329499
