### PR TITLE
exception_tracer should support libc++

### DIFF
--- a/folly/debugging/exception_tracer/ExceptionAbi.h
+++ b/folly/debugging/exception_tracer/ExceptionAbi.h
@@ -22,7 +22,7 @@
 #include <exception>
 #include <typeinfo>
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #include <unwind.h>
 
@@ -60,4 +60,4 @@ __cxa_eh_globals* __cxa_get_globals_fast(void) noexcept;
 
 } // namespace __cxxabiv1
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)

--- a/folly/debugging/exception_tracer/ExceptionCounterLib.cpp
+++ b/folly/debugging/exception_tracer/ExceptionCounterLib.cpp
@@ -31,7 +31,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 using namespace folly::exception_tracer;
 
@@ -145,6 +145,6 @@ Initializer initializer;
 
 } // namespace
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/ExceptionCounterLib.h
+++ b/folly/debugging/exception_tracer/ExceptionCounterLib.h
@@ -23,7 +23,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 namespace folly {
 namespace exception_tracer {
@@ -46,6 +46,6 @@ std::ostream& operator<<(std::ostream& out, const ExceptionStats& stats);
 } // namespace exception_tracer
 } // namespace folly
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/ExceptionStackTraceLib.cpp
+++ b/folly/debugging/exception_tracer/ExceptionStackTraceLib.cpp
@@ -24,7 +24,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 using namespace folly::exception_tracer;
 
@@ -123,6 +123,6 @@ Initializer initializer;
 
 } // namespace
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/ExceptionTracer.cpp
+++ b/folly/debugging/exception_tracer/ExceptionTracer.cpp
@@ -31,7 +31,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #include <dlfcn.h>
 
@@ -238,6 +238,6 @@ void installHandlers() {
 } // namespace exception_tracer
 } // namespace folly
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/ExceptionTracerLib.cpp
+++ b/folly/debugging/exception_tracer/ExceptionTracerLib.cpp
@@ -23,7 +23,7 @@
 #include <folly/SharedMutex.h>
 #include <folly/Synchronized.h>
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #include <dlfcn.h>
 
@@ -214,4 +214,4 @@ __attribute__((__noreturn__)) void rethrow_exception(std::exception_ptr ep) {
 } // namespace std
 #endif
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)

--- a/folly/debugging/exception_tracer/ExceptionTracerLib.h
+++ b/folly/debugging/exception_tracer/ExceptionTracerLib.h
@@ -19,7 +19,7 @@
 #include <exception>
 #include <typeinfo>
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 namespace folly {
 namespace exception_tracer {
@@ -39,4 +39,4 @@ void registerRethrowExceptionCallback(RethrowExceptionSig& callback);
 } // namespace exception_tracer
 } // namespace folly
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)

--- a/folly/debugging/exception_tracer/SmartExceptionStackTraceHooks.cpp
+++ b/folly/debugging/exception_tracer/SmartExceptionStackTraceHooks.cpp
@@ -20,7 +20,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 namespace folly::exception_tracer {
 
@@ -98,6 +98,6 @@ Initialize initialize;
 } // namespace
 } // namespace folly::exception_tracer
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/SmartExceptionTracer.cpp
+++ b/folly/debugging/exception_tracer/SmartExceptionTracer.cpp
@@ -29,7 +29,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 namespace folly {
 namespace exception_tracer {
@@ -133,6 +133,6 @@ ExceptionInfo getAsyncTrace(const std::exception& ex) {
 } // namespace exception_tracer
 } // namespace folly
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/SmartExceptionTracer.h
+++ b/folly/debugging/exception_tracer/SmartExceptionTracer.h
@@ -21,7 +21,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #define FOLLY_HAVE_SMART_EXCEPTION_TRACER 1
 
@@ -45,6 +45,6 @@ ExceptionInfo getAsyncTrace(const exception_wrapper& ew);
 
 } // namespace folly::exception_tracer
 
-#endif // defined(__GLIBCXX__)
+#endif // defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF


### PR DESCRIPTION
Summary:
exception_tracer seemed to have no issue supporting libc++. Enable this for libc++ built binaries as well. 

```
grep -lR "defined(__GLIBCXX__)" fbcode/folly/ | xargs sed -i 's/defined(__GLIBCXX__)/defined(__GLIBCXX__) || defined(_LIBCPP_VERSION)/g'
```

Differential Revision: D71221982


