### PR TITLE
IWYU: add #include <unordered_map> to SingletonRelaxedCounter.h

### DIFF
--- a/folly/concurrency/SingletonRelaxedCounter.h
+++ b/folly/concurrency/SingletonRelaxedCounter.h
@@ -19,6 +19,7 @@
 #include <array>
 #include <atomic>
 #include <type_traits>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <folly/Likely.h>


### PR DESCRIPTION
`std::unordered_map` is referenced in this file but the header is not included, causing build error in some environment.