### PR TITLE
Reduce thread count in ConcurrentHashMapTest to prevent system thread limit breach

### DIFF
--- a/folly/concurrency/test/ConcurrentHashMapTest.cpp
+++ b/folly/concurrency/test/ConcurrentHashMapTest.cpp
@@ -1156,10 +1156,11 @@ TYPED_TEST_P(ConcurrentHashMapTest, StressTestReclamation) {
   EXPECT_TRUE(map.insert(std::make_pair(key_link_explosion, 0)).second);
 
   std::vector<std::thread> threads;
-  // Test with (2^16)+ threads, enough to overflow a 16 bit integer.
-  // It should be uncommon to have more than 2^32 concurrent accesses.
-  static constexpr uint64_t num_threads = std::numeric_limits<uint16_t>::max();
-  static constexpr uint64_t iters = 100;
+  // It should be uncommon to have more than 1024 concurrent accesses.
+  // A higher thread number may cause the process to fail as the thread limit
+  // is breached.
+  static constexpr uint64_t num_threads = 1024;
+  static constexpr uint64_t iters = 1000;
   folly::Latch start(num_threads);
   for (uint64_t t = 0; t < num_threads; t++) {
     threads.push_back(lib::thread([t, &map, &start]() {


### PR DESCRIPTION
The earlier number of threads,  `65536`, is causing subprocess termination on Apple M3/16 GB/MacOS 15.1.  This is understable since the OS thread limit per process is significantly lower(`4096` as shown below).
```
sysctl kern.num_taskthreads
kern.num_taskthreads: 4096
```

Reducing the thread count to `1024` to add some some margin of error for other platforms as well. `1024` is practically already high enough for most real world use cases so this should be _stress_ enough. But to _somewhat_ compensate for the lower total thread count here, the number of iterations has been increased from `100` to `1000`.

Its to be noted that other multi threaded tests in the same file are already using lower total thread counts(e.g. `32` [here](https://github.com/facebook/folly/blob/30a4e783a7618f17a5b24048625872e363068887/folly/concurrency/test/ConcurrentHashMapTest.cpp#L620).