### PR TITLE
Ninja update to avoid build fail on python3.13

### DIFF
--- a/build/fbcode_builder/manifests/ninja
+++ b/build/fbcode_builder/manifests/ninja
@@ -14,8 +14,8 @@ ninja-build
 ninja
 
 [download.os=windows]
-url = https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip
-sha256 = bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f
+url = https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-win.zip
+sha256 = f550fec705b6d6ff58f2db3c374c2277a37691678d6aba463adcbb129108467a
 
 [build.os=windows]
 builder = nop
@@ -24,9 +24,9 @@ builder = nop
 ninja.exe = bin/ninja.exe
 
 [download.not(os=windows)]
-url = https://github.com/ninja-build/ninja/archive/v1.10.2.tar.gz
-sha256 = ce35865411f0490368a8fc383f29071de6690cbadc27704734978221f25e2bed
+url = https://github.com/ninja-build/ninja/archive/v1.12.1.tar.gz
+sha256 = 821bdff48a3f683bc4bb3b6f0b5fe7b2d647cf65d52aeb63328c91a6c6df285a
 
 [build.not(os=windows)]
 builder = ninja_bootstrap
-subdir = ninja-1.10.2
+subdir = ninja-1.12.1


### PR DESCRIPTION
When building from scratch folly on python 3.13, here is the issue you will encounter:
```
Extract /private/tmp/follyt/downloads/ninja-v1.10.2.tar.gz -> /private/tmp/follyt/extracted/ninja-v1.10.2.tar.gz
Building ninja...
---
+ cd /private/tmp/follyt/extracted/ninja-v1.10.2.tar.gz/ninja-1.10.2 && \
+ /opt/homebrew/opt/python@3.13/bin/python3.13 \
+      configure.py \
+      --bootstrap
Traceback (most recent call last):
  File "/private/tmp/follyt/extracted/ninja-v1.10.2.tar.gz/ninja-1.10.2/configure.py", line 26, in <module>
    import pipes
ModuleNotFoundError: No module named 'pipes'
Command '['/opt/homebrew/opt/python@3.13/bin/python3.13', 'configure.py', '--bootstrap']' returned non-zero exit status 1.
!! Failed
```
(`python3.13 ./build/fbcode_builder/getdeps.py build --scratch-path /tmp/follyt`)

This is because the version `1.10.2` of ninja uses `pipes`, which has been deprecated since python 3.11 and removed in python 3.13. [^1]

This PR changes the ninja dependency from 1.10.2 to 1.12.1. 

[^1]: https://docs.python.org/3/library/pipes.html