### PR TITLE
build SmartExceptionTracer with cmake

### DIFF
--- a/folly/debugging/exception_tracer/CMakeLists.txt
+++ b/folly/debugging/exception_tracer/CMakeLists.txt
@@ -17,6 +17,8 @@ if (FOLLY_HAVE_ELF AND FOLLY_HAVE_DWARF)
     folly_exception_tracer_base
     ExceptionTracer.cpp
     StackTrace.cpp
+    SmartExceptionTracer.cpp
+    SmartExceptionTracerSingleton.cpp
   )
   set_property(TARGET folly_exception_tracer_base PROPERTY VERSION ${PACKAGE_VERSION})
   apply_folly_compile_options_to_target(folly_exception_tracer_base)
@@ -29,6 +31,7 @@ if (FOLLY_HAVE_ELF AND FOLLY_HAVE_DWARF)
     folly_exception_tracer
     ExceptionStackTraceLib.cpp
     ExceptionTracerLib.cpp
+    SmartExceptionStackTraceHooks.cpp
   )
   set_property(TARGET folly_exception_tracer PROPERTY VERSION ${PACKAGE_VERSION})
   apply_folly_compile_options_to_target(folly_exception_tracer)
@@ -50,11 +53,11 @@ if (FOLLY_HAVE_ELF AND FOLLY_HAVE_DWARF)
 
   install(
     FILES
-      ExceptionAbi.h
       ExceptionCounterLib.h
       ExceptionTracer.h
       ExceptionTracerLib.h
       StackTrace.h
+      SmartExceptionTracer.h
     DESTINATION
       ${INCLUDE_INSTALL_DIR}/folly/debugging/exception_tracer
   )


### PR DESCRIPTION
When using FOLLY_NO_EXCEPTION_TRACER, we may still want to use GtestHelpers.h, which references SmartExceptionTracer.h. For this to work, we can manually link the `folly_exception_tracer` target like:

    target_link_libraries(main PRIVATE $<LINK_LIBRARY:WHOLE_ARCHIVE,Folly::folly_exception_tracer>)

Without WHOLE_ARCHIVE, the global `initialize` will not be pulled in by linker.

Manually tested this with a simple project: folly is configured with `-DGFLAGS_USE_TARGET_NAMESPACE=ON -DFOLLY_NO_EXCEPTION_TRACER=ON`
main.cpp:
```cpp
#include <exception>
#include <iostream>
#include <folly/debugging/exception_tracer/SmartExceptionTracer.h>

void f() {
    throw std::exception();
}

int main() {
    try {
        f();
    } catch(const std::exception& ex) {
        std::cerr << folly::exception_tracer::getTrace(ex);
    }
}
```
CMakeLists.txt
```cmake
cmake_minimum_required(VERSION 3.24)
project(folly-try)

set(CMAKE_CXX_STANDARD 17)

set(GFLAGS_USE_TARGET_NAMESPACE ON)
find_package(gflags REQUIRED)
find_package(folly REQUIRED)

add_executable(main main.cpp)
target_link_libraries(main PRIVATE $<LINK_LIBRARY:WHOLE_ARCHIVE,Folly::folly_exception_tracer>)
target_link_libraries(main PRIVATE Folly::folly)
```
Ordering folly_exception_tracer before folly is important. (Maybe flaw of cmake?)
```
# ./main 
Exception type: std::exception (7 frames)
    @ 0000000000014745 _ZN5folly16exception_tracer12_GLOBAL__N_113throwCallbackEPvPSt9type_infoPPFvS2_E
                       /root/folly/folly/debugging/exception_tracer/SmartExceptionStackTraceHooks.cpp:64
    @ 000000000000ed51 __cxa_throw
                       /root/folly/folly/debugging/exception_tracer/ExceptionTracerLib.cpp:73
    @ 000000000000dc36 _Z1fv
                       /root/folly_try/main.cpp:6
    @ 000000000000dc57 main
                       /root/folly_try/main.cpp:11
    @ 0000000000029d8f (unknown)
    @ 0000000000029e3f __libc_start_main
    @ 000000000000db34 _start
```
Without linking to folly_exception_tracer: link error
```
[ 50%] Linking CXX executable main
/usr/bin/ld: CMakeFiles/main.dir/main.cpp.o: in function `main':
/root/folly_try/main.cpp:13: undefined reference to `folly::exception_tracer::getTrace(std::exception const&)'
/usr/bin/ld: /root/folly_try/main.cpp:13: undefined reference to `folly::exception_tracer::operator<<(std::ostream&, folly::exception_tracer::ExceptionInfo const&)'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/main.dir/build.make:122: main] Error 1
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/main.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
link to folly_exception_tracer without WHOLE_ARCHIVE
```
# ./main 
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0309 16:01:49.557803 113195 SmartExceptionTracer.cpp:48] Smart exception tracer library not linked, stack traces not available
Exception type: std::exception
```
So even without FOLLY_NO_EXCEPTION_TRACER, we will need this, because we definitely don't want to specify WHOLE_ARCHIVE for the main folly library.

BTW, ExceptionAbi.h is removed from install. It is copied from libstdc++, and folly should not expose this.