### PR TITLE
[AArch64] Add SVE2 version of qfind_first_byte_of

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -64,7 +64,7 @@
 #include <folly/Likely.h>
 #include <folly/Traits.h>
 #include <folly/detail/RangeCommon.h>
-#include <folly/detail/RangeSse42.h>
+#include <folly/detail/RangeSimd.h>
 
 // Ignore shadowing warnings within this file, so includers can use -Wshadow.
 FOLLY_PUSH_WARNING
@@ -1537,10 +1537,9 @@ namespace detail {
 
 inline size_t qfind_first_byte_of(
     const StringPiece haystack, const StringPiece needles) {
-  static auto const qfind_first_byte_of_fn = folly::CpuId().sse42()
-      ? qfind_first_byte_of_sse42
-      : qfind_first_byte_of_nosse;
-  return qfind_first_byte_of_fn(haystack, needles);
+  // Let's default to the SIMD implementation. Internally, if that's not
+  // available, the _nosimd version gets picked instead.
+  return qfind_first_byte_of_simd(haystack, needles);
 }
 
 } // namespace detail

--- a/folly/detail/RangeCommon.h
+++ b/folly/detail/RangeCommon.h
@@ -75,7 +75,7 @@ size_t qfind_first_byte_of_bitset(
 size_t qfind_first_byte_of_byteset(
     const StringPieceLite haystack, const StringPieceLite needles);
 
-inline size_t qfind_first_byte_of_nosse(
+inline size_t qfind_first_byte_of_nosimd(
     const StringPieceLite haystack, const StringPieceLite needles) {
   if (FOLLY_UNLIKELY(needles.empty() || haystack.empty())) {
     return std::string::npos;

--- a/folly/detail/RangeSimd.cpp
+++ b/folly/detail/RangeSimd.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/detail/RangeSimd.h>
+
+#include <cassert>
+
+#include <folly/Portability.h>
+
+#include <folly/detail/RangeSse42.h>
+#include <folly/external/nvidia/detail/RangeSve2.h>
+
+namespace folly {
+namespace detail {
+
+size_t qfind_first_byte_of_simd(
+    const StringPieceLite haystack, const StringPieceLite needles) {
+#if __ARM_FEATURE_SVE2
+  return qfind_first_byte_of_sve2(haystack, needles);
+#elif FOLLY_SSE_PREREQ(4, 2)
+  return qfind_first_byte_of_sse42(haystack, needles);
+#else
+  return qfind_first_byte_of_nosimd(haystack, needles);
+#endif
+}
+
+} // namespace detail
+} // namespace folly

--- a/folly/detail/RangeSimd.h
+++ b/folly/detail/RangeSimd.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include <folly/detail/RangeCommon.h>
+
+namespace folly {
+namespace detail {
+
+size_t qfind_first_byte_of_simd(
+    const StringPieceLite haystack, const StringPieceLite needles);
+
+} // namespace detail
+} // namespace folly

--- a/folly/detail/RangeSse42.cpp
+++ b/folly/detail/RangeSse42.cpp
@@ -30,7 +30,7 @@ namespace folly {
 namespace detail {
 size_t qfind_first_byte_of_sse42(
     const StringPieceLite haystack, const StringPieceLite needles) {
-  return qfind_first_byte_of_nosse(haystack, needles);
+  return qfind_first_byte_of_nosimd(haystack, needles);
 }
 } // namespace detail
 } // namespace folly
@@ -79,7 +79,7 @@ size_t qfind_first_byte_of_needles16(
        page_for(haystack.end() - 1) != page_for(haystack.data() + 15)) ||
       // can't load needles into SSE register if it could cross page boundary
       page_for(needles.end() - 1) != page_for(needles.data() + 15)) {
-    return detail::qfind_first_byte_of_nosse(haystack, needles);
+    return detail::qfind_first_byte_of_nosimd(haystack, needles);
   }
 
   auto arr2 = _mm_loadu_si128_unchecked(

--- a/folly/external/nvidia/detail/RangeSve2.cpp
+++ b/folly/external/nvidia/detail/RangeSve2.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/external/nvidia/detail/RangeSve2.h>
+
+#include <cassert>
+
+#include <folly/Portability.h>
+
+#if !__ARM_FEATURE_SVE2
+namespace folly {
+namespace detail {
+size_t qfind_first_byte_of_sve2(
+    const StringPieceLite haystack, const StringPieceLite needles) {
+  return qfind_first_byte_of_nosimd(haystack, needles);
+}
+} // namespace detail
+} // namespace folly
+#else
+#include <arm_sve.h>
+
+namespace folly {
+namespace detail {
+
+// helper method for case where needles.size() <= 16
+size_t qfind_first_byte_of_needles16(
+    const StringPieceLite haystack, const StringPieceLite needles) {
+  assert(haystack.size() > 0u);
+  assert(needles.size() > 0u);
+  assert(needles.size() <= 16u);
+
+  svuint8_t arr1, arr2;
+  svbool_t pc, pn, pg = svwhilelt_b8(0, 16);  // pg = ptrue VL16
+
+  // Only read the needles that are valid, otherwise `match' may report
+  // incorrect matches. Also, copy a valid needle to inactive elements to avoid
+  // incorrectly matching with zero.
+  pn = svwhilelt_b8_u64(0, needles.size());
+  arr2 = svld1_u8(pn, reinterpret_cast<uint8_t const*>(needles.data()));
+  arr2 = svsel(pn, arr2, svdup_lane(arr2, 0));
+
+  size_t index = 0;
+
+  // Read valid chunks of 16 bytes.
+  for (; index+16 <= haystack.size(); index += 16) {
+    arr1 = svld1_u8(pg, reinterpret_cast<uint8_t const*>(haystack.data()+index));
+    pc = svmatch_u8(pg, arr1, arr2);
+
+    if (svptest_any(pg, pc)) {
+      pc = svbrkb_z(pg, pc);
+      return index+svcntp_b8(pg, pc);
+    }
+  }
+
+  // Handle remainder.
+  if (index < haystack.size()) {
+    // Get a predicate just for the valid elements, otherwise same as above.
+    pg = svwhilelt_b8(index, haystack.size());
+
+    arr1 = svld1_u8(pg, reinterpret_cast<uint8_t const*>(haystack.data()+index));
+    pc = svmatch_u8(pg, arr1, arr2);
+
+    if (svptest_any(pg, pc)) {
+      pc = svbrkb_z(pg, pc);
+      return index+svcntp_b8(pg, pc);
+    }
+  }
+
+  // No matches found.
+  return std::string::npos;
+}
+
+size_t qfind_first_byte_of_sve2(
+    const StringPieceLite haystack, const StringPieceLite needles) {
+  if (FOLLY_UNLIKELY(needles.empty() || haystack.empty())) {
+    return std::string::npos;
+  } else if (needles.size() <= 16) {
+    return qfind_first_byte_of_needles16(haystack, needles);
+  }
+
+  // This is pretty much the same as in `qfind_first_byte_of_needles16', just
+  // looping through the needles.
+
+  svuint8_t arr1, arr2;
+  svbool_t pc, pn, pg;
+
+  // Loop through haystacks of 16 (or potentially less) bytes.
+  // Note: We could have an epilogue to avoid the min and `whilelt' below (see
+  // qfind_first_byte_of_needles16).
+  for (size_t index = 0; index < haystack.size(); index += 16) {
+    // Load the haystack.
+    pg = svwhilelt_b8(index, std::min(index+16, haystack.size()));
+    arr1 = svld1_u8(pg, reinterpret_cast<uint8_t const*>(haystack.data()+index));
+
+    // Loop through the needles in groups of 16 at a time.
+    size_t j = 0;
+    pn = svwhilelt_b8(0, 16);  // pn = ptrue VL16
+    for (; j+16 <= needles.size(); j += 16) {
+      // Load them.
+      arr2 = svld1_u8(pn, reinterpret_cast<uint8_t const*>(needles.data()+j));
+
+      // Carry the match.
+      pc = svmatch_u8(pg, arr1, arr2);
+
+      // If any match is found count and return the index of the first match
+      // via a sequence of brkb+cntp.
+      if (svptest_any(pg, pc)) {
+        pc = svbrkb_z(pg, pc);
+        return index+svcntp_b8(pg, pc);
+      }
+    }
+
+    // Handle remainder needles.
+    if (j < needles.size()) {
+      // Get a predicate just for the valid elements, otherwise same as above.
+      pn = svwhilelt_b8(j, needles.size());
+
+      arr2 = svld1_u8(pn, reinterpret_cast<uint8_t const*>(needles.data()+j));
+      arr2 = svsel(pn, arr2, svdup_lane(arr2, 0));
+
+      pc = svmatch_u8(pg, arr1, arr2);
+      if (svptest_any(pg, pc)) {
+        pc = svbrkb_z(pg, pc);
+        return index+svcntp_b8(pg, pc);
+      }
+    }
+  }
+
+  return std::string::npos;
+}
+} // namespace detail
+} // namespace folly
+#endif

--- a/folly/external/nvidia/detail/RangeSve2.h
+++ b/folly/external/nvidia/detail/RangeSve2.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include <folly/detail/RangeCommon.h>
+
+namespace folly {
+namespace detail {
+
+size_t qfind_first_byte_of_sve2(
+    const StringPieceLite haystack, const StringPieceLite needles);
+
+} // namespace detail
+} // namespace folly

--- a/folly/test/RangeFindBenchmark.cpp
+++ b/folly/test/RangeFindBenchmark.cpp
@@ -167,8 +167,8 @@ BENCHMARK(FindFirstOf1NeedlesBase, n) {
   findFirstOfRange(delims1, detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(FindFirstOf1NeedlesNoSSE, n) {
-  findFirstOfRange(delims1, detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(FindFirstOf1NeedlesNoSIMD, n) {
+  findFirstOfRange(delims1, detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(FindFirstOf1NeedlesStd, n) {
@@ -191,8 +191,8 @@ BENCHMARK(FindFirstOf2NeedlesBase, n) {
   findFirstOfRange(delims2, detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(FindFirstOf2NeedlesNoSSE, n) {
-  findFirstOfRange(delims2, detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(FindFirstOf2NeedlesNoSIMD, n) {
+  findFirstOfRange(delims2, detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(FindFirstOf2NeedlesStd, n) {
@@ -215,8 +215,8 @@ BENCHMARK(FindFirstOf4NeedlesBase, n) {
   findFirstOfRange(delims4, detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(FindFirstOf4NeedlesNoSSE, n) {
-  findFirstOfRange(delims4, detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(FindFirstOf4NeedlesNoSIMD, n) {
+  findFirstOfRange(delims4, detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(FindFirstOf4NeedlesStd, n) {
@@ -239,8 +239,8 @@ BENCHMARK(FindFirstOf8NeedlesBase, n) {
   findFirstOfRange(delims8, detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(FindFirstOf8NeedlesNoSSE, n) {
-  findFirstOfRange(delims8, detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(FindFirstOf8NeedlesNoSIMD, n) {
+  findFirstOfRange(delims8, detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(FindFirstOf8NeedlesStd, n) {
@@ -263,8 +263,8 @@ BENCHMARK(FindFirstOf16NeedlesBase, n) {
   findFirstOfRange(delims16, detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(FindFirstOf16NeedlesNoSSE, n) {
-  findFirstOfRange(delims16, detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(FindFirstOf16NeedlesNoSIMD, n) {
+  findFirstOfRange(delims16, detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(FindFirstOf16NeedlesStd, n) {
@@ -287,8 +287,8 @@ BENCHMARK(FindFirstOf32NeedlesBase, n) {
   findFirstOfRange(delims32, detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(FindFirstOf32NeedlesNoSSE, n) {
-  findFirstOfRange(delims32, detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(FindFirstOf32NeedlesNoSIMD, n) {
+  findFirstOfRange(delims32, detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(FindFirstOf32NeedlesStd, n) {
@@ -313,8 +313,8 @@ BENCHMARK(FindFirstOf64NeedlesBase, n) {
   findFirstOfRange(delims64, detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(FindFirstOf64NeedlesNoSSE, n) {
-  findFirstOfRange(delims64, detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(FindFirstOf64NeedlesNoSIMD, n) {
+  findFirstOfRange(delims64, detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(FindFirstOf64NeedlesStd, n) {
@@ -344,8 +344,8 @@ BENCHMARK(FindFirstOfRandomBase, n) {
   findFirstOfRandom(detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(FindFirstOfRandomNoSSE, n) {
-  findFirstOfRandom(detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(FindFirstOfRandomNoSIMD, n) {
+  findFirstOfRandom(detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(FindFirstOfRandomStd, n) {
@@ -366,8 +366,8 @@ BENCHMARK(CountDelimsBase, n) {
   countHits(detail::qfind_first_byte_of, n);
 }
 
-BENCHMARK_RELATIVE(CountDelimsNoSSE, n) {
-  countHits(detail::qfind_first_byte_of_nosse, n);
+BENCHMARK_RELATIVE(CountDelimsNoSIMD, n) {
+  countHits(detail::qfind_first_byte_of_nosimd, n);
 }
 
 BENCHMARK_RELATIVE(CountDelimsStd, n) {

--- a/folly/test/RangeTest.cpp
+++ b/folly/test/RangeTest.cpp
@@ -948,7 +948,7 @@ class NeedleFinderTest : public ::testing::Test {
   }
 };
 
-struct SseNeedleFinder {
+struct SimdNeedleFinder {
   static size_t find_first_byte_of(StringPiece haystack, StringPiece needles) {
     // This will only use the SSE version if it is supported on this CPU
     // (selected using ifunc).
@@ -956,9 +956,9 @@ struct SseNeedleFinder {
   }
 };
 
-struct NoSseNeedleFinder {
+struct NoSimdNeedleFinder {
   static size_t find_first_byte_of(StringPiece haystack, StringPiece needles) {
-    return detail::qfind_first_byte_of_nosse(haystack, needles);
+    return detail::qfind_first_byte_of_nosimd(haystack, needles);
   }
 };
 
@@ -969,7 +969,7 @@ struct ByteSetNeedleFinder {
 };
 
 using NeedleFinders =
-    ::testing::Types<SseNeedleFinder, NoSseNeedleFinder, ByteSetNeedleFinder>;
+    ::testing::Types<SimdNeedleFinder, NoSimdNeedleFinder, ByteSetNeedleFinder>;
 TYPED_TEST_SUITE(NeedleFinderTest, NeedleFinders);
 
 TYPED_TEST(NeedleFinderTest, Null) {


### PR DESCRIPTION
This patch adds optimised routines for "find first" methods for AArch64 targets that support SVE2. The implementation is based on the already existing SSE routines.

I've placed the new routines in our (NVIDIA) external folder and renamed the NoSSE methods to NoSIMD (please let me know if you have a better suggestion). On Grace, the new routines show very significant speedups on the Range Find benchmark.