### PR TITLE
Fix type casting for size parameters in F14Table methods

### DIFF
--- a/folly/container/detail/F14Table.h
+++ b/folly/container/detail/F14Table.h
@@ -2559,9 +2559,9 @@ class F14Table : public Policy {
     auto origSize = size();
     auto origCapacity = bucket_count();
     if (willReset) {
-      this->beforeReset(origSize, origCapacity);
+      this->beforeReset(static_cast<std::size_t>(origSize), origCapacity);
     } else {
-      this->beforeClear(origSize, origCapacity);
+      this->beforeClear(static_cast<std::size_t>(origSize), origCapacity);
     }
 
     if (!empty()) {
@@ -2604,9 +2604,10 @@ class F14Table : public Policy {
       chunks_ = Chunk::getSomeEmptyInstance();
       sizeAndChunkShiftAndPackedBegin_.setChunkCount(1);
 
-      this->afterReset(origSize, origCapacity, rawAllocation, rawSize);
+      this->afterReset(
+          static_cast<std::size_t>(origSize), origCapacity, rawAllocation, rawSize);
     } else {
-      this->afterClear(origSize, origCapacity);
+      this->afterClear(static_cast<std::size_t>(origSize), origCapacity);
     }
   }
 


### PR DESCRIPTION
In React Native Windows, we are compiling folly using MSVC and we are facing some warning.
This change will fix that.

<img width="1946" height="397" alt="image" src="https://github.com/user-attachments/assets/b2a712bd-d60e-44b4-940a-0fb4791875e7" />
