### PR TITLE
Fix UninitializedMemoryHacks.h check for asan wtih libc++

### DIFF
--- a/folly/memory/UninitializedMemoryHacks.h
+++ b/folly/memory/UninitializedMemoryHacks.h
@@ -332,7 +332,7 @@ void unsafeVectorSetLargerSize(std::vector<T>& v, std::size_t n) {
   // enabled we need to call the appropriate annotation functions in order to
   // stop ASAN from reporting false positives. When ASAN is disabled, the
   // annotation function is a no-op.
-#ifndef _LIBCPP_HAS_NO_ASAN
+#if defined(_LIBCPP_HAS_ASAN) ? _LIBCPP_HAS_ASAN : !defined(_LIBCPP_HAS_NO_ASAN)
   __sanitizer_annotate_contiguous_container(
       v.data(), v.data() + v.capacity(), v.data() + s, v.data() + n);
 #endif


### PR DESCRIPTION
Checks were updated from _LIBCPP_HAS_NO_ASAN to _LIBCPP_HAS_ASAN Relevant change: https://github.com/llvm/llvm-project/pull/89178