### PR TITLE
Remove use of unsupported std::shared_ptr::unique()

### DIFF
--- a/folly/fibers/AddTasks-inl.h
+++ b/folly/fibers/AddTasks-inl.h
@@ -31,7 +31,7 @@ inline bool TaskIterator<T>::hasCompleted() const {
 
 template <typename T>
 inline bool TaskIterator<T>::hasPending() const {
-  return !context_.unique();
+  return context_.use_count() > 1;
 }
 
 template <typename T>


### PR DESCRIPTION
libc++ 18 and newer gate this behind the
`_LIBCPP_ENABLE_CXX20_REMOVED_SHARED_PTR_UNIQUE` macro, since the feature was deprecated in C++17 and removed in C++20.

It's probably better to replace it with use_count() rather than using the macro.