### PR TITLE
Revert "allow fmt::format with StringPiece format-string"

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -714,15 +714,6 @@ class Range {
     return Tgt(b_, walk_size());
   }
 
-#if FMT_VERSION
-  template <
-      typename IterType = Iter,
-      std::enable_if_t<detail::range_is_char_type_v_<IterType>, int> = 0>
-  constexpr operator fmt::basic_string_view<value_type>() const noexcept {
-    return _t<StringViewType<value_type>>(*this);
-  }
-#endif
-
   /// explicit non-operator conversion to any compatible type
   ///
   /// A compatible type is one which is constructible with an iterator and a

--- a/folly/test/RangeTest.cpp
+++ b/folly/test/RangeTest.cpp
@@ -1761,12 +1761,6 @@ TEST(StringPiece, Format) {
   EXPECT_EQ("  foo", fmt::format("{:>5}", folly::StringPiece("foo")));
 }
 
-TEST(StringPiece, FormatInFormatString) {
-  EXPECT_EQ(
-      "  foo",
-      fmt::format(folly::StringPiece("{:>5}"), folly::StringPiece("foo")));
-}
-
 namespace {
 
 // Range with non-pod value type should not cause compile errors.


### PR DESCRIPTION

This reverts commit f909b69c0c38f5f5e55206d89d07e951b10559ed.
