### PR TITLE
Fix va_list reuse and null dereference in getenv/setenv on Windows

### DIFF
--- a/folly/portability/Stdio.cpp
+++ b/folly/portability/Stdio.cpp
@@ -31,7 +31,11 @@ int dprintf(int fd, const char* fmt, ...) {
     va_end(args);
   };
 
-  int ret = vsnprintf(nullptr, 0, fmt, args);
+  // vsnprintf will consume it, so better copy args before using them 
+  va_list argsCopy;
+  va_copy(argsCopy, args);
+  int ret = vsnprintf(nullptr, 0, fmt, argsCopy);
+  va_end(argsCopy);
   if (ret <= 0) {
     return -1;
   }

--- a/folly/portability/Stdlib.cpp
+++ b/folly/portability/Stdlib.cpp
@@ -102,12 +102,19 @@ int setenv(const char* name, const char* value, int overwrite) {
 
   // Here lies the documentation we blatently ignore to make
   // this work >_>...
-  *getenv(name) = '\0';
+
+  char* env = getenv(name);
+  if (!env) {
+    errno = EINVAL;
+    return -1;
+  }
+  *env = '\0';
+  *(env + 1) = '=';
+
   // This would result in a double null termination, which
   // normally signifies the end of the environment variable
   // list, so we stick a completely empty environment variable
   // into the list instead.
-  *(getenv(name) + 1) = '=';
 
   // If _wenviron is null, the wide environment has not been initialized
   // yet, and we don't need to try to update it.
@@ -121,8 +128,13 @@ int setenv(const char* name, const char* value, int overwrite) {
       errno = EINVAL;
       return -1;
     }
-    *_wgetenv(buf) = u'\0';
-    *(_wgetenv(buf) + 1) = u'=';
+    wchar_t* wenv = _wgetenv(buf);
+    if (!wenv) {
+      errno = EINVAL;
+      return -1;
+    }
+    *wenv = u'\0';
+    *(wenv + 1) = u'=';
   }
 
   // And now, we have to update the outer environment to have


### PR DESCRIPTION
This PR fixes two small but important issues I found while reading and testing the code in `folly`. I'm a student learning more about programming and contributing to open-source projects, and I noticed two places where the code could cause real issues due to undefined or unsafe behavior.

1. Fix: Reusing `va_list` without `va_copy` in `dprintf()`
In `Stdio.cpp`, the function `dprintf` calls `vsnprintf` twice using the same `va_list` (`args`). According to the C++ standard, once `va_list` is passed to a function like `vsnprintf`, it is considered consumed and cannot be reused safely.
This could cause unpredictable behavior, incorrect formatting, or even a crash.
I fixed this by adding a `va_copy` before the first usage, and properly calling `va_end` on the copy.

2. Fix: Potential null pointer dereference when using `getenv`
In `Stdlib.cpp`, there was a line that was directly dereferencing the result of `getenv(name)`: *getenv(name) = '\0';
This assumes that getenv(name) always returns a valid pointer. However, if the environment variable does not exist, getenv returns nullptr, and this line could cause a segmentation fault.
I added a check to ensure the return value of getenv(name) is not null before attempting to dereference it. I also applied the same fix to the _wgetenv section that handles wide environment variables.

Please let me know if these fixes are correct or if there’s anything that needs to be improved.