### PR TITLE
removing movemask from platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,6 +649,8 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
     DIRECTORY algorithm/simd/detail/test/
       TEST algorithm_simd_detail_simd_any_of_test SOURCES SimdAnyOfTest.cpp
       TEST algorithm_simd_detail_simd_for_each_test SOURCES SimdForEachTest.cpp
+      TEST algorithm_simd_detail_simd_for_each_test SOURCES SimdForEachTest.cpp
+      TEST algorithm_simd_detail_ignore_test SOURCES IgnoreTest.cpp
       TEST algorithm_simd_detail_unroll_utils_test SOURCES UnrollUtilsTest.cpp
       # disabled until C++20
       # TEST algorithm_simd_detail_simd_traits_test SOURCES TraitsTest.cpp

--- a/folly/algorithm/simd/FindFixed.h
+++ b/folly/algorithm/simd/FindFixed.h
@@ -194,7 +194,7 @@ std::optional<std::size_t> findSplitFirstRegister(
 
 template <typename Scalar, typename Reg>
 std::optional<std::size_t> firstTrue(Reg reg) {
-  auto [bits, bitsPerElement] = folly::movemask<Scalar>(reg);
+  auto [bits, bitsPerElement] = folly::simd::movemask<Scalar>(reg);
   if (bits) {
     return std::countr_zero(bits) / bitsPerElement();
   }

--- a/folly/algorithm/simd/detail/BUCK
+++ b/folly/algorithm/simd/detail/BUCK
@@ -6,6 +6,14 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 oncall("fbcode_entropy_wardens_folly")
 
 cpp_library(
+    name = "ignore",
+    headers = ["Ignore.h"],
+    exported_deps = [
+        "//folly/lang:bits",
+    ],
+)
+
+cpp_library(
     name = "simd_any_of",
     headers = ["SimdAnyOf.h"],
     exported_deps = [
@@ -19,7 +27,7 @@ cpp_library(
     name = "simd_char_platform",
     headers = ["SimdCharPlatform.h"],
     exported_deps = [
-        ":simd_for_each",
+        ":ignore",
         "//folly:portability",
         "//folly/algorithm/simd:movemask",
         "//folly/lang:bits",
@@ -30,9 +38,10 @@ cpp_library(
     name = "simd_for_each",
     headers = ["SimdForEach.h"],
     exported_deps = [
+        ":ignore",
+        ":unroll_utils",
         "//folly:c_portability",
         "//folly:traits",
-        "//folly/algorithm/simd/detail:unroll_utils",
     ],
 )
 

--- a/folly/algorithm/simd/detail/Ignore.h
+++ b/folly/algorithm/simd/detail/Ignore.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/lang/Bits.h>
+
+#include <type_traits>
+
+namespace folly::simd::detail {
+
+/**
+ * ignore(_none/_extrema)
+ *
+ * Tag types for handling the tails.
+ * ignore_none indicates that the whole register is used.
+ * ignore_extrema.first, .last show how many elements are out of the data.
+ *
+ * For example 3 elements, starting from the second for an 8 element register
+ * will be ignore_extrema{.first = 1, .last = 4}
+ */
+
+struct ignore_extrema {
+  int first = 0;
+  int last = 0;
+};
+
+struct ignore_none {};
+
+/*
+ * NOTE: for ignore none we don't clear anything, even if some bits are not
+ * doing anything. We expect mmask to only have zeroes in masked out elements.
+ *
+ * Maybe we need to revisit that at some point.
+ */
+template <int Cardinal, typename Uint, typename BitsPerElement, typename Ignore>
+void mmaskClearIgnored(std::pair<Uint, BitsPerElement>& mmask, Ignore ignore) {
+  if constexpr (std::is_same_v<Ignore, ignore_extrema>) {
+    mmask.first = set_rzero(mmask.first, ignore.first * BitsPerElement{});
+
+    static constexpr int kTopBitsAlwaysIgnored =
+        sizeof(Uint) * 8 - Cardinal * BitsPerElement{};
+    mmask.first = set_lzero(
+        mmask.first, ignore.last * BitsPerElement{} + kTopBitsAlwaysIgnored);
+  }
+}
+
+} // namespace folly::simd::detail

--- a/folly/algorithm/simd/detail/SimdForEach.h
+++ b/folly/algorithm/simd/detail/SimdForEach.h
@@ -18,6 +18,7 @@
 
 #include <folly/CPortability.h>
 #include <folly/Traits.h>
+#include <folly/algorithm/simd/detail/Ignore.h>
 #include <folly/algorithm/simd/detail/UnrollUtils.h>
 
 #include <array>
@@ -34,23 +35,6 @@ namespace simd::detail {
 // function that does everything. Otherwise sometimes the compiler tends
 // to mess that up.
 //
-
-/**
- * ignore(_none/_extrema)
- *
- * Tag types for handling the tails.
- * ignore_none indicates that the whole register is used.
- * ignore_extrema.first, .last show how many elements are out of the data.
- *
- * For example 3 elements, starting from the second for an 8 element register
- * will be ignore_extrema{.first = 1, .last = 4}
- */
-struct ignore_extrema {
-  int first = 0;
-  int last = 0;
-};
-
-struct ignore_none {};
 
 /**
  * simdForEachAligning<unrolling>(cardinal, f, l, delegate);

--- a/folly/algorithm/simd/detail/test/BUCK
+++ b/folly/algorithm/simd/detail/test/BUCK
@@ -25,6 +25,15 @@ cpp_unittest(
 )
 
 cpp_unittest(
+    name = "ignore_test",
+    srcs = ["IgnoreTest.cpp"],
+    deps = [
+        "//folly/algorithm/simd/detail:ignore",
+        "//folly/portability:gtest",
+    ],
+)
+
+cpp_unittest(
     name = "traits_test",
     srcs = ["TraitsTest.cpp"],
     deps = [

--- a/folly/algorithm/simd/detail/test/IgnoreTest.cpp
+++ b/folly/algorithm/simd/detail/test/IgnoreTest.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/algorithm/simd/detail/Ignore.h>
+
+#include <cstdint>
+
+#include <folly/portability/GTest.h>
+
+namespace folly::simd::detail {
+
+struct IgnoreTest : ::testing::Test {};
+
+TEST_F(IgnoreTest, MaskClearIgnored) {
+  auto mmask =
+      std::pair{std::uint8_t{0xff}, std::integral_constant<std::uint32_t, 2>{}};
+
+  // mostly relying on folly::clear_<>_n_bits working correctly
+  // simd any of also covers a lot of cases.
+  // this is just the bare minimal smoke test.
+
+  mmaskClearIgnored<4>(mmask, ignore_none{});
+  EXPECT_EQ(0xff, mmask.first);
+
+  mmaskClearIgnored<4>(mmask, ignore_extrema{1, 2});
+  EXPECT_EQ(0b0000'1100, mmask.first);
+
+  mmaskClearIgnored<2>(mmask, ignore_extrema{0, 1});
+  EXPECT_EQ(0b0000'0000, mmask.first);
+}
+
+} // namespace folly::simd::detail

--- a/folly/algorithm/simd/detail/test/SimdAnyOfTest.cpp
+++ b/folly/algorithm/simd/detail/test/SimdAnyOfTest.cpp
@@ -83,7 +83,7 @@ TEST(SimdAnyOfSimple, Ignore) {
   buffer.fill(' ');
   for (auto& c : buffer) {
     c = 'a';
-    anySpacesTest({&c, 1}, false);
+    ASSERT_NO_FATAL_FAILURE(anySpacesTest({&c, 1}, false));
     c = ' ';
   }
 }

--- a/folly/algorithm/simd/test/MovemaskTest.cpp
+++ b/folly/algorithm/simd/test/MovemaskTest.cpp
@@ -55,11 +55,11 @@ void allOneTrueTests() {
   std::array<T, N> arr;
   arr.fill(kFalse);
 
-  ASSERT_EQ(0, folly::movemask<T>(loadReg<Reg>(arr)).first);
+  ASSERT_EQ(0, folly::simd::movemask<T>(loadReg<Reg>(arr)).first);
 
   for (std::size_t i = 0; i != N; ++i) {
     arr[i] = kTrue;
-    auto [bits, bitsPerElement] = folly::movemask<T>(loadReg<Reg>(arr));
+    auto [bits, bitsPerElement] = folly::simd::movemask<T>(loadReg<Reg>(arr));
     std::uint64_t oneElement = safeShift(1, bitsPerElement()) - 1;
     std::uint64_t expectedBits = safeShift(oneElement, i * bitsPerElement());
 

--- a/folly/detail/BUCK
+++ b/folly/detail/BUCK
@@ -269,6 +269,8 @@ cpp_library(
     exported_deps = [
         "//folly:portability",
         "//folly:range",
+        "//folly/algorithm/simd:movemask",
+        "//folly/algorithm/simd/detail:ignore",
         "//folly/algorithm/simd/detail:simd_char_platform",
         "//folly/algorithm/simd/detail:simd_for_each",
         "//folly/lang:bits",

--- a/folly/detail/SplitStringSimdImpl.h
+++ b/folly/detail/SplitStringSimdImpl.h
@@ -18,6 +18,8 @@
 
 #include <folly/Portability.h>
 #include <folly/Range.h>
+#include <folly/algorithm/simd/Movemask.h>
+#include <folly/algorithm/simd/detail/Ignore.h>
 #include <folly/algorithm/simd/detail/SimdCharPlatform.h>
 #include <folly/algorithm/simd/detail/SimdForEach.h>
 #include <folly/lang/Bits.h>
@@ -78,17 +80,19 @@ struct PlatformSimdSplitByChar {
     res.emplace_back(f, l - f);
   }
 
-  template <typename Uint, typename Container>
+  template <typename Uint, typename BitsPerElement, typename Container>
   FOLLY_ALWAYS_INLINE void outputStringsFoMmask(
-      Uint mmask,
+      std::pair<Uint, BitsPerElement> mmask,
       const char* pos,
       const char*& prev,
       Container& res) const { // reserve was not beneficial on benchmarks.
-    while (mmask) {
-      auto counted = folly::findFirstSet(mmask) - 1;
-      mmask >>= counted;
-      mmask >>= Platform::kMmaskBitsPerElement;
-      auto firstSet = counted / Platform::kMmaskBitsPerElement;
+
+    Uint mmaskBits = mmask.first;
+    while (mmaskBits) {
+      auto counted = folly::findFirstSet(mmaskBits) - 1;
+      mmaskBits >>= counted;
+      mmaskBits >>= BitsPerElement{};
+      auto firstSet = counted / BitsPerElement{};
 
       const char* split = pos + firstSet;
       pos = split + 1;
@@ -108,8 +112,8 @@ struct PlatformSimdSplitByChar {
     FOLLY_ALWAYS_INLINE bool step(
         const char* ptr, Ignore ignore, UnrollIndex) const {
       reg_t loaded = Platform::loada(ptr, ignore);
-      auto mmask = Platform::movemask(Platform::equal(loaded, sep));
-      mmask = Platform::clear(mmask, ignore);
+      auto mmask = simd::movemask<std::uint8_t>(Platform::equal(loaded, sep));
+      simd::detail::mmaskClearIgnored<Platform::kCardinal>(mmask, ignore);
       self.outputStringsFoMmask(mmask, ptr, prev, res);
       return false;
     }

--- a/folly/lang/Bits.h
+++ b/folly/lang/Bits.h
@@ -67,6 +67,10 @@
 #include <folly/lang/CString.h>
 #include <folly/portability/Builtins.h>
 
+#ifdef __BMI2__
+#include <immintrin.h>
+#endif
+
 #if __has_include(<bit>) && (__cplusplus >= 202002L || (defined(__cpp_lib_bit_cast) && __cpp_lib_bit_cast >= 201806L))
 #include <bit>
 #endif
@@ -106,6 +110,11 @@ constexpr std::make_unsigned_t<Dst> bits_to_unsigned(Src const s) {
   static_assert(std::is_unsigned<Dst>::value, "signed type");
   return static_cast<Dst>(to_unsigned(s));
 }
+
+template <typename T>
+inline constexpr bool supported_in_bits_operations_v =
+    std::is_unsigned_v<T> && sizeof(T) <= 8;
+
 } // namespace detail
 
 /// findFirstSet
@@ -222,6 +231,147 @@ inline constexpr T strictPrevPowTwo(T const v) {
   static_assert(std::is_unsigned<T>::value, "signed type");
   return v > 1 ? prevPowTwo(T(v - 1)) : T(0);
 }
+
+/// make_maskr
+/// make_maskr_fn
+///
+/// Returns an unsigned integer of type T, where n
+/// least significant (right) bits are set and others are not.
+template <class T>
+struct make_maskr_fn {
+  static_assert(detail::supported_in_bits_operations_v<T>, "");
+
+  FOLLY_NODISCARD constexpr T operator()(std::uint32_t n) const {
+    if (!folly::is_constant_evaluated_or(true)) {
+      compiler_may_unsafely_assume(n <= sizeof(T) * 8);
+
+#ifdef __BMI2__
+      if constexpr (sizeof(T) <= 4) {
+        return static_cast<T>(_bzhi_u32(static_cast<std::uint32_t>(-1), n));
+      }
+      return static_cast<T>(_bzhi_u64(static_cast<std::uint64_t>(-1), n));
+#endif
+    }
+
+    if (sizeof(T) == 8 && n == 64) {
+      return static_cast<T>(-1);
+    }
+    return static_cast<T>((std::uint64_t{1} << n) - 1);
+  }
+};
+
+template <class T>
+inline constexpr make_maskr_fn<T> make_maskr;
+
+/// make_maskl
+/// make_maskl_fn
+///
+/// Returns an unsigned integer of type T, where n
+/// most significant bits (left) are set and others are not.
+template <class T>
+struct make_maskl_fn {
+  static_assert(detail::supported_in_bits_operations_v<T>, "");
+
+  FOLLY_NODISCARD constexpr T operator()(std::uint32_t n) const {
+    if (!folly::is_constant_evaluated_or(true)) {
+      compiler_may_unsafely_assume(n <= sizeof(T) * 8);
+
+#ifdef __BMI2__
+      // assembler looks smaller here, if we use bzhi from `set_lowest_n_bits`
+      if constexpr (sizeof(T) == 8) {
+        return static_cast<T>(~make_maskr<T>(64 - n));
+      }
+#endif
+    }
+
+    if (sizeof(T) == 8 && n == 0) {
+      return 0;
+    }
+    n = sizeof(T) * 8 - n;
+
+    std::uint64_t ones = static_cast<T>(~0);
+    return static_cast<T>(ones << n);
+  }
+};
+
+template <class T>
+inline constexpr make_maskl_fn<T> make_maskl;
+
+/// set_rzero
+/// set_rzero_fn
+///
+/// Clears n least significant (right) bits. Other bits stay the same.
+struct set_rzero_fn {
+  template <typename T>
+  FOLLY_NODISCARD constexpr T operator()(T x, std::uint32_t n) const {
+    static_assert(detail::supported_in_bits_operations_v<T>, "");
+
+    // alternative is to do two shifts but that has
+    // a dependency between them, so is likely worse
+    return x & make_maskl<T>(sizeof(T) * 8 - n);
+  }
+};
+
+inline constexpr set_rzero_fn set_rzero;
+
+/// set_rone
+/// set_rone_fn
+///
+/// Sets n least significant (right) bits. Other bits stay the same.
+struct set_rone_fn {
+  template <typename T>
+  FOLLY_NODISCARD constexpr T operator()(T x, std::uint32_t n) const {
+    static_assert(detail::supported_in_bits_operations_v<T>, "");
+
+    // alternative is to do two shifts but that has
+    // a dependency between them, so is likely worse
+    return x | make_maskr<T>(n);
+  }
+};
+
+inline constexpr set_rone_fn set_rone;
+
+/// set_lzero
+/// set_lzero_fn
+///
+/// Clears n most significant (left) bits. Other bits stay the same.
+struct set_lzero_fn {
+  template <typename T>
+  FOLLY_NODISCARD constexpr T operator()(T x, std::uint32_t n) const {
+    static_assert(detail::supported_in_bits_operations_v<T>, "");
+
+    if (!folly::is_constant_evaluated_or(true)) {
+      compiler_may_unsafely_assume(n <= sizeof(T) * 8);
+
+#ifdef __BMI2__
+      if constexpr (sizeof(T) <= 4) {
+        return static_cast<T>(_bzhi_u32(x, sizeof(T) * 8 - n));
+      }
+      return static_cast<T>(_bzhi_u64(x, sizeof(T) * 8 - n));
+#endif
+    }
+
+    // alternative is to do two shifts but that has
+    // a dependency between them, so is likely worse
+    return x & make_maskr<T>(sizeof(T) * 8 - n);
+  }
+};
+
+inline constexpr set_lzero_fn set_lzero;
+
+/// set_lone
+/// set_lone_fn
+///
+/// Sets n most significant (left) bits. Other bits stay the same.
+struct set_lone_fn {
+  template <typename T>
+  FOLLY_NODISCARD constexpr T operator()(T x, std::uint32_t n) const {
+    static_assert(detail::supported_in_bits_operations_v<T>, "");
+    return x | make_maskl<T>(n);
+  }
+};
+
+inline constexpr set_lone_fn set_lone;
 
 /**
  * Endianness detection and manipulation primitives.


### PR DESCRIPTION
Summary:
stepping stone for simd::contains.

We want to do less things in simd platform if possbile, so moving out non essential things.

Differential Revision: D63388617
