### PR TITLE
change contains interface to be more restrictive

### DIFF
--- a/folly/algorithm/simd/detail/Traits.h
+++ b/folly/algorithm/simd/detail/Traits.h
@@ -53,13 +53,13 @@ using simd_friendly_equivalent_scalar_t = std::enable_if_t<
     like_t<T, decltype(findSimdFriendlyEquivalent<std::remove_const_t<T>>())>>;
 
 template <typename T>
-constexpr bool has_integral_simd_friendly_equivalent_scalar =
+constexpr bool has_integral_simd_friendly_equivalent_scalar_v =
     std::is_integral_v< // void will return false
         decltype(findSimdFriendlyEquivalent<std::remove_const_t<T>>())>;
 
 template <typename T>
 using unsigned_simd_friendly_equivalent_scalar_t = std::enable_if_t<
-    has_integral_simd_friendly_equivalent_scalar<T>,
+    has_integral_simd_friendly_equivalent_scalar_v<T>,
     like_t<T, uint_bits_t<sizeof(T) * 8>>>;
 
 template <typename R>

--- a/folly/algorithm/simd/test/ContainsTest.cpp
+++ b/folly/algorithm/simd/test/ContainsTest.cpp
@@ -20,6 +20,9 @@
 
 #include <folly/portability/GTest.h>
 
+#include <list>
+#include <vector>
+
 namespace folly::simd {
 
 static_assert( //
@@ -33,6 +36,60 @@ static_assert( //
         contains_fn,
         std::vector<int>&,
         int>);
+
+static_assert( //
+    std::is_invocable_v< //
+        folly::simd::contains_fn,
+        std::vector<int>&,
+        int>);
+
+static_assert( //
+    std::is_invocable_v< //
+        folly::simd::contains_fn,
+        std::vector<int>&,
+        std::int16_t>);
+
+static_assert( //
+    std::is_invocable_v< //
+        folly::simd::contains_fn,
+        std::vector<int>&,
+        std::uint16_t>);
+
+static_assert( //
+    !std::is_invocable_v< //
+        folly::simd::contains_fn,
+        std::vector<int>&,
+        std::uint32_t>);
+
+static_assert( //
+    !std::is_invocable_v< //
+        folly::simd::contains_fn,
+        std::vector<int>&,
+        std::int64_t>);
+
+static_assert( //
+    !std::is_invocable_v< //
+        folly::simd::contains_fn,
+        std::vector<std::uint32_t>&,
+        std::int16_t>);
+
+static_assert( //
+    std::is_invocable_v< //
+        folly::simd::contains_fn,
+        std::vector<std::uint32_t>&,
+        std::uint16_t>);
+
+static_assert( //
+    !std::is_invocable_v< //
+        folly::simd::contains_fn,
+        std::list<std::int32_t>&,
+        std::int32_t>);
+
+static_assert( //
+    !std::is_invocable_v< //
+        folly::simd::contains_fn,
+        const std::vector<std::vector<std::int32_t>>&,
+        std::vector<std::int32_t>>);
 
 template <typename T>
 struct ContainsTest : ::testing::Test {};


### PR DESCRIPTION
Summary:
previous interface allowed for implicit conversions.
So it so happens that the user would have to guard against it.

I think I better guard here.

Differential Revision: D63979345


