### PR TITLE
fix(oss): Make ExceptionWrapper explicitly formattable

### DIFF
--- a/folly/ExceptionWrapper-inl.h
+++ b/folly/ExceptionWrapper-inl.h
@@ -184,6 +184,19 @@ inline folly::fbstring exception_wrapper::class_name() const {
   return !*this ? "" : !ti ? "<unknown>" : folly::demangle(*ti);
 }
 
+template <>
+struct fmt::formatter<folly::exception_wrapper>
+    : formatter<std::string_view> {
+  template <typename Context>
+  auto format(const folly::exception_wrapper& ew, Context& ctx) const {
+    if (auto e = ew.get_exception()) {
+      return formatter<std::string_view>::format(class_name() + ": " + e->what(), ctx);
+    } else {
+      return formatter<std::string_view>::format(class_name() + ": <unknown>", ctx);
+    }
+  }
+};
+
 template <class Ex>
 inline bool exception_wrapper::is_compatible_with() const noexcept {
   return exception_ptr_get_object<Ex>(ptr_);


### PR DESCRIPTION
In OSS, glog + fmt requires enum classes to be explicitly formattable. (Internal tooling automagically does this.)

This fixes a build error in the OSS build of sapling:
```
| In file included from /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/fmt-D8kIIbuH_WwNugCsuzfJISa4iK0ETp73FQx_CYqwA_s/include/fmt/format.h:41,
|                  from /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/folly/include/folly/lang/Exception.h:27,
|                  from /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/folly/include/folly/Optional.h:74,
|                  from /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/folly/include/folly/futures/Future.h:27,
|                  from /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/edencommon/include/eden/common/utils/ImmediateFuture.h:10,
|                  from /Users/ben/oss/sapling/eden/fs/inodes/CheckoutAction.h:13,
|                  from /Users/ben/oss/sapling/eden/fs/inodes/CheckoutAction.cpp:8:
| /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/fmt-D8kIIbuH_WwNugCsuzfJISa4iK0ETp73FQx_CYqwA_s/include/fmt/base.h: In instantiation of ‘constexpr fmt::v11::detail::value<Context> fmt::v11::detail::make_arg(T&) [with bool PACKED = true; Context = fmt::v11::context; T = const folly::exception_wrapper; typename std::enable_if<PACKED, int>::type <anonymous> = 0]’:
| /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/fmt-D8kIIbuH_WwNugCsuzfJISa4iK0ETp73FQx_CYqwA_s/include/fmt/base.h:2018:74:   required from ‘constexpr fmt::v11::detail::format_arg_store<Context, NUM_ARGS, 0, DESC> fmt::v11::make_format_args(T& ...) [with Context = fmt::v11::context; T = {const folly::Range<const char*>, const folly::exception_wrapper}; long unsigned int NUM_ARGS = 2; long unsigned int NUM_NAMED_ARGS = 0; long long unsigned int DESC = 253; typename std::enable_if<(NUM_NAMED_ARGS == 0), int>::type <anonymous> = 0]’
| /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/folly/include/folly/logging/LogStreamProcessor.h:371:52:   required from ‘std::string folly::LogStreamProcessor::formatLogString(folly::StringPiece, const Args& ...) [with Args = {folly::Range<const char*>, folly::exception_wrapper}; std::string = std::__cxx11::basic_string<char>; folly::StringPiece = folly::Range<const char*>]’
| /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/folly/include/folly/logging/LogStreamProcessor.h:255:28:   required from ‘folly::LogStreamProcessor::LogStreamProcessor(folly::XlogFileScopeInfo*, folly::LogLevel, folly::StringPiece, bool, folly::StringPiece, unsigned int, folly::StringPiece, folly::LogStreamProcessor::FormatType, folly::StringPiece, Args&& ...) [with Args = {folly::Range<const char*>&, folly::exception_wrapper&}; folly::StringPiece = folly::Range<const char*>]’
| /Users/ben/oss/sapling/eden/fs/inodes/CheckoutAction.cpp:190:3:   required from here
| /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/fmt-D8kIIbuH_WwNugCsuzfJISa4iK0ETp73FQx_CYqwA_s/include/fmt/base.h:1641:63: error: ‘fmt::v11::detail::type_is_unformattable_for<const folly::exception_wrapper, char> _’ has incomplete type
|  1641 |     type_is_unformattable_for<T, typename Context::char_type> _;
|       |                                                               ^
| /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/fmt-D8kIIbuH_WwNugCsuzfJISa4iK0ETp73FQx_CYqwA_s/include/fmt/base.h:1644:7: error: static assertion failed: Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt
|  1644 |       formattable,
|       |       ^~~~~~~~~~~
| /tmp/fbcode_builder_getdeps-ZUsersZbenZossZsaplingZbuildZfbcode_builder-root/installed/fmt-D8kIIbuH_WwNugCsuzfJISa4iK0ETp73FQx_CYqwA_s/include/fmt/base.h:1644:7: note: ‘formattable’ evaluates to false
```