### PR TITLE
add "8192_to_32768" to memcpy benchmark

### DIFF
--- a/folly/test/MemcpyBenchmark.cpp
+++ b/folly/test/MemcpyBenchmark.cpp
@@ -134,6 +134,7 @@ BENCH_BOTH(16, 32, true, HOT)
 BENCH_BOTH(32, 256, true, HOT)
 BENCH_BOTH(256, 1024, true, HOT)
 BENCH_BOTH(1024, 8192, true, HOT)
+BENCH_BOTH(8192, 32768, true, HOT)
 
 BENCHMARK_DRAW_LINE();
 BENCH_BOTH(0, 7, false, COLD)
@@ -150,6 +151,7 @@ BENCH_BOTH(16, 32, false, COLD)
 BENCH_BOTH(32, 256, false, COLD)
 BENCH_BOTH(256, 1024, false, COLD)
 BENCH_BOTH(1024, 8192, false, COLD)
+BENCH_BOTH(8192, 32768, false, COLD)
 
 static inline void* ptr_bytewise_arith(void* p, ptrdiff_t diff) noexcept {
   auto addr = reinterpret_cast<uint8_t*>(p);


### PR DESCRIPTION
Summary: as titled. This way it the ranges of `0_to_xxx` and `xxx_to_yyy` will be aligned.

Differential Revision: D88103518


