### PR TITLE
Traits.h: Fix feature-test macro for P1144 trivial relocatability

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -640,7 +640,7 @@ struct IsRelocatable
           !require_sizeof<T> ||
               is_detected_v<traits_detail::detect_IsRelocatable, T>,
           traits_detail::has_true_IsRelocatable<T>,
-#if defined(__cpp_lib_is_trivially_relocatable) // P1144
+#if defined(__cpp_lib_trivially_relocatable) // P1144
           std::is_trivially_relocatable<T>
 #else
           std::is_trivially_copyable<T>


### PR DESCRIPTION
Well, this is awkward. #2216 added this `#if` check, but with the P1144 macro typo'ed: `__cpp_lib_is_trivially_relocatable` should have been `__cpp_lib_trivially_relocatable`.

In #2216 I even pointed to both [the proposal](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1144r10.html#wording) and [another repo's (correct) example](https://github.com/charles-salvia/std_error/blob/3abc272/all_in_one.hpp#L180-L196), and yet somehow I still typo'ed it in the actual PR, and didn't notice for months! Really sorry about this.

Compiler Explorer (left-hand pane: as it is today; right-hand pane: with the wrong macro manually defined so that you get the codegen you were supposed to be getting all along)
https://godbolt.org/z/7oP3Yz61d

Attn: @Orvid, @ot