### PR TITLE
Change HazptrHoler try_protect  memory fence from light to heavy

### DIFF
--- a/folly/synchronization/HazptrHolder.h
+++ b/folly/synchronization/HazptrHolder.h
@@ -119,7 +119,7 @@ class hazptr_holder {
        for stealing bits of the pointer word */
     auto p = ptr;
     reset_protection(f(p));
-    /*** Full fence ***/ folly::asymmetric_thread_fence_light(
+    /*** Full fence ***/ folly::asymmetric_thread_fence_heavy(
         std::memory_order_seq_cst);
     ptr = src.load(std::memory_order_acquire);
     if (FOLLY_UNLIKELY(p != ptr)) {


### PR DESCRIPTION
The protected pointer placed in hprec_ (`store`) should not be reordered after to read hazptr_obj (`load`). `folly::asymmetric_thread_fence_light` on Linux only prevents compiler reordering, but cannot prevent CPU reordering (x86 allows `store-load` reorder). 

Therefore the load operation may be executed first but the protected pointer has not yet placed to hprec_, if there some other threads try to retire this `hazptr`, it might be success.