### PR TITLE
libc++20 removes std::__compressed_pair; amend preprocessor directive

### DIFF
--- a/folly/memory/UninitializedMemoryHacks.h
+++ b/folly/memory/UninitializedMemoryHacks.h
@@ -298,7 +298,7 @@ namespace detail {
   }                                                                      \
   }
 
-#if defined(_LIBCPP_VECTOR)
+#if defined(_LIBCPP_VECTOR) && (_LIBCPP_VERSION < 200000)
 // libc++
 
 template <typename T, typename Alloc = std::allocator<T>>


### PR DESCRIPTION
Conditionally protect against the offending code as stopgap.

References issue #2351 

If desired can try to use [`[[no_unique_address]]`](https://en.cppreference.com/w/cpp/language/attributes/no_unique_address) and `[[msvc::no_unique_address]]` where applicable.
