### PR TITLE
Missing GFlags headers

### DIFF
--- a/folly/concurrency/test/ConcurrentHashMapBench.cpp
+++ b/folly/concurrency/test/ConcurrentHashMapBench.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <thread>
 
+#include <folly/portability/GFlags.h>
 #include <folly/synchronization/test/Barrier.h>
 
 DEFINE_int32(reps, 10, "number of reps");


### PR DESCRIPTION
Fix #2246.
GFlags headers were missing in `folly/concurrent/test/ConcurrentHashMapBench.cpp`.