### PR TITLE
fix .stapsdt.base section in folly_sdt macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1144,6 +1144,7 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       TEST range_test SOURCES RangeTest.cpp
       TEST replaceable_test WINDOWS_DISABLED SOURCES ReplaceableTest.cpp
       TEST scope_guard_test WINDOWS_DISABLED SOURCES ScopeGuardTest.cpp
+      TEST sdt_test SOURCES SdtTest.cpp
       # Heavily dependent on drand and srand48
       #TEST shared_mutex_test SOURCES SharedMutexTest.cpp
       # SingletonTest requires Subprocess

--- a/folly/test/BUCK
+++ b/folly/test/BUCK
@@ -2,6 +2,7 @@ load("@fbcode_macros//build_defs:cpp_benchmark.bzl", "cpp_benchmark")
 load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbsource//tools/build_defs:fb_native_wrapper.bzl", "fb_native")
 
 oncall("fbcode_entropy_wardens_folly")
 
@@ -1958,5 +1959,25 @@ cpp_library(
     headers = ["ComparisonOperatorTestUtil.h"],
     exported_deps = [
         "//folly/portability:gtest",
+    ],
+)
+
+fb_native.filegroup(
+    name = "linker-scripts",
+    srcs = ["SdtTest.lds"],
+)
+
+cpp_unittest(
+    name = "sdt_test",
+    srcs = ["SdtTest.cpp"],
+    headers = [],
+    linker_flags = [
+        "--gc-sections",
+        "-T",
+        "$(location :linker-scripts)/SdtTest.lds",
+    ],
+    deps = [
+        "//folly/debugging/symbolizer:elf",
+        "//folly/tracing:static_tracepoint",
     ],
 )

--- a/folly/test/SdtTest.cpp
+++ b/folly/test/SdtTest.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/debugging/symbolizer/Elf.h>
+#include <folly/tracing/StaticTracepoint.h>
+
+namespace {
+
+void init() {
+  FOLLY_SDT(SdtTest, sdt_test_init_enter);
+  // ...
+  FOLLY_SDT(SdtTest, sdt_test_init_exit);
+}
+
+void fini() {
+  FOLLY_SDT(SdtTest, sdt_test_fini_enter);
+  // ...
+  FOLLY_SDT(SdtTest, sdt_test_fini_exit);
+}
+
+bool test(const char* filename) {
+  using namespace folly::symbolizer;
+  ElfFile elf;
+  if (elf.openNoThrow(filename) != 0) {
+    return 1;
+  }
+  return elf.iterateSections([&](const auto& shdr) {
+    return strcmp(elf.getSectionName(shdr), ".stapsdt.base") == 0;
+  });
+}
+
+} // namespace
+
+int main(int /*argc*/, char* argv[]) {
+  init();
+  fini();
+  return test(argv[0]) ? 0 : 1;
+}

--- a/folly/test/SdtTest.lds
+++ b/folly/test/SdtTest.lds
@@ -1,0 +1,8 @@
+SECTIONS
+{
+  .stapsdt.base :
+  {
+    KEEP(*(.stapsdt.base))
+  }
+}
+INSERT AFTER .text;


### PR DESCRIPTION
Summary:
Fix .stapsdt.base section in FOLLY_SDT macro.

Ported .stapsdt.base initialization from sys/sdt.h https://github.com/jav/systemtap/blob/2da355dd02a18bf4f67e2ceeb504b351b4bd5b83/includes/sys/sdt.h#L174C1-L199C21.

```
#define _SDT_ASM_BODY(provider, name, pack_args, args)			      \
  _SDT_ASM_1(990:	_SDT_NOP)					      \
  _SDT_ASM_3(		.pushsection .note.stapsdt,_SDT_ASM_AUTOGROUP,"note") \
  _SDT_ASM_1(		.balign 4)					      \
  _SDT_ASM_3(		.4byte 992f-991f, 994f-993f, _SDT_NOTE_TYPE)	      \
  _SDT_ASM_1(991:	.asciz _SDT_NOTE_NAME)				      \
  _SDT_ASM_1(992:	.balign 4)					      \
  _SDT_ASM_1(993:	_SDT_ASM_ADDR 990b)				      \
  _SDT_ASM_1(		_SDT_ASM_ADDR _.stapsdt.base)			      \
  _SDT_SEMAPHORE(provider,name)						      \
  _SDT_ASM_STRING(provider)						      \
  _SDT_ASM_STRING(name)							      \
  pack_args args							      \
  _SDT_ASM_1(994:	.balign 4)					      \
  _SDT_ASM_1(		.popsection)

#define _SDT_ASM_BASE							      \
  _SDT_ASM_1(.ifndef _.stapsdt.base)					      \
  _SDT_ASM_5(		.pushsection .stapsdt.base,"aG","progbits",	      \
							.stapsdt.base,comdat) \
  _SDT_ASM_1(		.weak _.stapsdt.base)				      \
  _SDT_ASM_1(		.hidden _.stapsdt.base)				      \
  _SDT_ASM_1(	_.stapsdt.base: .space 1)				      \
  _SDT_ASM_2(		.size _.stapsdt.base, 1)			      \
  _SDT_ASM_1(		.popsection)					      \
  _SDT_ASM_1(.endif)
```
This section might be discarded explicitly using --discard-section=.stapsdt.base https://fburl.com/code/0pbird2s or implicitly using --gc-sections https://fburl.com/code/iy16v9v8. Use linker script to keep it if your build system sets --gc-sections implicitly.

Reviewed By: nslingerland

Differential Revision: D61148295


