### PR TITLE
Fix GitHub issue #2487: Add missing <stdexcept> include

### DIFF
--- a/folly/hash/Checksum.cpp
+++ b/folly/hash/Checksum.cpp
@@ -17,6 +17,7 @@
 #include <folly/hash/Checksum.h>
 
 #include <algorithm>
+#include <stdexcept>
 
 #include <boost/crc.hpp>
 


### PR DESCRIPTION
- Add explicit #include <stdexcept> to folly/hash/Checksum.cpp
- Fixes compilation error: 'runtime_error' is not a member of 'std'
- Issue occurs in fallback implementation path when neither SSE4.2 nor ARM CRC32 are available
- Resolves platform-specific compilation failures on RedHat 8 and other systems


FYI, I used copilot to help me identify the root cause, even tho the solution was already in the issue please see #2487 for more information. The AI was used to understand the underlying issue, and did not generate any code. 