### PR TITLE
simd::contains (the interfaces) - restored.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,11 +649,11 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
     DIRECTORY algorithm/simd/detail/test/
       TEST algorithm_simd_detail_simd_any_of_test SOURCES SimdAnyOfTest.cpp
       TEST algorithm_simd_detail_simd_for_each_test SOURCES SimdForEachTest.cpp
+      TEST algorithm_simd_detail_simd_traits_test SOURCES TraitsTest.cpp
       TEST algorithm_simd_detail_unroll_utils_test SOURCES UnrollUtilsTest.cpp
-      # disabled until C++20
-      # TEST algorithm_simd_detail_simd_traits_test SOURCES TraitsTest.cpp
 
     DIRECTORY algorithm/simd/test/
+      TEST algorithm_simd_contains_test SOURCES ContainsTest.cpp
       TEST algorithm_simd_find_fixed_test SOURCES FindFixedTest.cpp
       TEST algorithm_simd_movemask_test SOURCES MovemaskTest.cpp
 

--- a/folly/algorithm/simd/BUCK
+++ b/folly/algorithm/simd/BUCK
@@ -22,3 +22,16 @@ cpp_library(
         "//folly/algorithm/simd/detail:traits",
     ],
 )
+
+cpp_library(
+    name = "contains",
+    srcs = ["Contains.cpp"],
+    headers = ["Contains.h"],
+    deps = [
+        "//folly/algorithm/simd/detail:simd_contains_impl",
+    ],
+    exported_deps = [
+        "//folly:c_portability",
+        "//folly/algorithm/simd/detail:traits",
+    ],
+)

--- a/folly/algorithm/simd/Contains.cpp
+++ b/folly/algorithm/simd/Contains.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/algorithm/simd/Contains.h>
+
+#include <algorithm>
+#include <cstring>
+#include <folly/algorithm/simd/detail/ContainsImpl.h>
+
+namespace folly::simd::detail {
+
+bool containsU8(folly::span<const std::uint8_t> haystack, std::uint8_t needle) {
+  return containsImpl(haystack, needle);
+}
+bool containsU16(
+    folly::span<const std::uint16_t> haystack, std::uint16_t needle) {
+  return containsImpl(haystack, needle);
+}
+bool containsU32(
+    folly::span<const std::uint32_t> haystack, std::uint32_t needle) {
+  return containsImpl(haystack, needle);
+}
+
+bool containsU64(
+    folly::span<const std::uint64_t> haystack, std::uint64_t needle) {
+  return containsImpl(haystack, needle);
+}
+
+} // namespace folly::simd::detail

--- a/folly/algorithm/simd/Contains.h
+++ b/folly/algorithm/simd/Contains.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/CPortability.h>
+#include <folly/algorithm/simd/detail/Traits.h>
+
+#include <iterator>
+
+namespace folly::simd {
+namespace detail {
+
+// no overloading for easier profiling.
+
+bool containsU8(folly::span<const std::uint8_t> haystack, std::uint8_t needle);
+bool containsU16(
+    folly::span<const std::uint16_t> haystack, std::uint16_t needle);
+bool containsU32(
+    folly::span<const std::uint32_t> haystack, std::uint32_t needle);
+bool containsU64(
+    folly::span<const std::uint64_t> haystack, std::uint64_t needle);
+
+template <typename R>
+using std_range_value_t = typename std::iterator_traits<decltype(std::begin(
+    std::declval<R&>()))>::value_type;
+
+} // namespace detail
+
+/**
+ * folly::simd::contains
+ * folly::simd::contains_fn
+ *
+ * A vectorized version of `std::ranges::find(r, x) != r.end()`.
+ * Only works for "simd friendly cases" -
+ * specifically the ones where the type can be reasonably cast
+ * to `uint8/16/32/64_t`.
+ *
+ **/
+struct contains_fn {
+  template <
+      typename R,
+      typename = std::enable_if_t<
+          std::is_invocable_v<detail::AsSimdFriendlyUintFn, R>>>
+  FOLLY_ERASE bool operator()(R&& r, detail::std_range_value_t<R> x) const {
+    auto castR = detail::asSimdFriendlyUint(folly::span(r));
+    auto castX = detail::asSimdFriendlyUint(x);
+
+    using T = decltype(castX);
+
+    if constexpr (std::is_same_v<T, std::uint8_t>) {
+      return detail::containsU8(castR, castX);
+    } else if constexpr (std::is_same_v<T, std::uint16_t>) {
+      return detail::containsU16(castR, castX);
+    } else if constexpr (std::is_same_v<T, std::uint32_t>) {
+      return detail::containsU32(castR, castX);
+    } else {
+      static_assert(
+          std::is_same_v<T, std::uint64_t>, "internal error, unknown type");
+      return detail::containsU64(castR, castX);
+    }
+  }
+};
+
+inline constexpr contains_fn contains;
+
+} // namespace folly::simd

--- a/folly/algorithm/simd/FindFixed.h
+++ b/folly/algorithm/simd/FindFixed.h
@@ -293,7 +293,8 @@ constexpr std::optional<std::size_t> findFixed(std::span<const T, N> where, U x)
     return find_fixed_detail::findFixedConstexpr(std::span<const T>(where), x);
   } else {
     return find_fixed_detail::findFixedDispatch(
-        detail::asSimdFriendlyUint(where), detail::asSimdFriendlyUint(x));
+        simd::detail::asSimdFriendlyUint(where),
+        simd::detail::asSimdFriendlyUint(x));
   }
 }
 

--- a/folly/algorithm/simd/detail/BUCK
+++ b/folly/algorithm/simd/detail/BUCK
@@ -27,6 +27,17 @@ cpp_library(
 )
 
 cpp_library(
+    name = "simd_contains_impl",
+    headers = ["ContainsImpl.h"],
+    exported_deps = [
+        ":simd_any_of",
+        ":simd_char_platform",
+        "//folly:c_portability",
+        "//folly/container:span",
+    ],
+)
+
+cpp_library(
     name = "simd_for_each",
     headers = ["SimdForEach.h"],
     exported_deps = [

--- a/folly/algorithm/simd/detail/BUCK
+++ b/folly/algorithm/simd/detail/BUCK
@@ -40,6 +40,7 @@ cpp_library(
     name = "traits",
     headers = ["Traits.h"],
     exported_deps = [
+        "//folly:c_portability",
         "//folly:memory",
         "//folly:traits",
         "//folly/container:span",

--- a/folly/algorithm/simd/detail/ContainsImpl.h
+++ b/folly/algorithm/simd/detail/ContainsImpl.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <cwchar>
+#include <type_traits>
+
+#include <folly/CPortability.h>
+#include <folly/algorithm/simd/detail/SimdAnyOf.h>
+#include <folly/algorithm/simd/detail/SimdCharPlatform.h>
+#include <folly/container/span.h>
+
+namespace folly::simd::detail {
+
+/*
+ * The functions in this file are FOLLY_ERASE to make sure
+ * that the only place behind a call boundary is the explicit one.
+ */
+
+template <typename T>
+FOLLY_ERASE bool containsImplStd(folly::span<const T> haystack, T needle) {
+  static_assert(
+      std::is_unsigned_v<T>, "we should only get here for uint8/16/32/64");
+  if constexpr (sizeof(T) == 1) {
+    auto* ptr = reinterpret_cast<const char*>(haystack.data());
+    auto castNeedle = static_cast<char>(needle);
+    if (haystack.empty()) { // memchr requires not null
+      return false;
+    }
+    return std::memchr(ptr, castNeedle, haystack.size()) != nullptr;
+  } else if constexpr (sizeof(T) == sizeof(wchar_t)) {
+    auto* ptr = reinterpret_cast<const wchar_t*>(haystack.data());
+    auto castNeedle = static_cast<wchar_t>(needle);
+    if (haystack.empty()) { // wmemchr requires not null
+      return false;
+    }
+    return std::wmemchr(ptr, castNeedle, haystack.size()) != nullptr;
+  } else {
+    // Using find instead of any_of on an off chance that the standard library
+    // will add some custom vectorization.
+    // That wouldn't be possible for any_of because of the predicates.
+    return std::find(haystack.begin(), haystack.end(), needle) !=
+        haystack.end();
+  }
+}
+
+template <typename T>
+constexpr bool hasHandwrittenContains() {
+  return std::is_same_v<T, std::uint8_t> &&
+      !std::is_same_v<SimdCharPlatform, void>;
+}
+
+template <typename T>
+FOLLY_ERASE bool containsImplHandwritten(
+    folly::span<const T> haystack, T needle) {
+  static_assert(std::is_same_v<T, std::uint8_t>, "");
+  auto as_chars = folly::reinterpret_span_cast<const char>(haystack);
+  return simdAnyOf<SimdCharPlatform, 4>(
+      as_chars.data(),
+      as_chars.data() + as_chars.size(),
+      [&](SimdCharPlatform::reg_t x) {
+        return SimdCharPlatform::equal(x, static_cast<char>(needle));
+      });
+}
+
+template <typename T>
+FOLLY_ERASE bool containsImpl(folly::span<const T> haystack, T needle) {
+  if constexpr (hasHandwrittenContains<T>()) {
+    return containsImplHandwritten(haystack, needle);
+  } else {
+    return containsImplStd(haystack, needle);
+  }
+}
+
+} // namespace folly::simd::detail

--- a/folly/algorithm/simd/detail/Traits.h
+++ b/folly/algorithm/simd/detail/Traits.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/CPortability.h>
 #include <folly/Memory.h>
 #include <folly/Traits.h>
 #include <folly/container/span.h>
@@ -23,7 +24,7 @@
 #include <concepts>
 #include <type_traits>
 
-namespace folly::detail {
+namespace folly::simd::detail {
 
 template <typename T>
 auto findSimdFriendlyEquivalent() {
@@ -36,65 +37,75 @@ auto findSimdFriendlyEquivalent() {
       return double{};
     }
   } else if constexpr (std::is_signed_v<T>) {
-    if constexpr (sizeof(T) == 1) {
-      return std::int8_t{};
-    } else if constexpr (sizeof(T) == 2) {
-      return std::int16_t{};
-    } else if constexpr (sizeof(T) == 4) {
-      return std::int32_t{};
-    } else if constexpr (sizeof(T) == 8) {
-      return std::int64_t{};
-    }
+    return int_bits_t<sizeof(T) * 8>{};
   } else if constexpr (std::is_unsigned_v<T>) {
-    if constexpr (sizeof(T) == 1) {
-      return std::uint8_t{};
-    } else if constexpr (sizeof(T) == 2) {
-      return std::uint16_t{};
-    } else if constexpr (sizeof(T) == 4) {
-      return std::uint32_t{};
-    } else if constexpr (sizeof(T) == 8) {
-      return std::uint64_t{};
-    }
+    return uint_bits_t<sizeof(T) * 8>{};
   }
 }
 
 template <typename T>
-concept has_simd_friendly_equivalent =
+constexpr bool has_simd_friendly_equivalent_scalar =
     !std::is_same_v<void, decltype(findSimdFriendlyEquivalent<T>())>;
 
-template <has_simd_friendly_equivalent T>
-using simd_friendly_equivalent_t = folly::like_t< //
-    T,
-    decltype(findSimdFriendlyEquivalent<std::remove_const_t<T>>())>;
+template <typename T>
+using simd_friendly_equivalent_scalar_t = std::enable_if_t<
+    has_simd_friendly_equivalent_scalar<T>,
+    like_t<T, decltype(findSimdFriendlyEquivalent<std::remove_const_t<T>>())>>;
 
 template <typename T>
-concept has_integral_simd_friendly_equivalent =
-    has_simd_friendly_equivalent<T> && // have to explicitly specify this for
-                                       // subsumption to work
-    std::integral<simd_friendly_equivalent_t<T>>;
+constexpr bool has_integral_simd_friendly_equivalent_scalar =
+    std::is_integral_v< // void will return false
+        decltype(findSimdFriendlyEquivalent<std::remove_const_t<T>>())>;
 
-template <has_integral_simd_friendly_equivalent T>
-using integral_simd_friendly_equivalent = simd_friendly_equivalent_t<T>;
+template <typename T>
+using unsigned_simd_friendly_equivalent_scalar_t = std::enable_if_t<
+    has_integral_simd_friendly_equivalent_scalar<T>,
+    like_t<T, uint_bits_t<sizeof(T) * 8>>>;
 
-template <has_simd_friendly_equivalent T, std::size_t Extend>
-auto asSimdFriendly(folly::span<T, Extend> s) {
-  return folly::reinterpret_span_cast<simd_friendly_equivalent_t<T>>(s);
-}
+template <typename R>
+using span_for = decltype(folly::span(std::declval<const R&>()));
 
-template <has_simd_friendly_equivalent T>
-constexpr auto asSimdFriendly(T x) {
-  return static_cast<simd_friendly_equivalent_t<T>>(x);
-}
+struct AsSimdFriendlyFn {
+  template <typename T, std::size_t extent>
+  FOLLY_ERASE auto operator()(folly::span<T, extent> s) const
+      -> folly::span<simd_friendly_equivalent_scalar_t<T>, extent> {
+    return reinterpret_span_cast<simd_friendly_equivalent_scalar_t<T>>(s);
+  }
 
-template <has_simd_friendly_equivalent T, std::size_t Extend>
-auto asSimdFriendlyUint(folly::span<T, Extend> s) {
-  return folly::reinterpret_span_cast<
-      folly::like_t<T, uint_bits_t<sizeof(T) * 8>>>(s);
-}
+  template <typename R>
+  FOLLY_ERASE auto operator()(R&& r) const
+      -> decltype(operator()(span_for<R>(r))) {
+    return operator()(folly::span(r));
+  }
 
-template <has_simd_friendly_equivalent T>
-constexpr auto asSimdFriendlyUint(T x) {
-  return static_cast<uint_bits_t<sizeof(T) * 8>>(x);
-}
+  template <typename T>
+  FOLLY_ERASE constexpr auto operator()(T x) const
+      -> simd_friendly_equivalent_scalar_t<T> {
+    return static_cast<simd_friendly_equivalent_scalar_t<T>>(x);
+  }
+};
+inline constexpr AsSimdFriendlyFn asSimdFriendly;
 
-} // namespace folly::detail
+struct AsSimdFriendlyUintFn {
+  template <typename T, std::size_t extent>
+  FOLLY_ERASE auto operator()(folly::span<T, extent> s) const
+      -> folly::span<unsigned_simd_friendly_equivalent_scalar_t<T>, extent> {
+    return reinterpret_span_cast<unsigned_simd_friendly_equivalent_scalar_t<T>>(
+        s);
+  }
+
+  template <typename R>
+  FOLLY_ERASE auto operator()(R&& r) const
+      -> decltype(operator()(span_for<R>(r))) {
+    return operator()(folly::span(r));
+  }
+
+  template <typename T>
+  FOLLY_ERASE constexpr auto operator()(T x) const
+      -> unsigned_simd_friendly_equivalent_scalar_t<T> {
+    return static_cast<unsigned_simd_friendly_equivalent_scalar_t<T>>(x);
+  }
+};
+inline constexpr AsSimdFriendlyUintFn asSimdFriendlyUint;
+
+} // namespace folly::simd::detail

--- a/folly/algorithm/simd/detail/test/BUCK
+++ b/folly/algorithm/simd/detail/test/BUCK
@@ -27,6 +27,7 @@ cpp_unittest(
 cpp_unittest(
     name = "traits_test",
     srcs = ["TraitsTest.cpp"],
+    compiler_flags = ["--std=c++17"],
     deps = [
         "//folly/algorithm/simd/detail:traits",
         "//folly/portability:gmock",

--- a/folly/algorithm/simd/detail/test/TraitsTest.cpp
+++ b/folly/algorithm/simd/detail/test/TraitsTest.cpp
@@ -24,7 +24,7 @@
 
 namespace folly::simd::detail {
 
-struct FollySimdTraitsTest : testing::Test {};
+struct SimdTraitsTest : testing::Test {};
 
 namespace simd_friendly_equivalent_scalar_test {
 
@@ -161,7 +161,7 @@ static_assert(!std::is_invocable_v<AsSimdFriendlyUintFn, std::set<int>>);
 
 } // namespace as_simd_friendly_uint_type_test
 
-TEST_F(FollySimdTraitsTest, AsSimdFriendly) {
+TEST_F(SimdTraitsTest, AsSimdFriendly) {
   enum SomeEnum : int { Foo = 1, Bar, Baz };
 
   static_assert(asSimdFriendly(SomeEnum::Foo) == 1);
@@ -171,7 +171,7 @@ TEST_F(FollySimdTraitsTest, AsSimdFriendly) {
   ASSERT_THAT(castSpan, testing::ElementsAre(1, 2, 3));
 }
 
-TEST_F(FollySimdTraitsTest, AsSimdFriendlyUint) {
+TEST_F(SimdTraitsTest, AsSimdFriendlyUint) {
   enum SomeEnum : int { Foo = 1, Bar, Baz };
 
   static_assert(asSimdFriendlyUint(SomeEnum::Foo) == 1U);

--- a/folly/algorithm/simd/test/BUCK
+++ b/folly/algorithm/simd/test/BUCK
@@ -36,3 +36,14 @@ cpp_benchmark(
         "//folly/init:init",
     ],
 )
+
+cpp_unittest(
+    name = "contains_test",
+    srcs = ["ContainsTest.cpp"],
+    headers = [],
+    deps = [
+        "//folly/algorithm/simd:contains",
+        "//folly/algorithm/simd/detail:simd_contains_impl",
+        "//folly/portability:gtest",
+    ],
+)

--- a/folly/algorithm/simd/test/ContainsTest.cpp
+++ b/folly/algorithm/simd/test/ContainsTest.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/algorithm/simd/Contains.h>
+
+#include <folly/algorithm/simd/detail/ContainsImpl.h>
+
+#include <folly/portability/GTest.h>
+
+namespace folly::simd {
+namespace not_invocable_tests {
+
+static_assert(!std::is_invocable_v< //
+              folly::simd::contains_fn,
+              std::vector<double>&,
+              double>);
+
+static_assert(std::is_invocable_v< //
+              folly::simd::contains_fn,
+              std::vector<int>&,
+              int>);
+
+} // namespace not_invocable_tests
+
+template <typename T>
+struct ContainsTest : ::testing::Test {};
+
+using TypesToTest = ::testing::Types<
+    std::int8_t,
+    std::int16_t,
+    std::int32_t,
+    std::int64_t,
+    std::uint8_t,
+    std::uint16_t,
+    std::uint32_t,
+    std::uint64_t>;
+
+TYPED_TEST_SUITE(ContainsTest, TypesToTest);
+
+template <typename T>
+void testSimdContainsVerify(folly::span<T> haystack, T needle, bool expected) {
+  bool actual1 = simd::contains(haystack, needle);
+  ASSERT_EQ(expected, actual1);
+
+  auto const_haystack = folly::static_span_cast<const T>(haystack);
+
+  if constexpr (
+      std::is_same_v<T, std::uint8_t> || std::is_same_v<T, std::uint16_t> ||
+      std::is_same_v<T, std::uint32_t> || std::is_same_v<T, std::uint64_t>) {
+    bool actual2 = simd::detail::containsImplStd(const_haystack, needle);
+    ASSERT_EQ(expected, actual2) << " haystack.size(): " << haystack.size();
+  }
+
+  if constexpr (std::is_same_v<T, std::uint8_t>) {
+    bool actual3 =
+        simd::detail::containsImplHandwritten(const_haystack, needle);
+    ASSERT_EQ(expected, actual3) << " haystack.size(): " << haystack.size();
+  }
+}
+
+TYPED_TEST(ContainsTest, Basic) {
+  using T = TypeParam;
+
+  for (std::size_t size = 0; size != 100; ++size) {
+    std::vector<T> buf(size, T{0});
+    for (std::size_t offset = 0; offset != std::min(32UL, buf.size());
+         ++offset) {
+      folly::span<T> haystack(buf.data() + offset, buf.data() + buf.size());
+      T needle{1};
+      testSimdContainsVerify(haystack, needle, /*expected*/ false);
+
+      for (auto& x : haystack) {
+        x = needle;
+        testSimdContainsVerify(haystack, needle, /*expected*/ true);
+        x = 0;
+      }
+    }
+  }
+}
+
+} // namespace folly::simd

--- a/folly/container/BUCK
+++ b/folly/container/BUCK
@@ -172,11 +172,12 @@ cpp_library(
     name = "span",
     headers = ["span.h"],
     exported_deps = [
+        ":access",
+        ":iterator",
         "//folly:cpp_attributes",
         "//folly:portability",
         "//folly:traits",
         "//folly:utility",
-        "//folly/container:access",
         "//folly/functional:invoke",
         "//folly/portability:constexpr",
     ],

--- a/folly/container/Iterator.h
+++ b/folly/container/Iterator.h
@@ -112,6 +112,12 @@ inline constexpr bool iterator_category_matches_v =
 template <typename Iter>
 using iterator_value_type_t = typename std::iterator_traits<Iter>::value_type;
 
+//  iterator_reference_type_t
+//
+//  Extracts reference from an iterator (C++20 iter_reference_t backported)
+template <typename Iter>
+using iterator_reference_t = decltype(*std::declval<Iter&>());
+
 //  iterator_key_type_t
 //
 //  Extracts a key type from an iterator, leverages the knowledge that

--- a/folly/container/span.h
+++ b/folly/container/span.h
@@ -27,6 +27,7 @@
 #include <folly/Traits.h>
 #include <folly/Utility.h>
 #include <folly/container/Access.h>
+#include <folly/container/Iterator.h>
 #include <folly/functional/Invoke.h>
 #include <folly/portability/Constexpr.h>
 
@@ -246,6 +247,22 @@ class span {
     return {data_ + size() - count, count};
   }
 };
+
+template <typename T, typename EndOrSize>
+span(T*, EndOrSize) -> span<T>;
+
+template <typename T, std::size_t N>
+span(T (&)[N]) -> span<T, N>;
+
+template <typename T, std::size_t N>
+span(std::array<T, N>&) -> span<T, N>;
+
+template <typename T, std::size_t N>
+span(const std::array<T, N>&) -> span<const T, N>;
+
+template <typename R>
+span(R&&) -> span<std::remove_reference_t<
+              iterator_reference_t<decltype(std::begin(std::declval<R&>()))>>>;
 
 } // namespace fallback_span
 

--- a/folly/container/test/span_test.cpp
+++ b/folly/container/test/span_test.cpp
@@ -324,6 +324,46 @@ TYPED_TEST_P(SpanTest, fix_as_bytes) {
   EXPECT_EQ(20, wbytes.size());
 }
 
+namespace fallback_span_ctad {
+
+namespace fallback = folly::detail::fallback_span;
+
+template <typename... Ts>
+using deduced_for = decltype(fallback::span(std::declval<Ts>()...));
+
+static_assert( //
+    std::is_same_v<
+        fallback::span<const int>,
+        deduced_for<const int*, std::size_t>>);
+
+static_assert( //
+    std::is_same_v<
+        fallback::span<const int>,
+        deduced_for<const std::vector<int>&>>);
+
+static_assert( //
+    std::is_same_v<fallback::span<int>, deduced_for<std::vector<int>&>>);
+
+static_assert(
+    std::is_same_v<fallback::span<int, 3>, deduced_for<std::array<int, 3>&>>);
+
+static_assert( //
+    std::is_same_v<
+        fallback::span<const int, 3>,
+        deduced_for<const std::array<int, 3>&>>);
+
+int arr1[3];
+static_assert( //
+    std::is_same_v<fallback::span<int, 3>, decltype(fallback::span(arr1))>);
+
+constexpr int arr2[3]{0, 1, 2};
+static_assert( //
+    std::is_same_v<
+        fallback::span<const int, 3>,
+        decltype(fallback::span(arr2))>);
+
+} // namespace fallback_span_ctad
+
 // clang-format off
 REGISTER_TYPED_TEST_SUITE_P(
     SpanTest


### PR DESCRIPTION
Summary:
Faster equivalent to
```
std::ranges::find(haystack, needle) != haystack.end();
```

This diff is just the interfaces.

Differential Revision: D63635498
