### PR TITLE
Provide aliasing hint to the compiler

### DIFF
--- a/folly/io/IOBufQueue.h
+++ b/folly/io/IOBufQueue.h
@@ -21,6 +21,7 @@
 
 #include <folly/ScopeGuard.h>
 #include <folly/io/IOBuf.h>
+#include <folly/lang/Hint.h>
 
 namespace folly {
 
@@ -198,7 +199,9 @@ class IOBufQueue {
      */
     uint8_t* writableData() {
       dcheckIntegrity();
-      return data_.cachedRange.first;
+      uint8_t* const ptr = data_.cachedRange.first;
+      folly::compiler_may_unsafely_assume_separate_storage(this, ptr);
+      return ptr;
     }
 
     /**


### PR DESCRIPTION
Summary:
This change results in massive speedups on ProtocolBench. Prod canaries also gave some promising signals.

# x86 ProtocolBench
Benchmarks not included below were neutral or only small wins. See pastes for full results.

Before: full results (P1791766582)
```
CompactProtocol_write_MixedInt                            114.09ns     8.77M
CompactProtocol_write_LargeMixed                          526.47ns     1.90M
CompactProtocol_write_BigListBigInt                        34.63us    28.87K
CompactProtocol_write_BigListMixedInt                     824.45us     1.21K
```

After: full results (P1791763018)
Benchmarks not included below were neutral or only small wins. See pastes for full results.

Before: 
```
CompactProtocol_write_MixedInt                             47.03ns    21.26M
CompactProtocol_write_LargeMixed                          491.08ns     2.04M
CompactProtocol_write_BigListBigInt                        20.74us    48.22K
CompactProtocol_write_BigListMixedInt                     330.13us     3.03K
```

# aarch64 ProtocolBench
Benchmarks not included below were neutral or only small wins. See pastes for full results.

Before: full results (P1791766333)
```
CompactProtocol_write_MixedInt                             56.34ns    17.75M
CompactProtocol_write_BigListByte                          18.49us    54.08K
CompactProtocol_write_BigListBigInt                        24.08us    41.52K
CompactProtocol_write_BigListFloat                         18.45us    54.20K
CompactProtocol_write_BigListDouble                        19.07us    52.43K
CompactProtocol_write_BigListMixed                        185.41us     5.39K
CompactProtocol_write_BigListMixedInt                     479.46us     2.09K
CompactProtocol_write_LargeSetInt                         149.90ms      6.67
CompactProtocol_write_LargeUnorderedMapMixed               22.94ms     43.58
CompactProtocol_write_LargeSortedVecMapMixed               22.56ms     44.33
CompactProtocol_write_NestedMap                           541.29us     1.85K
CompactProtocol_write_SortedVecNestedMap                  548.71us     1.82K
```

After: full results (P1791763404)
```
CompactProtocol_write_MixedInt                             30.46ns    32.83M
CompactProtocol_write_BigListByte                           6.26us   159.84K
CompactProtocol_write_BigListBigInt                        19.06us    52.48K
CompactProtocol_write_BigListFloat                          6.25us   160.10K
CompactProtocol_write_BigListDouble                         6.56us   152.39K
CompactProtocol_write_BigListMixed                        173.73us     5.76K
CompactProtocol_write_BigListMixedInt                     229.13us     4.36K
CompactProtocol_write_LargeSetInt                         107.13ms      9.33
CompactProtocol_write_LargeUnorderedMapMixed               18.93ms     52.84
CompactProtocol_write_LargeSortedVecMapMixed               18.68ms     53.54
CompactProtocol_write_NestedMap                           419.08us     2.39K
CompactProtocol_write_SortedVecNestedMap                  412.94us     2.42K
```

Differential Revision: D73367438


