### PR TITLE
Allow using system liboqs on Fedora

### DIFF
--- a/build/fbcode_builder/manifests/liboqs
+++ b/build/fbcode_builder/manifests/liboqs
@@ -14,3 +14,6 @@ OQS_MINIMAL_BUILD = KEM_kyber_512;KEM_kyber_768;KEM_kyber_1024;KEM_ml_kem_512;KE
 
 [dependencies]
 openssl
+
+[rpms.distro=fedora]
+liboqs-devel


### PR DESCRIPTION
Fedora 41 and 42 both package liboqs 0.12.0.