### PR TITLE
Fix compiliation if glog >= 0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1230,4 +1230,6 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
   endif()
 endif()
 
+add_definitions(-DGLOG_USE_GLOG_EXPORT)
+
 add_subdirectory(folly)


### PR DESCRIPTION
Fix #2171. As I understand it 'GLOG_USE_GLOG_EXPORT' figures out the right thing to do i(f you're not building glog itself).