### PR TITLE
fix uninitialized field in BufferedAtomic before C++20

### DIFF
--- a/folly/test/BufferedAtomic.h
+++ b/folly/test/BufferedAtomic.h
@@ -383,7 +383,7 @@ struct BufferedAtomic {
   }
 
   static std::unordered_map<const BufferedAtomic<T>*, RecordBuffer<T>> bufs;
-  mutable std::atomic<std::thread::id> prevUnguardedAccess;
+  mutable std::atomic<std::thread::id> prevUnguardedAccess{};
 };
 
 template <typename T>


### PR DESCRIPTION
Summary:
Prior to C++20, `std::atomic` default initialization is trivial. Since C++20, `std::atomic` default initialization is zeroing.

`BufferedAtomic` has a data member of type `std::atomic<std::thread::id>`, but it was not explicitly initialized - so its value prior to C++20 could be anything.

This bug be causing test failures in mac builds on github. This diff may fix that problem.

Differential Revision: D77458631


