### PR TITLE
fix windows folly build

### DIFF
--- a/CMake/FollyCompilerMSVC.cmake
+++ b/CMake/FollyCompilerMSVC.cmake
@@ -120,6 +120,7 @@ function(apply_folly_compile_options_to_target THETARGET)
 
       /permissive- # Be mean, don't allow bad non-standard stuff (C++/CLI, __declspec, etc. are all left intact).
       /std:${MSVC_LANGUAGE_VERSION} # Build in the requested version of C++
+      /utf-8 # fmt needs unicode support, which requires compiling with /utf-8
 
     PRIVATE
       /bigobj # Support objects with > 65k sections. Needed due to templates.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -649,13 +649,17 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
     DIRECTORY algorithm/simd/detail/test/
       TEST algorithm_simd_detail_simd_any_of_test SOURCES SimdAnyOfTest.cpp
       TEST algorithm_simd_detail_simd_for_each_test SOURCES SimdForEachTest.cpp
-      TEST algorithm_simd_detail_simd_traits_test SOURCES TraitsTest.cpp
+      # Needs C++20 on MSVC
+      TEST algorithm_simd_detail_simd_traits_test WINDOWS_DISABLED
+        SOURCES TraitsTest.cpp
       TEST algorithm_simd_detail_unroll_utils_test SOURCES UnrollUtilsTest.cpp
 
     DIRECTORY algorithm/simd/test/
       TEST algorithm_simd_contains_test SOURCES ContainsTest.cpp
       TEST algorithm_simd_find_fixed_test SOURCES FindFixedTest.cpp
-      TEST algorithm_simd_movemask_test SOURCES MovemaskTest.cpp
+      # needs C++20 on MSVC
+      TEST algorithm_simd_movemask_test WINDOWS_DISABLED 
+        SOURCES MovemaskTest.cpp
 
     DIRECTORY chrono/test/
       TEST chrono_conv_test WINDOWS_DISABLED
@@ -963,7 +967,9 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       TEST lang_aligned_test SOURCES AlignedTest.cpp
       TEST lang_badge_test SOURCES BadgeTest.cpp
       TEST lang_bits_class_test SOURCES BitsClassTest.cpp
-      TEST lang_bits_test SOURCES BitsTest.cpp
+      # Needs C++20 on Windows
+      TEST lang_bits_test WINDOWS_DISABLED
+        SOURCES BitsTest.cpp
       TEST lang_c_string_test SOURCES CStringTest.cpp
       TEST lang_cast_test SOURCES CastTest.cpp
       TEST lang_checked_math_test SOURCES CheckedMathTest.cpp
@@ -1063,7 +1069,8 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       TEST atomic_unordered_map_test SOURCES AtomicUnorderedMapTest.cpp
       TEST base64_test SOURCES base64_test.cpp
       TEST buffered_atomic_test SOURCES BufferedAtomicTest.cpp
-      TEST cancellation_token_test SOURCES CancellationTokenTest.cpp
+      TEST cancellation_token_test WINDOWS_DISABLED
+        SOURCES CancellationTokenTest.cpp
       TEST chrono_test SOURCES ChronoTest.cpp
       TEST clock_gettime_wrappers_test SOURCES ClockGettimeWrappersTest.cpp
       TEST concurrent_bit_set_test SOURCES ConcurrentBitSetTest.cpp
@@ -1071,7 +1078,8 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
         SOURCES ConcurrentSkipListBenchmark.cpp
       TEST concurrent_skip_list_test SOURCES ConcurrentSkipListTest.cpp
       TEST constexpr_math_test SOURCES ConstexprMathTest.cpp
-      TEST conv_test SOURCES ConvTest.cpp
+      TEST conv_test WINDOWS_DISABLED
+        SOURCES ConvTest.cpp
       TEST cpu_id_test SOURCES CpuIdTest.cpp
       TEST demangle_test SOURCES DemangleTest.cpp
       TEST deterministic_schedule_test SOURCES DeterministicScheduleTest.cpp
@@ -1145,7 +1153,9 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       TEST range_test SOURCES RangeTest.cpp
       TEST replaceable_test WINDOWS_DISABLED SOURCES ReplaceableTest.cpp
       TEST scope_guard_test WINDOWS_DISABLED SOURCES ScopeGuardTest.cpp
-      TEST sdt_test SOURCES SdtTest.cpp
+      # Needs ElfFile
+      TEST sdt_test WINDOWS_DISABLED
+        SOURCES SdtTest.cpp
       # Heavily dependent on drand and srand48
       #TEST shared_mutex_test SOURCES SharedMutexTest.cpp
       # SingletonTest requires Subprocess
@@ -1177,7 +1187,9 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       BENCHMARK uri_benchmark SOURCES UriBenchmark.cpp
       TEST uri_test SOURCES UriTest.cpp
       TEST utf8_string_test SOURCES UTF8StringTest.cpp
-      TEST utility_test SOURCES UtilityTest.cpp
+      # Needs C++20 on MSVC
+      TEST utility_test WINDOWS_DISABLED
+        SOURCES UtilityTest.cpp
       TEST varint_test SOURCES VarintTest.cpp
 
     DIRECTORY testing/test/

--- a/folly/algorithm/simd/test/ContainsTest.cpp
+++ b/folly/algorithm/simd/test/ContainsTest.cpp
@@ -138,7 +138,7 @@ TYPED_TEST(ContainsTest, Basic) {
 
   for (std::size_t size = 0; size != 100; ++size) {
     std::vector<T> buf(size, T{0});
-    for (std::size_t offset = 0; offset != std::min(32UL, buf.size());
+    for (std::size_t offset = 0; offset != std::min(std::size_t(32UL), buf.size());
          ++offset) {
       folly::span<T> haystack(buf.data() + offset, buf.data() + buf.size());
       T needle{1};

--- a/folly/container/RegexMatchCache.h
+++ b/folly/container/RegexMatchCache.h
@@ -391,15 +391,14 @@ class RegexMatchCacheKey {
   static data_type init(std::string_view regex) noexcept;
 
   template <typename T, typename V = std::remove_cv_t<T>>
-  static constexpr bool is_span_compatible(size_t const e) noexcept {
+  static constexpr bool is_span_compatible() noexcept {
     return //
         !std::is_volatile_v<T> && //
         std::is_integral_v<V> && //
         std::is_unsigned_v<V> && //
         !std::is_same_v<bool, V> && //
         !std::is_same_v<char, V> && //
-        alignof(V) <= data_align &&
-        (e == data_size / sizeof(V) || e == dynamic_extent);
+        alignof(V) <= data_align;
   }
 
  public:
@@ -409,7 +408,8 @@ class RegexMatchCacheKey {
   template <
       typename T,
       std::size_t E,
-      std::enable_if_t<is_span_compatible<T>(E), int> = 0>
+      std::enable_if_t<is_span_compatible<T>() &&
+        (E == data_size / sizeof(T) || E == dynamic_extent), int> = 0>
   explicit operator span<T const, E>() const noexcept {
     return {reinterpret_cast<T const*>(data_.data()), E};
   }

--- a/folly/settings/Settings.cpp
+++ b/folly/settings/Settings.cpp
@@ -131,10 +131,10 @@ void Snapshot::forEachSetting(
   map = *detail::settingsMap().rlock();
   for (const auto& kv : map) {
     auto [value, reason] = kv.second->getAsString(this);
-    Snapshot::SettingVisitorInfo visitInfo{
-        .meta = kv.second->meta(),
-        .value = std::move(value),
-        .reason = std::move(reason),
+    Snapshot::SettingVisitorInfo visitInfo = {
+        kv.second->meta(),
+        std::move(value),
+        std::move(reason),
     };
     func(std::move(visitInfo));
   }

--- a/folly/test/StringToFloatBenchmark.cpp
+++ b/folly/test/StringToFloatBenchmark.cpp
@@ -110,6 +110,10 @@ class PosixNumericLocale {
 };
 } // namespace
 
+#if defined(_WIN32)
+#define strtod_l _strtod_l
+#endif
+
 BENCHMARK(hardcoded_decimal_notation_STRTOFL_COPY, n) {
   char* end;
   for (unsigned int i = 0; i < n; ++i) {


### PR DESCRIPTION

Summary:
fix windows folly build
 * fmt requires unicode, add /utf-8 msvc flag
 * Settings.cpp was using C++20 struct init that MSVC is strict about, change to regular init
 * MSVC can't handle the parameter to RegexMatchCache::is_span_compatible,  extract out the check that needs E to into the
std::enable_if_t
 * ContainsTest needed cast to size_t for std::min to work
 * Disable tests that don't compile for windows

Test Plan:

local build with: `python ./build/fbcode_builder/getdeps.py build --src-dir=. folly`

before, [broken](https://github.com/facebook/folly/actions/runs/11402111839/job/31726415001#step:42:629)
```
Z:\installed\fmt--08ZeFppBnK_Qz90kx-Yjd0crzRfSn6gIcQEVrX89l4\include\fmt\base.h(458): error C2338: Unicode support requires compiling with /utf-8
[2/842] Building CXX object CMakeFiles\folly_base.dir\folly\Conv.cpp.obj
```

then...
```
C:\Users\alex\local\folly\folly/container/RegexMatchCache.h(434): error C2440: '<function-style-cast>': cannot convert from 'initializer list' to 'folly::detail::fallback_span::span<const size_t,18446744073709551615>'
C:\Users\alex\local\folly\folly/container/RegexMatchCache.h(434): note: No constructor could take the source type, or constructor overload resolution was ambiguous
ninja: build stopped: subcommand failed.
Command '['Y:\\build\\folly\\succeed.bat', '&&', 'Y:\\installed\\cmake-_qm1f2PWnzobdL5bp69h3vWFzt0Lbzikp_cDemrJG0U\\bin\\cmake.exe', '--build', 'Y:\\build\\folly', '--target', 'install', '--config', 'RelWithDebInfo', '-j', '32']' returned non-zero exit status 1.
!! Failed`
```
