### PR TITLE
fix StringPiece conversion to fmt::format_string

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -714,7 +714,7 @@ class Range {
     return Tgt(b_, walk_size());
   }
 
-#if FMT_VERSION
+#if FMT_VERSION < 100000
   template <
       typename IterType = Iter,
       std::enable_if_t<detail::range_is_char_type_v_<IterType>, int> = 0>


### PR DESCRIPTION
Summary:
Only define conversion `StringPiece::operator fmt::string_view` for older versions of `fmt`.

Fixes: https://github.com/facebook/folly/issues/2468.

Differential Revision: D77799250


