### PR TITLE
double-check endian-ness in get_bit_at test

### DIFF
--- a/folly/lang/test/BitsTest.cpp
+++ b/folly/lang/test/BitsTest.cpp
@@ -606,6 +606,8 @@ TYPED_TEST(BitsAllUintsTest, GetBitAtLE) {
     return;
   }
 
+  static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__);
+
   {
     std::uint64_t in = folly::set_n_least_significant_bits(0UL, 64);
     const auto* ptr = reinterpret_cast<const T*>(&in);


### PR DESCRIPTION
Summary: To see what is causing this: https://github.com/facebook/folly/actions/runs/14405029016/job/40399391114 .

Differential Revision: D72977827


