### PR TITLE
Buck2/clean up misc bits

### DIFF
--- a/.buckconfig.d/common.buckconfig
+++ b/.buckconfig.d/common.buckconfig
@@ -1,12 +1,11 @@
 [cells]
 prelude = prelude
 none = none
-gh_bazel_skylib = gh_bazel_skylib
 
 [cell_aliases]
 config = prelude
 ovr_config = prelude
-bazel_skylib = gh_bazel_skylib
+bazel_skylib = gh_facebook_buck2_shims_meta
 buck = gh_facebook_buck2_shims_meta
 fbcode = gh_facebook_buck2_shims_meta
 fbcode_macros = gh_facebook_buck2_shims_meta
@@ -16,11 +15,6 @@ toolchains = gh_facebook_buck2_shims_meta
 
 [external_cells]
 prelude = bundled
-gh_bazel_skylib = git
-
-[external_cell_gh_bazel_skylib]
-git_origin = https://github.com/bazelbuild/bazel-skylib.git
-commit_hash = 223e4e945801dfbc0bfa31d0900196f5bb54b0fc
 
 [build]
 execution_platforms = prelude//platforms:default

--- a/folly/debugging/exception_tracer/BUCK
+++ b/folly/debugging/exception_tracer/BUCK
@@ -345,19 +345,18 @@ fbcode_target(
     headers = ["ExceptionTracerLib.h"],
     compiler_flags = selects.if_(
         LIBSTDCXX_BUCKIFIED_SELECTOR,
-        # @fb-only[end= ]: ["-DFOLLY_STATIC_LIBSTDCXX=1"],
+        ["-DFOLLY_STATIC_LIBSTDCXX=1"],
         [],
     ),
     exported_linker_flags = selects.if_(
         LIBSTDCXX_BUCKIFIED_SELECTOR,
-        # @lint-ignore-every BUCKFORMAT
-        # @fb-only: [
-            # @fb-only[end= ]: "-Wl,--wrap=__cxa_throw",
-            # @fb-only[end= ]: "-Wl,--wrap=__cxa_rethrow",
-            # @fb-only[end= ]: "-Wl,--wrap=__cxa_begin_catch",
-            # @fb-only[end= ]: "-Wl,--wrap=__cxa_end_catch",
-            # @fb-only[end= ]: "-Wl,--wrap=_ZSt17rethrow_exceptionNSt15__exception_ptr13exception_ptrE",
-        # @fb-only[end= ]: ],
+        [
+         "-Wl,--wrap=__cxa_throw",
+         "-Wl,--wrap=__cxa_rethrow",
+         "-Wl,--wrap=__cxa_begin_catch",
+         "-Wl,--wrap=__cxa_end_catch",
+         "-Wl,--wrap=_ZSt17rethrow_exceptionNSt15__exception_ptr13exception_ptrE",
+         ],
         [],
     ),
     labels = ["EXCLUDED_FROM_LINK_GROUPS"],

--- a/folly/docs/BUCK
+++ b/folly/docs/BUCK
@@ -1,4 +1,4 @@
-load("@fbcode//folly/docs:defs.bzl", "copy", "html")
+load("@fbsource//xplat/folly/docs:defs.bzl", "copy", "html")
 load("@fbcode_macros//build_defs:build_file_migration.bzl", "fbcode_target")
 
 #


### PR DESCRIPTION
1. Switch from bazel-skylib external cell back to our own fork
2. Clean up a `load()` to allow it to work with our shims
3. Uncomment some content from OSS