### PR TITLE
Python related cmake changes to fix some configuration/installation issues on Linux 

### DIFF
--- a/build/.cmake/api/v1/query/client-neocmake/query.json
+++ b/build/.cmake/api/v1/query/client-neocmake/query.json
@@ -1,0 +1,1 @@
+{"requests":[{"kind":"codemodel","version":[{"major":2,"minor":8}]},{"kind":"configureLog","version":[{"major":1,"minor":0}]},{"kind":"cache","version":[{"major":2,"minor":0}]},{"kind":"cmakeFiles","version":[{"major":1,"minor":1}]},{"kind":"toolchains","version":[{"major":1,"minor":0}]}]}

--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+find_package(Python3 REQUIRED COMPONENTS Development)
+
 add_library(
     follybenchmark
     Benchmark.cpp
@@ -98,6 +100,8 @@ if (PYTHON_EXTENSIONS)
       "${_cybld}/folly/python/iobuf_api.h"
   )
 
+find_package(Python3 REQUIRED COMPONENTS Development)
+
   add_library(
     folly_python_cpp
       python/error.cpp
@@ -105,6 +109,8 @@ if (PYTHON_EXTENSIONS)
       python/iobuf.cpp
   )
 
+target_include_directories(folly_python_cpp PRIVATE ${Python3_INCLUDE_DIRS})
+target_link_libraries(folly_python_cpp PRIVATE Python3::Python)
   add_dependencies(folly_python_cpp folly_python_bindings create_post_binding_symlink)
   set_property(TARGET folly_python_cpp PROPERTY VERSION ${PACKAGE_VERSION})
   target_compile_definitions(folly_python_cpp PRIVATE BOOST_NO_AUTO_PTR)

--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -86,18 +86,11 @@ if (PYTHON_EXTENSIONS)
       python3 ${CMAKE_CURRENT_SOURCE_DIR}/python/setup.py
       build_ext -f ${incs} ${libs}
     BYPRODUCTS
-      ${_cybld}/folly/executor_api.h
       ${_cybld}/folly/iobuf_api.h
     WORKING_DIRECTORY ${_cybld}
   )
 
   add_custom_target(create_post_binding_symlink ALL)
-  add_custom_command(TARGET create_post_binding_symlink
-    COMMAND
-      ${CMAKE_COMMAND} -E create_symlink
-      "${_cybld}/folly/executor_api.h"
-      "${_cybld}/folly/python/executor_api.h"
-  )
   add_custom_command(TARGET create_post_binding_symlink
     COMMAND
       ${CMAKE_COMMAND} -E create_symlink
@@ -143,7 +136,6 @@ if (PYTHON_EXTENSIONS)
 
   install(
     FILES
-      ${_cybld}/folly/executor_api.h
       ${_cybld}/folly/iobuf_api.h
     DESTINATION ${INCLUDE_INSTALL_DIR}/folly/python
     COMPONENT dev

--- a/folly/python/executor.pyx
+++ b/folly/python/executor.pyx
@@ -106,7 +106,7 @@ cdef class IocpQueue(dict):
 # get_executor() should always be run from a running eventloop in a single
 # diff. But ultimately we will want to remove this function and
 # go back to just get_executor() that only binds to a running loop.
-cdef cAsyncioExecutor* get_running_executor(bint running):
+cdef cAsyncioExecutor* get_running_executor(bint running) noexcept:
     return get_running_executor_drive(running, False)
 
 
@@ -137,7 +137,7 @@ cdef cAsyncioExecutor* get_running_executor_drive(
     return executor._executor
 
 
-cdef int set_executor_for_loop(loop, cAsyncioExecutor* c_executor):
+cdef int set_executor_for_loop(loop, cAsyncioExecutor* c_executor) noexcept:
     if c_executor == NULL:
         del loop_to_q[loop]
         return 0


### PR DESCRIPTION
Issues addressed in these commits:

commit 1 - 'advoid trying to install deprecated executor_api.h'
https://github.com/facebook/folly/issues/2453 - executor_api.h seems to have been removed during the BUCK Weak Python adjustments that was introduced in https://github.com/facebook/folly/commit/d136fac18aa1dfb07779d8e40b4ffe367b8f7c1a

commit 2 - 'add noexcept to avoid compiler complaints'
I was not able to build with Gcc 15.1.1/Cython 3.1.2 without introducing noexcept to these functions - I tried -fpermissive as well as cxxstd 21, 20, and 17 unsuccessfully.

commit 3 - 'help cmake find Python.h'
Build failed due to missing Python.h - I did not dig too deep into this, but it seems to be resolved by forcing cmake to find python at these locations
