### PR TITLE
Fix UninitializedMemoryHacks.h for updated libc++ (std::__compressed_pair removed)

### DIFF
--- a/folly/memory/UninitializedMemoryHacks.h
+++ b/folly/memory/UninitializedMemoryHacks.h
@@ -309,7 +309,11 @@ struct std_vector_layout {
 
   pointer __begin_;
   pointer __end_;
+#ifdef _LIBCPP_COMPRESSED_PAIR
+  _LIBCPP_COMPRESSED_PAIR(pointer, __cap_ = nullptr, allocator_type, __alloc_);
+#else
   std::__compressed_pair<pointer, allocator_type> __end_cap_;
+#endif
 };
 
 template <typename T>


### PR DESCRIPTION
Update std_vector_layout, as __compressed_pair was removed in libc++ in https://github.com/llvm/llvm-project/pull/76756

fixes #2351