### PR TITLE
add death-test for “create before registrationComplete()” guard

### DIFF
--- a/folly/test/SingletonTest.cpp
+++ b/folly/test/SingletonTest.cpp
@@ -1232,3 +1232,18 @@ auto cancelOnDestructionSingleton =
 TEST(Singleton, CancelOnDestruction) {
   cancelOnDestructionSingleton.try_get();
 }
+
+TEST(Singleton, CreationBeforeRegistrationCompleteAborts) {
+  struct Dummy {};
+  struct VaultTag {};
+  struct Tag {};
+
+  folly::SingletonVault* vault = folly::SingletonVault::singleton<VaultTag>();
+  std::ignore = vault;
+
+  static folly::Singleton<Dummy, Tag, VaultTag> lateSingleton;
+
+  EXPECT_DEATH(
+      { std::ignore = lateSingleton.try_get(); },
+      "singletonWarnCreateBeforeRegistrationCompleteAndAbort");
+}


### PR DESCRIPTION
Summary:
# Motivation
----------
We recently hit a production crash (SIGABRT) when an HHVM extension tried to
instantiate a `folly::Singleton` during process shutdown.  The root cause was
that the singleton’s first `try_get()` call happened **while the vault was still
in the *registration* phase**, triggering
`singletonWarnCreateBeforeRegistrationCompleteAndAbort()`.

Folly currently has no unit-test exercising that guard, so a future refactor
could silently weaken or remove the invariant without CI noticing.  This patch
adds a minimal, isolated death-test that locks the behaviour in.

# What the test does
------------------
1. Creates a *fresh* vault identified by a private `VaultTag`; a new vault starts
   in the **REGISTRATION** state.
2. Registers a dummy singleton `<Dummy, Tag, VaultTag>` against that vault.
3. Calls `try_get()` **before** `registrationComplete()` is invoked.
4. Uses `EXPECT_DEATH` to assert that the process aborts with
   `singletonWarnCreateBeforeRegistrationCompleteAndAbort`.

Differential Revision: D73976074


