### PR TITLE
fix incorrect shift in get_bit_at test under MSVC

### DIFF
--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -342,7 +342,9 @@
 #define FOLLY_PUSH_WARNING __pragma(warning(push))
 #define FOLLY_POP_WARNING __pragma(warning(pop))
 // Disable the GCC warnings.
+#define FOLLY_GNU_ENABLE_WARNING(warningName)
 #define FOLLY_GNU_DISABLE_WARNING(warningName)
+#define FOLLY_GNU_ENABLE_ERROR(warningName)
 #define FOLLY_GCC_DISABLE_WARNING(warningName)
 #define FOLLY_CLANG_DISABLE_WARNING(warningName)
 #define FOLLY_MSVC_DISABLE_WARNING(warningNumber) \
@@ -350,7 +352,9 @@
 #else
 #define FOLLY_PUSH_WARNING
 #define FOLLY_POP_WARNING
+#define FOLLY_GNU_ENABLE_WARNING(warningName)
 #define FOLLY_GNU_DISABLE_WARNING(warningName)
+#define FOLLY_GNU_ENABLE_ERROR(warningName)
 #define FOLLY_GCC_DISABLE_WARNING(warningName)
 #define FOLLY_CLANG_DISABLE_WARNING(warningName)
 #define FOLLY_MSVC_DISABLE_WARNING(warningNumber)

--- a/folly/lang/test/BitsTest.cpp
+++ b/folly/lang/test/BitsTest.cpp
@@ -619,7 +619,7 @@ TYPED_TEST(BitsAllUintsTest, GetBitAt) {
   for (std::size_t i = 0; i != kBitSize; ++i) {
     in[1] = T{0};
     in[2] = kOnes;
-    T bit = static_cast<T>(1UL << i);
+    T bit = T(T{1} << i);
     in[1] = in[1] | bit;
     in[2] = in[2] ^ bit;
     ASSERT_TRUE(folly::get_bit_at(in, kBitSize + i)) << "i=" << i;


### PR DESCRIPTION
Summary:
The intention is to create a value of type `T` with a single bit set, but `1UL << i` is incorrect. Rather, `T(T{1} << i)` must be used.

Shifts are permitted only by less than the width of the type. `1UL << 32` is valid only if `1UL` is 64 bits. But in the MSVC builds on github, `1UL` is 32 bits, making the shift invalid, and causing the test to fail.

Fixes this test failure under MSVC:
```
[ RUN      ] BitsAllUintsTest/3.GetBitAt
D:\a\folly\folly\folly\lang\test\BitsTest.cpp(625): error: Value of: folly::get_bit_at(in, kBitSize + i)
  Actual: false
Expected: true
i=32
[  FAILED  ] BitsAllUintsTest/3.GetBitAt, where TypeParam = unsigned __int64 (0 ms)
```

Differential Revision: D77464671


