### PR TITLE
Fix Subprocess.cpp with clang + _FORTIFY_SOURCE on glibc >= 2.40

### DIFF
--- a/folly/Subprocess.cpp
+++ b/folly/Subprocess.cpp
@@ -145,6 +145,11 @@ static Ret subprocess_libc_load(
 #define FOLLY_DETAIL_SUBPROCESS_LIBC_X_OPEN(X) \
   X(open, __open_real)                         \
   X(openat, __openat_real)
+#elif defined(_FORTIFY_SOURCE) && defined(__clang__) && (__GLIBC__ > 2 || __GLIBC__ == 2 && __GLIBC_MINOR__ >= 40)
+// FORTIFY_SOURCE overloads openat() on glibc >=2.40, so pick our overload explicitly.
+#define FOLLY_DETAIL_SUBPROCESS_LIBC_X_OPEN(X) \
+  X(open, open)                                \
+  X(openat, __openat_2)
 #else
 #define FOLLY_DETAIL_SUBPROCESS_LIBC_X_OPEN(X) \
   X(open, open)                                \


### PR DESCRIPTION
On glibc >= 2.40, _FORTIFY_SOURCE overloads openat() when building with clang, causing the `decltype` call in Subprocess.cpp to fail since the target becomes ambiguous. So, explicitly specify our overload of choice in this case.

Reproduce/test by setting `CMAKE_CXX_FLAGS=-D_FORTIFY_SOURCE=3 -DCMAKE_CXX_COMPILER=clang++`.