### PR TITLE
Test folly sync'd to PR without -latomic flag

### DIFF
--- a/.buckconfig.d/external_cells/facebook/buck2-shims-meta/external_cell.buckconfig
+++ b/.buckconfig.d/external_cells/facebook/buck2-shims-meta/external_cell.buckconfig
@@ -6,4 +6,4 @@ gh_facebook_buck2_shims_meta = git
 
 [external_cell_gh_facebook_buck2_shims_meta]
 git_origin = https://github.com/facebook/buck2-shims-meta.git
-commit_hash = 407c8cd94c270c460df5889f9917ac435859f461
+commit_hash = 753c4c81efa8ec08abebe1f992c4ef0bb7fe4c6d


### PR DESCRIPTION
Summary:
Commit is from https://github.com/facebook/buck2-shims-meta/pull/15

Rollback Plan:

Differential Revision: D81727170


