### PR TITLE
feat(folly): Add macros for RISC-V Vector (RVV) version detection

### DIFF
--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -376,6 +376,19 @@ constexpr auto kHasWeakSymbols = false;
 #define FOLLY_SSE_PREREQ(major, minor) \
   (FOLLY_SSE > major || FOLLY_SSE == major && FOLLY_SSE_MINOR >= minor)
 
+#ifndef FOLLY_RVV
+#if defined(__riscv_v)
+  #define FOLLY_RVV       (__riscv_v / 1000000)
+  #define FOLLY_RVV_MINOR ((__riscv_v / 1000) % 1000)
+#else
+  #define FOLLY_RVV 0
+  #define FOLLY_RVV_MINOR 0
+#endif
+#endif
+
+#define FOLLY_RVV_PREREQ(major, minor) \
+  (FOLLY_RVV > major || (FOLLY_RVV == major && FOLLY_RVV_MINOR >= minor))
+
 #ifndef FOLLY_NEON
 #if (defined(__ARM_NEON) || defined(__ARM_NEON__)) && !defined(__CUDACC__)
 #define FOLLY_NEON 1


### PR DESCRIPTION
This commit introduces a set of preprocessor macros to detect the version of the RISC-V Vector (RVV) extension. This provides a standardized way to write code that conditionally compiles based on the availability and version of RVV support.

The new macros are:
- FOLLY_RVV: Defines the major version number of the RVV extension.
- FOLLY_RVV_MINOR: Defines the minor version number of the RVV extension.
- FOLLY_RVV_PREREQ(major, minor): A utility macro to check if the current RVV version meets a minimum requirement.

These macros parse the __riscv_v predefined macro, if it exists. If the compiler does not support RVV or the extension is not enabled, FOLLY_RVV and FOLLY_RVV_MINOR default to 0, ensuring backward compatibility.

This change enables future development of RVV-specific optimizations within Folly, improving performance and compatibility on the RISC-V platform.