### PR TITLE
fix(oss): explicitly enable coroutine support on g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,12 @@ if(NOT CMAKE_CXX_STANDARD)
   message(STATUS "setting C++ standard to C++${CMAKE_CXX_STANDARD}")
 endif()
 
+# Explicitly enable coroutine support, since GCC does not enable it
+# by default when targeting C++17/20.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>)
+endif()
+
 if(NOT DEFINED IS_X86_64_ARCH AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|AMD64")
   set(IS_X86_64_ARCH TRUE)
 else()


### PR DESCRIPTION
g++ doesn't enable coroutines by default and some upcoming changes require them. This change adds the necessary compiler flag on the open source build. The code here is brought over from fbthrift:

https://github.com/facebook/fbthrift/blob/main/CMakeLists.txt#L71-L75

Tested by including folly in a sapling build with PYTHON_EXTENSIONS enabled.