### PR TITLE
fix mpsc DynamicBoundedQueue try_enqueue could fail even if queue is empty

### DIFF
--- a/folly/concurrency/DynamicBoundedQueue.h
+++ b/folly/concurrency/DynamicBoundedQueue.h
@@ -517,6 +517,9 @@ class DynamicBoundedQueue {
     Weight capacity = getCapacity();
     Weight before = fetchAddDebit(weight);
     if (FOLLY_LIKELY(before + weight <= capacity)) {
+      if (FOLLY_UNLIKELY(before + weight > capacity / 2)) {
+        tryReduceDebit();
+      }
       return true;
     } else {
       subDebit(weight);

--- a/folly/concurrency/test/DynamicBoundedQueueTest.cpp
+++ b/folly/concurrency/test/DynamicBoundedQueueTest.cpp
@@ -340,6 +340,29 @@ TEST(DynamicBoundedQueue, enqDeq) {
   enq_deq_test<false, false, true>(10, 10);
 }
 
+TEST(DynamicBoundedQueue, mpsc_try_enqueue_when_is_empty_test) {
+  for (int repeat = 0; repeat < 10; repeat++) {
+    folly::DynamicBoundedQueue<int, false, true, true, 1> q(10);
+    const int capacity = 11;
+    for (int i = 0 ; i < capacity; i++) {
+      ASSERT_EQ(q.try_enqueue(0), true);
+      ASSERT_EQ(q.try_dequeue().has_value(), true);
+    }
+    ASSERT_EQ(q.empty(), true);
+
+    auto prod = [&](int tid) {
+      ASSERT_EQ(q.try_enqueue(1), true);
+    };
+
+    auto cons = [&](int tid) {
+    };
+
+    auto endfn = [&] {
+    };
+    run_once(5, 1, prod, cons, endfn);
+  }
+}
+
 template <typename RepFunc>
 uint64_t runBench(const std::string& name, int ops, const RepFunc& repFn) {
   int reps = FLAGS_reps;


### PR DESCRIPTION
#### Problem:
We used `folly::DMPSCQueue<> q(1024)` and  encountered try_enqueue() return false frequently even if the queue is empty.

#### Debug:
I logged the three atomic value `debit, credit, transfer` before and after `try_enqueue()` operation, and saw the issue.
```
01-14   20:45:07.562839 INFO    17569   ***.cc:111 trace_id:***548   Submit task to worker1_12 Ok debit=1124, credit=2, transfer=1122, qsize=0, after push debit=1125, credit=2, transfer=1122
01-14   20:45:07.562888 INFO    17576   ***.cc:111 trace_id:***055   Submit task to worker1_12 Ok debit=1125, credit=3, transfer=1122, qsize=0, after push debit=1126, credit=3, transfer=1122
01-14   20:45:07.568038 INFO    17572   ***.cc:111 trace_id:***618   Submit task to worker1_12 Ok debit=1126, credit=4, transfer=1122, qsize=0, after push debit=7, credit=5, transfer=0
01-14   20:45:07.568161 INFO    17570   ***.cc:111 trace_id:***736   Submit task to worker1_12 Fail debit=1126, credit=4, transfer=1122, qsize=0, after push debit=7, credit=5, transfer=0
```

```
  bool tryReduceDebit() noexcept {
    Weight w = takeTransfer();
    if (w > 0) {
      subDebit(w);
    }
    return w > 0;
  }

  Weight takeTransfer() noexcept {
    Weight w = getTransfer();
    if (w > 0) {
      w = transfer_.exchange(0, std::memory_order_acq_rel);
    }
    return w;
  }
```
At this case, capacity=1126, debit=1126, credit=4, transfer=1122, so **the queue is actually empty**.

Now there is 2 concurrent producers both do `takeTransfer()`. 
Producer_1 succeeded take transfer value, but haven't `subDebit(w)`.
producer_2 saw transfer value is 0, and return, and check debit + weight > capacity, then `try_enqueue()` failed.

The unit_test in the pr can reproduce the case.


#### Fix:
Let prodcuer do `tryReduceDebit()` earlier, when debit reaches half capacity.