### PR TITLE
fix intermittent failure in HeapVectorTypes.SimpleSetTest

### DIFF
--- a/folly/container/test/heap_vector_types_test.cpp
+++ b/folly/container/test/heap_vector_types_test.cpp
@@ -171,8 +171,12 @@ TEST(HeapVectorTypes, SimpleSetTest) {
   EXPECT_TRUE(s == s2);
 
   auto it = s2.lower_bound(32);
-  if (*it == 32) {
-    s2.erase(it);
+  if (it != s2.end()) {
+    if (*it == 32) {
+      s2.erase(it);
+    } else {
+      s2.erase(32);
+    }
     it = s2.lower_bound(32);
   }
   check_invariant(s2);


### PR DESCRIPTION
Summary:
Fix intermittent failure in HeapVectorTypes.SimpleSetTest.  When 32 isn’t present and all elements are <32, lower_bound(32) legitimately returns end(). The test immediately did if (*it == 32), which dereferences an end iterator, causing UB.

Added a guard it == s2.end() before dereferencing.

There was also flakiness if 32 is present and if s2.lower_bound(32); returned a lower value than 32 as then 32 not erased.  Fixed by explicity erasing 32 before insert

Differential Revision: D88592733


