### PR TITLE
remove boost.system from folly-config.cmake.in

### DIFF
--- a/CMake/folly-config.cmake.in
+++ b/CMake/folly-config.cmake.in
@@ -32,15 +32,13 @@ set(FOLLY_LIBRARIES Folly::folly)
 find_dependency(fmt)
 
 set(Boost_USE_STATIC_LIBS "@FOLLY_BOOST_LINK_STATIC@")
-find_dependency(Boost 1.51.0 MODULE
+find_package(Boost 1.69.0 REQUIRED
   COMPONENTS
     context
     filesystem
     program_options
     regex
-    system
     thread
-  REQUIRED
 )
 
 if (NOT folly_FIND_QUIETLY)

--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -35,7 +35,7 @@ else()
 endif()
 set(Boost_USE_STATIC_LIBS "${FOLLY_BOOST_LINK_STATIC}")
 
-find_package(Boost 1.51.0 REQUIRED
+find_package(Boost 1.69.0 REQUIRED
   COMPONENTS
     context
     filesystem


### PR DESCRIPTION
Summary: As in title

Differential Revision: D84936796


