### PR TITLE
let test AsyncFileWriter.fork use HasSubstr

### DIFF
--- a/folly/logging/test/AsyncFileWriterTest.cpp
+++ b/folly/logging/test/AsyncFileWriterTest.cpp
@@ -77,6 +77,7 @@ using folly::test::TemporaryFile;
 using std::chrono::milliseconds;
 using std::chrono::steady_clock;
 using testing::ContainsRegex;
+using testing::HasSubstr;
 
 TEST(AsyncFileWriter, noMessages) {
   TemporaryFile tmpFile{"logging_test"};
@@ -719,10 +720,9 @@ TEST(AsyncFileWriter, fork) {
   // The log file should contain all of the messages we wrote, from both the
   // parent and child processes.
   for (size_t n = 0; n < numMessages; ++n) {
-    EXPECT_THAT(
-        data, ContainsRegex(folly::to<std::string>("prefork", n, "\n")));
-    EXPECT_THAT(data, ContainsRegex(folly::to<std::string>("parent", n, "\n")));
-    EXPECT_THAT(data, ContainsRegex(folly::to<std::string>("child", n, "\n")));
+    EXPECT_THAT(data, HasSubstr(folly::to<std::string>("prefork", n, "\n")));
+    EXPECT_THAT(data, HasSubstr(folly::to<std::string>("parent", n, "\n")));
+    EXPECT_THAT(data, HasSubstr(folly::to<std::string>("child", n, "\n")));
   }
 #else
   SKIP() << "pthread_atfork() is not supported on this platform";


### PR DESCRIPTION
Summary:
Let this test use `HasSubstr` v.s. `ContainsRegex` since the provided pattern is not even a regex - it's just a substring to search for.

The test is currently failing in the mac builds on github - perhaps this will help.

Differential Revision: D77421549


