### PR TITLE
fix zlib using

### DIFF
--- a/folly/compression/Zlib.h
+++ b/folly/compression/Zlib.h
@@ -124,8 +124,6 @@ std::unique_ptr<StreamCodec> getStreamCodec(
 } // namespace compression
 } // namespace folly
 
-#endif // FOLLY_HAVE_LIBZ
-
 namespace folly::io::zlib {
 using folly::compression::zlib::defaultGzipOptions;
 using folly::compression::zlib::defaultZlibOptions;
@@ -133,3 +131,5 @@ using folly::compression::zlib::getCodec;
 using folly::compression::zlib::getStreamCodec;
 using folly::compression::zlib::Options;
 } // namespace folly::io::zlib
+#endif // FOLLY_HAVE_LIBZ
+


### PR DESCRIPTION
before this fix, if marco FOLLY_HAVE_LIBZ is NOT defined, using folly::compression::zlib::Option will report can't find symbol error. 