### PR TITLE
Make exception_tracer work with libc++abi

### DIFF
--- a/folly/debugging/exception_tracer/CMakeLists.txt
+++ b/folly/debugging/exception_tracer/CMakeLists.txt
@@ -50,6 +50,7 @@ if (FOLLY_HAVE_ELF AND FOLLY_HAVE_DWARF)
 
   install(
     FILES
+      Compatibility.h
       ExceptionAbi.h
       ExceptionCounterLib.h
       ExceptionTracer.h

--- a/folly/debugging/exception_tracer/Compatibility.h
+++ b/folly/debugging/exception_tracer/Compatibility.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <version>
+
+#if (defined(__GLIBCXX__) || defined(_LIBCPP_VERSION))
+#define FOLLY_DETAIL_EXN_TRACER_CXX_STDLIB_COMPATIBLE 1
+#else
+#define FOLLY_DETAIL_EXN_TRACER_CXX_STDLIB_COMPATIBLE 0
+#endif // (defined(__GLIBCXX__) || defined(_LIBCPP_VERSION))
+
+#if (!defined(__FreeBSD__) && !_WIN32)
+#define FOLLY_DETAIL_EXN_TRACER_OS_CXX_ABI_COMPATIBLE 1
+#else
+#define FOLLY_DETAIL_EXN_TRACER_OS_CXX_ABI_COMPATIBLE 0
+#endif // (!defined(__FreeBSD__) && ! _WIN32)
+
+#if FOLLY_DETAIL_EXN_TRACER_CXX_STDLIB_COMPATIBLE && \
+    FOLLY_DETAIL_EXN_TRACER_OS_CXX_ABI_COMPATIBLE
+#define FOLLY_HAS_EXCEPTION_TRACER 1
+#else
+#define FOLLY_HAS_EXCEPTION_TRACER 0
+#endif // CXX_STDLIB_COMPATIBLE && OS_CXX_ABI_COMPATIBLE

--- a/folly/debugging/exception_tracer/ExceptionCounterLib.cpp
+++ b/folly/debugging/exception_tracer/ExceptionCounterLib.cpp
@@ -25,13 +25,14 @@
 #include <folly/hash/SpookyHashV2.h>
 #include <folly/synchronization/RWSpinLock.h>
 
+#include <folly/debugging/exception_tracer/Compatibility.h>
 #include <folly/debugging/exception_tracer/ExceptionTracerLib.h>
 #include <folly/debugging/exception_tracer/StackTrace.h>
 #include <folly/experimental/symbolizer/Symbolizer.h>
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if FOLLY_HAS_EXCEPTION_TRACER
 
 using namespace folly::exception_tracer;
 
@@ -145,6 +146,6 @@ Initializer initializer;
 
 } // namespace
 
-#endif // defined(__GLIBCXX__)
+#endif //  FOLLY_HAS_EXCEPTION_TRACER
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/ExceptionCounterLib.h
+++ b/folly/debugging/exception_tracer/ExceptionCounterLib.h
@@ -19,11 +19,12 @@
 #include <ostream>
 #include <vector>
 
+#include <folly/debugging/exception_tracer/Compatibility.h>
 #include <folly/debugging/exception_tracer/ExceptionTracer.h>
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if FOLLY_HAS_EXCEPTION_TRACER
 
 namespace folly {
 namespace exception_tracer {
@@ -46,6 +47,6 @@ std::ostream& operator<<(std::ostream& out, const ExceptionStats& stats);
 } // namespace exception_tracer
 } // namespace folly
 
-#endif // defined(__GLIBCXX__)
+#endif //  FOLLY_HAS_EXCEPTION_TRACER
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/ExceptionStackTraceLib.cpp
+++ b/folly/debugging/exception_tracer/ExceptionStackTraceLib.cpp
@@ -26,7 +26,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if FOLLY_HAS_EXCEPTION_TRACER
 
 using namespace folly::exception_tracer;
 
@@ -130,6 +130,6 @@ Initializer initializer;
 
 } // namespace
 
-#endif // defined(__GLIBCXX__)
+#endif //  FOLLY_HAS_EXCEPTION_TRACER
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/ExceptionTracer.cpp
+++ b/folly/debugging/exception_tracer/ExceptionTracer.cpp
@@ -35,7 +35,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if FOLLY_HAS_EXCEPTION_TRACER
 
 namespace {
 
@@ -240,6 +240,6 @@ void installHandlers() {
 } // namespace exception_tracer
 } // namespace folly
 
-#endif // defined(__GLIBCXX__)
+#endif //  FOLLY_HAS_EXCEPTION_TRACER
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/ExceptionTracerLib.h
+++ b/folly/debugging/exception_tracer/ExceptionTracerLib.h
@@ -19,7 +19,9 @@
 #include <exception>
 #include <typeinfo>
 
-#if defined(__GLIBCXX__)
+#include <folly/debugging/exception_tracer/Compatibility.h>
+
+#if FOLLY_HAS_EXCEPTION_TRACER
 
 namespace folly {
 namespace exception_tracer {
@@ -39,4 +41,4 @@ void registerRethrowExceptionCallback(RethrowExceptionSig& callback);
 } // namespace exception_tracer
 } // namespace folly
 
-#endif // defined(__GLIBCXX__)
+#endif //  FOLLY_HAS_EXCEPTION_TRACER

--- a/folly/debugging/exception_tracer/SmartExceptionStackTraceHooks.cpp
+++ b/folly/debugging/exception_tracer/SmartExceptionStackTraceHooks.cpp
@@ -20,7 +20,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if FOLLY_HAS_EXCEPTION_TRACER
 
 namespace folly::exception_tracer {
 
@@ -98,6 +98,6 @@ Initialize initialize;
 } // namespace
 } // namespace folly::exception_tracer
 
-#endif // defined(__GLIBCXX__)
+#endif //  FOLLY_HAS_EXCEPTION_TRACER
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/SmartExceptionTracer.cpp
+++ b/folly/debugging/exception_tracer/SmartExceptionTracer.cpp
@@ -29,7 +29,7 @@
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if FOLLY_HAS_EXCEPTION_TRACER
 
 namespace folly {
 namespace exception_tracer {
@@ -133,6 +133,6 @@ ExceptionInfo getAsyncTrace(const std::exception& ex) {
 } // namespace exception_tracer
 } // namespace folly
 
-#endif // defined(__GLIBCXX__)
+#endif //  FOLLY_HAS_EXCEPTION_TRACER
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF

--- a/folly/debugging/exception_tracer/SmartExceptionTracer.h
+++ b/folly/debugging/exception_tracer/SmartExceptionTracer.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <folly/ExceptionWrapper.h>
+#include <folly/debugging/exception_tracer/Compatibility.h>
 #include <folly/debugging/exception_tracer/ExceptionTracer.h>
 
 #if FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF
 
-#if defined(__GLIBCXX__)
+#if FOLLY_HAS_EXCEPTION_TRACER
 
 #define FOLLY_HAVE_SMART_EXCEPTION_TRACER 1
 
@@ -45,6 +46,6 @@ ExceptionInfo getAsyncTrace(const exception_wrapper& ew);
 
 } // namespace folly::exception_tracer
 
-#endif // defined(__GLIBCXX__)
+#endif //  FOLLY_HAS_EXCEPTION_TRACER
 
 #endif // FOLLY_HAVE_ELF && FOLLY_HAVE_DWARF


### PR DESCRIPTION
Summary:
The exception tracer is a facility we use to display backtraces when the program (or thread) dies with an exception. It also stores the stack trace during unwinding of the exception for future retrieval should the user desire. Originally, the full exception tracer was hooked  to work with only libstdc++'s ABI implementation called `libsupc++`. However, with a few adjustments, this can be made to work with `libc++abi` and potentially libcxxrt on FreeBSD too. 

There are two main changes to make exception tracer work with libc++ and libc++abi. 

1. We need to dlsym the mangled name for `std::rethrow_exception(std::exception_ptr)`. There's a difference between the two libraries. We rely on the std library macro (i.e. `__GLIBCXX__` or `_LIBCPP_VERSION`) to select which one. 
2. Patched `__cxa_exception` struct to include the fields to reflect the difference between the two libraries.

Differential Revision: D73237091


