### PR TITLE
] std::ranges::enable_borrowed_range for folly::Range

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -56,6 +56,10 @@
 #include <string_view>
 #include <type_traits>
 
+#if defined(__cpp_lib_ranges)
+#include <ranges>
+#endif
+
 #if __has_include(<fmt/format.h>)
 #include <fmt/format.h>
 #endif
@@ -1781,3 +1785,8 @@ namespace ranges {
 template <class Iter>
 inline constexpr bool enable_view<::folly::Range<Iter>> = true;
 } // namespace ranges
+
+#if defined(__cpp_lib_ranges)
+template <typename T>
+constexpr bool std::ranges::enable_borrowed_range<folly::Range<T>> = true;
+#endif

--- a/folly/test/RangeTest.cpp
+++ b/folly/test/RangeTest.cpp
@@ -35,6 +35,8 @@
 #include <folly/portability/SysMman.h>
 #include <folly/portability/Unistd.h>
 
+#include <folly/container/span.h>
+
 #if __has_include(<range/v3/range/concepts.hpp>)
 #include <range/v3/range/concepts.hpp>
 
@@ -44,6 +46,10 @@ CPP_assert(ranges::range<folly::StringPiece>);
 CPP_assert(ranges::view_<folly::StringPiece>);
 #endif
 
+#if defined(__cpp_lib_ranges)
+#include <ranges>
+#endif
+
 using namespace folly;
 using namespace std;
 
@@ -51,6 +57,12 @@ static_assert(folly::detail::range_is_char_type_v_<char*>, "");
 static_assert(folly::detail::range_is_byte_type_v_<unsigned char*>, "");
 
 static_assert(std::is_same_v<char, typename Range<char*>::value_type>);
+
+static_assert(std::is_convertible_v<folly::Range<int*>, folly::span<int>>, "");
+#if defined(__cpp_lib_ranges)
+static_assert(std::ranges::borrowed_range<folly::Range<int*>>, "");
+static_assert(std::ranges::borrowed_range<folly::Range<const int*>>, "");
+#endif
 
 BOOST_CONCEPT_ASSERT((boost::RandomAccessRangeConcept<StringPiece>));
 


### PR DESCRIPTION
Summary: enable borrowed range is important because, for example, it enables an implicit conversion to a mutable span.

Differential Revision: D73584344


