### PR TITLE
Only use acq ordering for MicroSpinLock locking

### DIFF
--- a/folly/synchronization/MicroSpinLock.h
+++ b/folly/synchronization/MicroSpinLock.h
@@ -68,7 +68,7 @@ struct MicroSpinLock {
   void init() noexcept { payload()->store(FREE); }
 
   bool try_lock() noexcept {
-    bool ret = xchg(LOCKED) == FREE;
+    bool ret = xchg_acq(LOCKED) == FREE;
     annotate_rwlock_try_acquired(
         this, annotate_rwlock_level::wrlock, ret, __FILE__, __LINE__);
     return ret;
@@ -76,7 +76,7 @@ struct MicroSpinLock {
 
   void lock() noexcept {
     detail::Sleeper sleeper;
-    while (xchg(LOCKED) != FREE) {
+    while (xchg_acq(LOCKED) != FREE) {
       do {
         sleeper.wait();
       } while (payload()->load(std::memory_order_relaxed) == LOCKED);
@@ -98,9 +98,9 @@ struct MicroSpinLock {
     return reinterpret_cast<std::atomic<uint8_t>*>(&this->lock_);
   }
 
-  uint8_t xchg(uint8_t newVal) noexcept {
+  uint8_t xchg_acq(uint8_t newVal) noexcept {
     return std::atomic_exchange_explicit(
-        payload(), newVal, std::memory_order_acq_rel);
+        payload(), newVal, std::memory_order_acquire);
   }
 };
 static_assert(


### PR DESCRIPTION
Only acquire ordering is required here, not acq_rel. Fixes https://github.com/facebook/folly/issues/2389.