### PR TITLE
folly::tape - add shrink to fit

### DIFF
--- a/folly/container/tape.h
+++ b/folly/container/tape.h
@@ -311,7 +311,6 @@ class tape {
   }
 
   // capacity ------
-
   void reserve(size_type records, size_type elements) {
     markers_.reserve(records + 1);
     data_.reserve(elements);
@@ -321,6 +320,11 @@ class tape {
   void reserve(size_type records) {
     markers_.reserve(records + 1);
     data_.reserve(records);
+  }
+
+  void shrink_to_fit() {
+    markers_.shrink_to_fit();
+    data_.shrink_to_fit();
   }
 
   // resize/clear -------

--- a/folly/container/test/tape_test.cpp
+++ b/folly/container/test/tape_test.cpp
@@ -573,6 +573,25 @@ TEST(Tape, Iteration) {
   ASSERT_THAT(st2, testing::ElementsAre("1000", "100", "10", "0"));
 }
 
+TEST(Tape, ReserveShrink) {
+  // There is a limit to what we can test since reserve/shrink
+  // have very little guarantees.
+
+  folly::string_tape st;
+  st.reserve(2, 7);
+
+  st.push_back("abc");
+  const char* beforePushSecond = st[0].data();
+
+  st.push_back("defg");
+  const char* afterPushSecond = st[0].data();
+  ASSERT_EQ(beforePushSecond, afterPushSecond);
+
+  st.shrink_to_fit();
+  const char* afterShrink = st[0].data();
+  ASSERT_EQ(beforePushSecond, afterShrink);
+}
+
 TEST(Tape, TapeOfTapes) {
   folly::tape<folly::string_tape> strings;
 


### PR DESCRIPTION
Summary: shrink to fit is missing and I need it

Reviewed By: yfeldblum

Differential Revision: D72404855


