### PR TITLE
Fix asan check in UninitializedMemoryHacks.h

### DIFF
--- a/folly/memory/UninitializedMemoryHacks.h
+++ b/folly/memory/UninitializedMemoryHacks.h
@@ -336,15 +336,7 @@ void unsafeVectorSetLargerSize(std::vector<T>& v, std::size_t n) {
   // enabled we need to call the appropriate annotation functions in order to
   // stop ASAN from reporting false positives. When ASAN is disabled, the
   // annotation function is a no-op.
-#if defined(_LIBCPP_HAS_ASAN)
-#define FOLLY_ASAN_ANNOTATE_CONTIGUOUS_CONTAINER _LIBCPP_HAS_ASAN
-#elif defined(_LIBCPP_HAS_NO_ASAN)
-#define FOLLY_ASAN_ANNOTATE_CONTIGUOUS_CONTAINER 0
-#else
-#define FOLLY_ASAN_ANNOTATE_CONTIGUOUS_CONTAINER 1
-#endif
-
-#if FOLLY_ASAN_ANNOTATE_CONTIGUOUS_CONTAINER
+#if __has_feature(address_sanitizer)
   __sanitizer_annotate_contiguous_container(
       v.data(), v.data() + v.capacity(), v.data() + s, v.data() + n);
 #endif


### PR DESCRIPTION
libcxx removed `_LIBCPP_HAS_ASAN`/`_LIBCPP_HAS_NO_ASAN` macro in favor simple feature test for sanitizer. See: https://github.com/llvm/llvm-project/commit/040e9e02ccbf69bebd293a4c389948d7ecbc7bd9