### PR TITLE
Subprocess: fix constructor for macOS

### DIFF
--- a/folly/Subprocess.cpp
+++ b/folly/Subprocess.cpp
@@ -73,6 +73,12 @@
   __attribute__((noinline, no_sanitize("address", "undefined", "thread")))
 #endif
 
+#if defined(__APPLE__) && !defined(__clang__)
+#define FOLLY_DETAIL_SUBPROCESS_CONSTRUCTOR __attribute__((constructor))
+#else
+#define FOLLY_DETAIL_SUBPROCESS_CONSTRUCTOR __attribute__((constructor(101)))
+#endif
+
 constexpr int kExecFailure = 127;
 constexpr int kChildFailure = 126;
 
@@ -175,7 +181,7 @@ struct subprocess_libc {
 
 FOLLY_DETAIL_SUBPROCESS_LIBC_X(FOLLY_DETAIL_SUBPROCESS_LIBC_FIELD_DEFN)
 
-__attribute__((constructor(101))) static void subprocess_libc_init() {
+FOLLY_DETAIL_SUBPROCESS_CONSTRUCTOR static void subprocess_libc_init() {
   auto handle = !kIsSanitize
       ? nullptr
       : ::dlopen(subprocess_libc_soname, RTLD_LAZY | RTLD_LOCAL | RTLD_NOLOAD);


### PR DESCRIPTION
See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119435

P. S. May also be relevant for Solaris: https://github.com/OpenMathLib/OpenBLAS/issues/700
But I have no way to check that.