### PR TITLE
fix(folly): Replace __type_pack_element in ForeachTest.cpp for GCC 14 Compatibility

### DIFF
--- a/folly/container/test/ForeachTest.cpp
+++ b/folly/container/test/ForeachTest.cpp
@@ -314,8 +314,8 @@ TEST(ForEach, FetchTestPreferIterator) {
 template <typename...>
 struct LargeTuple {};
 template <size_t I, typename... T>
-type_pack_element_t<I, T...>& get(LargeTuple<T...>&) {
-  static type_pack_element_t<I, T...> elem;
+std::tuple_element_t<I, std::tuple<T...>>& get(LargeTuple<T...>&) {
+  static std::tuple_element_t<I, std::tuple<T...>> elem;
   return elem;
 }
 namespace std {


### PR DESCRIPTION
This pull request addresses a build failure in folly/container/test/ForeachTest.cpp when compiling with GCC 14. The error is due to the use of the compiler builtin __type_pack_element in function signatures, which is no longer permitted.
The fix replaces the problematic use of type_pack_element_t with the standard library equivalent, std::tuple_element_t. This change ensures that the test suite remains compatible with the latest compiler versions without altering the logic of the tests.