### PR TITLE
Enable `folly::resizeWithoutInitialization` for `std::pair`

### DIFF
--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include <folly/Portability.h>
 
@@ -186,6 +187,36 @@ concept uncvref_instantiated_from =
     is_instantiation_of_v<Templ, std::remove_cvref_t<T>>;
 
 #endif
+
+template <typename T>
+  requires is_instantiation_of_v<std::pair, T>
+struct is_trivially_destructible : std::is_trivially_destructible<T> {};
+
+namespace detail {
+
+template <typename T>
+constexpr bool is_trivially_destructible_impl() {
+  if constexpr (std::is_trivially_destructible_v<T>) {
+    return true;
+  }
+  // std::pair is the only type that has this problem of having a non trivial
+  // default destructor.
+  else if constexpr (is_instantiation_of_v<std::pair, std::remove_cv_t<T>>) {
+    return is_trivially_destructible_impl<typename T::first_type>() &&
+        is_trivially_destructible_impl<typename T::second_type>();
+  }
+}
+
+} // namespace detail
+
+/*
+ * Extension of std::is_trivially_destructible_v that will also
+ * say "true" for certain known aggregate types from the standard,
+ * like std::pair.
+ */
+template <typename T>
+constexpr bool is_trivially_destructible_v =
+    detail::is_trivially_destructible_impl<T>();
 
 /// member_pointer_traits
 ///

--- a/folly/memory/UninitializedMemoryHacks.h
+++ b/folly/memory/UninitializedMemoryHacks.h
@@ -21,6 +21,8 @@
 #include <type_traits>
 #include <vector>
 
+#include <folly/Traits.h>
+
 // On MSVC an incorrect <version> header get's picked up
 #if !defined(_MSC_VER) && __has_include(<version>)
 #include <version>
@@ -98,7 +100,7 @@ void unsafeVectorSetLargerSize(std::vector<T>& v, std::size_t n);
 template <
     typename T,
     typename =
-        typename std::enable_if<std::is_trivially_destructible<T>::value>::type>
+        typename std::enable_if<folly::is_trivially_destructible_v<T>>::type>
 inline void resizeWithoutInitialization(
     std::basic_string<T>& s, std::size_t n) {
   if (n <= s.size()) {
@@ -137,7 +139,7 @@ inline void resizeWithoutInitialization(
 template <
     typename T,
     typename = typename std::enable_if<
-        std::is_trivially_destructible<T>::value &&
+        folly::is_trivially_destructible_v<T> &&
         !std::is_same<T, bool>::value>::type>
 void resizeWithoutInitialization(std::vector<T>& v, std::size_t n) {
   if (n <= v.size()) {
@@ -380,7 +382,7 @@ void unsafeVectorSetLargerSize(std::vector<T>& v, std::size_t n) {
   e += (n - v.size());
 }
 
-#define FOLLY_DECLARE_VECTOR_RESIZE_WITHOUT_INIT(TYPE)
+#define FOLLY_DECLARE_VECTOR_RESIZE_WITHOUT_INIT(_)
 
 #elif defined(_MSC_VER)
 

--- a/folly/memory/test/UninitializedMemoryHacksTest.cpp
+++ b/folly/memory/test/UninitializedMemoryHacksTest.cpp
@@ -87,11 +87,25 @@ void doResizeWithoutInit(
   }
 }
 
+struct asTestType {
+  std::size_t value;
+
+  template <typename T>
+  operator T() const {
+    return static_cast<T>(value);
+  }
+
+  template <typename T, typename U>
+  operator std::pair<T, U>() const {
+    return {static_cast<T>(value), static_cast<U>(value)};
+  }
+};
+
 template <typename T>
 void doOverwrite(
     T& target, std::vector<bool>& valid, std::size_t b, std::size_t e) {
   for (auto i = b; i < e && i < target.size(); ++i) {
-    target[i] = '0' + (i % 10);
+    target[i] = asTestType{'0' + (i % 10)};
     valid[i] = true;
   }
 }
@@ -298,6 +312,10 @@ TEST(UninitializedMemoryHacks, simpleVectorInt) {
   testSimple<std::vector<int>>();
 }
 
+TEST(UninitializedMemoryHacks, simpleVectorPair) {
+  testSimple<std::vector<std::pair<int, char>>>();
+}
+
 TEST(UninitializedMemoryHacks, randomString) {
   testRandom<std::string>();
 }
@@ -325,3 +343,4 @@ TEST(UninitializedMemoryHacks, randomVectorInt) {
 // We are deliberately putting this at the bottom to make sure it can follow use
 FOLLY_DECLARE_STRING_RESIZE_WITHOUT_INIT(signed char)
 FOLLY_DECLARE_VECTOR_RESIZE_WITHOUT_INIT(int)
+FOLLY_DECLARE_VECTOR_RESIZE_WITHOUT_INIT((std::pair<int, char>))

--- a/folly/test/TraitsTest.cpp
+++ b/folly/test/TraitsTest.cpp
@@ -579,6 +579,23 @@ TEST(Traits, InstantiationOf) {
 }
 #endif
 
+TEST(Traits, IsTriviallyDestructible) {
+  static_assert(folly::is_trivially_destructible_v<int>);
+  static_assert(folly::is_trivially_destructible_v<const int>);
+  static_assert(folly::is_trivially_destructible_v<const int&>);
+  //
+  static_assert(folly::is_trivially_destructible_v<std::pair<int, int>>);
+  static_assert(folly::is_trivially_destructible_v<const std::pair<int, int>>);
+  static_assert(folly::is_trivially_destructible_v<const std::pair<int, int>&>);
+  //
+  static_assert(folly::is_trivially_destructible_v<std::array<int, 3>>);
+  static_assert(folly::is_trivially_destructible_v<const std::array<int, 3>>);
+  //
+  static_assert(folly::is_trivially_destructible_v<std::tuple<int, char>>);
+  static_assert(
+      folly::is_trivially_destructible_v<const std::tuple<int, char>>);
+}
+
 TEST(Traits, member_pointer_traits_data) {
   struct o {};
   using d = float;


### PR DESCRIPTION
Summary:
folly::resizeWithoutInitialization should work for pairs.
I have an example where this would be nice.

Differential Revision: D71815841


