### PR TITLE
Add inlining hints to concurrent hash map

### DIFF
--- a/folly/concurrency/ConcurrentHashMap.h
+++ b/folly/concurrency/ConcurrentHashMap.h
@@ -288,10 +288,12 @@ class ConcurrentHashMap {
     return true;
   }
 
-  ConstIterator find(const KeyType& k) const { return findImpl(k); }
+  FOLLY_ALWAYS_INLINE ConstIterator find(const KeyType& k) const {
+    return findImpl(k);
+  }
 
   template <typename K, EnableHeterogeneousFind<K, int> = 0>
-  ConstIterator find(const K& k) const {
+  FOLLY_ALWAYS_INLINE ConstIterator find(const K& k) const {
     return findImpl(k);
   }
 
@@ -604,7 +606,8 @@ class ConcurrentHashMap {
           segment_(std::exchange(o.segment_, uint64_t(NumShards))),
           parent_(std::exchange(o.parent_, nullptr)) {}
 
-    ConstIterator(const ConcurrentHashMap* parent, uint64_t segment)
+    FOLLY_ALWAYS_INLINE ConstIterator(
+        const ConcurrentHashMap* parent, uint64_t segment)
         : segment_(segment), parent_(parent) {}
 
    private:
@@ -656,7 +659,7 @@ class ConcurrentHashMap {
 
  private:
   template <typename K>
-  ConstIterator findImpl(const K& k) const {
+  FOLLY_ALWAYS_INLINE ConstIterator findImpl(const K& k) const {
     auto h = HashFn{}(k);
     auto segment = pickSegment(h);
     ConstIterator res(this, segment);

--- a/folly/concurrency/detail/ConcurrentHashMap-detail.h
+++ b/folly/concurrency/detail/ConcurrentHashMap-detail.h
@@ -482,7 +482,7 @@ class alignas(64) BucketTable {
         bucket_count_.load(std::memory_order_relaxed) * load_factor_;
   }
 
-  Iterator cbegin() {
+  FOLLY_ALWAYS_INLINE Iterator cbegin() {
     Iterator res;
     size_t bcount;
     Buckets* buckets;
@@ -605,7 +605,7 @@ class alignas(64) BucketTable {
 
     Iterator& operator=(const Iterator& o) = delete;
 
-    Iterator& operator=(Iterator&& o) noexcept {
+    FOLLY_ALWAYS_INLINE Iterator& operator=(Iterator&& o) noexcept {
       if (this != &o) {
         hazptrs_ = std::move(o.hazptrs_);
         node_ = std::exchange(o.node_, nullptr);
@@ -1899,7 +1899,7 @@ class alignas(64) ConcurrentHashMapSegment {
 
   void max_load_factor(float factor) { impl_.max_load_factor(factor); }
 
-  Iterator cbegin() { return impl_.cbegin(); }
+  FOLLY_ALWAYS_INLINE Iterator cbegin() { return impl_.cbegin(); }
 
   Iterator cend() { return impl_.cend(); }
 

--- a/folly/concurrency/test/ConcurrentHashMapBench.cpp
+++ b/folly/concurrency/test/ConcurrentHashMapBench.cpp
@@ -21,6 +21,7 @@
 #include <thread>
 
 #include <folly/synchronization/test/Barrier.h>
+#include <folly/BenchmarkUtil.h>
 
 DEFINE_int32(reps, 10, "number of reps");
 DEFINE_int32(ops, 1000 * 1000, "number of operations per rep");
@@ -92,7 +93,7 @@ uint64_t bench_ctor_dtor(
       for (int i = 0; i < ops; ++i) {
         folly::ConcurrentHashMap<int, int> m;
         for (int j = 0; j < size; ++j) {
-          m.insert(j, j);
+          folly::doNotOptimizeAway(m.insert(j, j));
         }
       }
     };
@@ -114,11 +115,11 @@ uint64_t bench_find(
     auto fn = [&](int) {
       if (sameItem) {
         for (int i = 0; i < ops; ++i) {
-          m.find(key);
+          folly::doNotOptimizeAway(m.find(key));
         }
       } else {
         for (int i = 0; i < ops; ++i) {
-          m.find(i);
+          folly::doNotOptimizeAway(m.find(i));
         }
       }
     };
@@ -138,7 +139,7 @@ uint64_t bench_iter(const int nthr, int size, const std::string& name) {
   auto repFn = [&] {
     auto fn = [&](int) {
       for (int i = 0; i < reps; ++i) {
-        for (auto it = m.begin(); it != m.end(); ++it) {
+        for (auto it = m.begin(); it != m.end(); doNotOptimizeAway(++it)) {
         }
       }
     };
@@ -157,7 +158,7 @@ uint64_t bench_begin(const int nthr, int size, const std::string& name) {
   auto repFn = [&] {
     auto fn = [&](int) {
       for (int i = 0; i < ops; ++i) {
-        auto it = m.begin();
+        folly::doNotOptimizeAway(m.begin());
       }
     };
     auto endfn = [&] {};
@@ -175,7 +176,7 @@ uint64_t bench_empty(const int nthr, int size, const std::string& name) {
   auto repFn = [&] {
     auto fn = [&](int) {
       for (int i = 0; i < ops; ++i) {
-        m.empty();
+        folly::doNotOptimizeAway(m.empty());
       }
     };
     auto endfn = [&] {};
@@ -193,7 +194,7 @@ uint64_t bench_size(const int nthr, int size, const std::string& name) {
   auto repFn = [&] {
     auto fn = [&](int) {
       for (int i = 0; i < ops; ++i) {
-        m.size();
+        folly::doNotOptimizeAway(m.size());
       }
     };
     auto endfn = [&] {};


### PR DESCRIPTION
This PR adds inlining hints to several functions of the ConcurrentHashMap. With clang17 and NVIDIA Grace, this speeds up the benchmarks for begin() by ~35-40% and find() by ~15-20%. The iterate benchmarks show inconclusive results and may have a slowdown or speedup depending on input size and number of threads. Overall the effect is positive.

This PR depends on #2393, otherwise the additional inlining hints will allow the compiler to remove parts of the benchmark.
