### PR TITLE
Fix: Replace _Py_IsFinalizing with Py_IsFinalizing for Python 3.13 compatibility and added version hex 

### DIFF
--- a/folly/python/AsyncioExecutor.h
+++ b/folly/python/AsyncioExecutor.h
@@ -23,6 +23,11 @@
 #include <folly/executors/SequencedExecutor.h>
 #include <folly/io/async/NotificationQueue.h>
 
+
+#if PY_VERSION_HEX < 0x030d0000 // Check if the python version is less than 3.13
+#define Py_IsFinalizing _Py_IsFinalizing
+#endif
+
 namespace folly {
 namespace python {
 
@@ -79,7 +84,7 @@ class AsyncioExecutor : public DrivableExecutor {
 #if PY_VERSION_HEX <= 0x03070000
     return false;
 #else
-    return _Py_IsFinalizing();
+    return Py_IsFinalizing(); // change _PY_IsFinalizing to Py_IsFinalizing
 #endif
   }
 


### PR DESCRIPTION
### Summary
- Addressed issue #2358 by replacing the deprecated `_Py_IsFinalizing` with the public API `Py_IsFinalizing`, introduced in Python 3.13.
- Added version gating using `PY_VERSION_HEX` to ensure compatibility with older Python versions.

### Changes:
- Updated `AsyncioExecutor.h`:
  - Replaced `_Py_IsFinalizing` with `Py_IsFinalizing`.
  - Added a macro to alias `_Py_IsFinalizing` for Python versions before 3.13.

### Reference:
- Related issue: #2358
