### PR TITLE
Implement cdf for TDigest

### DIFF
--- a/folly/stats/BUCK
+++ b/folly/stats/BUCK
@@ -112,6 +112,7 @@ fbcode_target(
     deps = [
         "//folly:overload",
         "//folly/algorithm:binary_heap",
+        "//folly/lang:exception",
         "//folly/memory:malloc",
         "//folly/stats/detail:double_radix_sort",
     ],

--- a/folly/stats/TDigest.h
+++ b/folly/stats/TDigest.h
@@ -126,6 +126,13 @@ class TDigest {
    */
   double estimateQuantile(double q) const;
 
+  /*
+   * Returns the estimate of the CDF at the given input.
+   * Raise an invalid_argument exception if the input is NaN or infinite.
+   * Returns NaN if the centroids are emtpy.
+   */
+  double estimateCdf(double x) const;
+
   double mean() const { return count_ > 0 ? sum_ / count_ : 0; }
 
   double sum() const { return sum_; }


### PR DESCRIPTION
Summary:
This commit implements the CDF (aka inverse of the quantile) to TDigest.

This follows from the reference implementation from
https://github.com/tdunning/t-digest/blob/main/core/src/main/java/com/tdunning/math/stats/MergingDigest.java#L560

Reviewed By: skrueger

Differential Revision: D76039753


