### PR TITLE
Break out of `epoll_wait` when adding loop callbacks during event loop

### DIFF
--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -851,6 +851,21 @@ void EventBase::terminateLoopSoon() {
   queue_->putMessage([] {});
 }
 
+void EventBase::addLoopCallback(LoopCallback& callback, bool thisIteration) {
+  if (runOnceCallbacks_ != nullptr && thisIteration) {
+    runOnceCallbacks_->push_back(callback);
+  } else {
+    loopCallbacks_.push_back(callback);
+    // If we're adding to loopCallbacks_ while the loop is running (but not
+    // inside runLoopCallbacks), we need to break out of eb_event_base_loop()
+    // so the callback can be processed promptly. Otherwise the loop may be
+    // blocked in epoll_wait and won't process the callback until it times out.
+    if (isRunning()) {
+      evb_->eb_event_base_loopbreak();
+    }
+  }
+}
+
 void EventBase::runInLoop(
     LoopCallback* callback,
     bool thisIteration,
@@ -858,22 +873,14 @@ void EventBase::runInLoop(
   dcheckIsInEventBaseThread();
   callback->cancelLoopCallback();
   callback->context_ = std::move(rctx);
-  if (runOnceCallbacks_ != nullptr && thisIteration) {
-    runOnceCallbacks_->push_back(*callback);
-  } else {
-    loopCallbacks_.push_back(*callback);
-  }
+  addLoopCallback(*callback, thisIteration);
 }
 
 void EventBase::runInLoop(Func cob, bool thisIteration) {
   dcheckIsInEventBaseThread();
   auto wrapper = new FunctionLoopCallback(std::move(cob));
   wrapper->context_ = RequestContext::saveContext();
-  if (runOnceCallbacks_ != nullptr && thisIteration) {
-    runOnceCallbacks_->push_back(*wrapper);
-  } else {
-    loopCallbacks_.push_back(*wrapper);
-  }
+  addLoopCallback(*wrapper, thisIteration);
 }
 
 void EventBase::runOnDestruction(OnDestructionCallback& callback) {

--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -1047,6 +1047,10 @@ class EventBase
       LoopCallbackList& currentCallbacks,
       const LoopCallbacksDeadline& deadline);
 
+  // Helper to add a callback to the appropriate list (runOnceCallbacks_ or
+  // loopCallbacks_) and break out of epoll_wait if needed.
+  void addLoopCallback(LoopCallback& callback, bool thisIteration);
+
   // executes any callbacks queued by runInLoop(); returns false if none found
   bool runLoopCallbacks();
 


### PR DESCRIPTION
# Thrift RPC Latency Bug

## Summary

Thrift RPC calls experience multi-second latency (5-7 seconds) when they should complete in milliseconds. The root cause is that `EventBase::runInLoop()` adds callbacks to `loopCallbacks_` without waking up the `EventBase` if it's blocked in `eb_event_base_loop()`.

## Environment

- folly EventBase with libevent backend
- fbthrift with Rocket protocol
- WriteBatcher for batching writes

## Reproducer

Here is minimal test case to be built in the FBOSS OSS tree demonstrates the issue:

```cpp
/*
 * Minimal reproducer for Thrift RPC latency issue.
 * Expected: RPC call should complete in < 10ms
 * Observed: RPC call takes several seconds due to WriteBatcher callback delay
 */

#include <chrono>
#include <iostream>
#include <memory>
#include <thread>

#include <folly/init/Init.h>
#include <folly/io/async/AsyncSocket.h>
#include <folly/io/async/EventBase.h>
#include <thrift/lib/cpp2/async/RocketClientChannel.h>
#include <thrift/lib/cpp2/util/ScopedServerInterfaceThread.h>

#include "fboss/agent/if/gen-cpp2/FbossCtrl.h"

using namespace facebook::fboss;
using namespace apache::thrift;

// Simple handler that returns a fixed timestamp
class SimpleHandler : public FbossCtrlSvIf {
 public:
  void getConfigAppliedInfo(ConfigAppliedInfo& info) override {
    info.lastAppliedInMs() = 12345;
    info.lastColdbootAppliedInMs() = 0;
  }
};

int main(int argc, char** argv) {
  folly::init(&argc, &argv);

  std::cout << "Creating Thrift server..." << std::endl;

  // Use ScopedServerInterfaceThread which handles startup/shutdown properly
  auto handler = std::make_shared<SimpleHandler>();
  ScopedServerInterfaceThread server(handler, "::1", 0);

  auto port = server.getAddress().getPort();
  std::cout << "Server listening on port " << port << std::endl;

  // Create client using ScopedServerInterfaceThread's helper
  auto client = server.newClient<FbossCtrlAsyncClient>(
      nullptr, RocketClientChannel::newChannel);

  std::cout << "Making RPC call..." << std::endl;

  // Measure RPC latency
  auto start = std::chrono::steady_clock::now();

  ConfigAppliedInfo result;
  client->sync_getConfigAppliedInfo(result);

  auto end = std::chrono::steady_clock::now();
  auto duration =
      std::chrono::duration_cast<std::chrono::milliseconds>(end - start);

  std::cout << "RPC call completed in " << duration.count() << " ms"
            << std::endl;
  std::cout << "Result: lastAppliedInMs = " << *result.lastAppliedInMs()
            << std::endl;

  if (duration.count() > 100) {
    std::cout << "ERROR: RPC took too long! Expected < 100ms" << std::endl;
  } else {
    std::cout << "OK: RPC latency is acceptable" << std::endl;
  }

  return duration.count() > 100 ? 1 : 0;
}
```

Save this file to `fboss/cli/fboss2/test/thrift_latency_test.cpp` and add this at the end of `cmake/CliFboss2Test.cmake`:
```cmake
add_executable(thrift_latency_test
  fboss/cli/fboss2/test/thrift_latency_test.cpp
)

target_link_libraries(thrift_latency_test
  ctrl_cpp2
  Folly::folly
  FBThrift::thriftcpp2
)
```

Before the fix this test binary takes 5-7 seconds to execute, after the fix it takes a few milliseconds.

## Root Cause Analysis

### The Problem

When a Thrift RPC response is ready to be sent, the [`WriteBatcher`](https://github.com/facebook/fbthrift/blob/main/thrift/lib/cpp2/transport/rocket/server/detail/WriteBatcher.h) calls [`runInLoop(this, true)`](https://github.com/facebook/folly/blob/b7df23698a3e03232d738b49a0ea571fb22f19d6/folly/io/async/EventBase.cpp#L868) to schedule the write. The `thisIteration=true` parameter indicates the callback should run in the current loop iteration.

However, the callback is only [added](https://github.com/facebook/folly/blob/b7df23698a3e03232d738b49a0ea571fb22f19d6/folly/io/async/EventBase.cpp#L873) to `runOnceCallbacks_` if we're currently inside `runLoopCallbacks()`. Otherwise, it's [added](https://github.com/facebook/folly/blob/b7df23698a3e03232d738b49a0ea571fb22f19d6/folly/io/async/EventBase.cpp#L875) to `loopCallbacks_` for the next iteration.

The issue occurs when:
1. The `EventBase` is inside `eb_event_base_loop()` (blocked in `epoll_wait`)
2. A socket event triggers a callback that calls `runInLoop()`
3. `runOnceCallbacks_` is null (we're not in `runLoopCallbacks()`)
4. The callback is added to `loopCallbacks_`
5. After the socket callback returns, `eb_event_base_loop()` continues blocking
6. The callback sits in `loopCallbacks_` until `epoll_wait` times out (~5-6 seconds typically)

### Code Flow (Before Fix)

```
eb_event_base_loop(EVLOOP_ONCE)  <- blocking in epoll_wait
  |
  +-> socket event fires
  |     |
  |     +-> WriteBatcher::enqueueWrite()
  |           |
  |           +-> runInLoop(this, true)
  |                 |
  |                 +-> runOnceCallbacks_ == nullptr
  |                 +-> loopCallbacks_.push_back(callback)  <- callback queued
  |
  +-> epoll_wait continues blocking  <- NO WAKEUP!
  |
  ... 5-6 seconds pass ...
  |
  +-> epoll_wait times out
  +-> eb_event_base_loop returns
  |
runLoopCallbacks()  <- finally processes the callback
```

## Instrumentation

I sprinkled a ton of debug logging in folly and fbthrift to debug the issue:

### EventBase.cpp
- Log when entering `eb_event_base_loop` (blocking vs non-blocking)
- Log when `runInLoop` adds to `loopCallbacks_` vs `runOnceCallbacks_`
- Log when `runLoopCallbacks` starts/ends

### WriteBatcher-inl.h
- Log when `enqueueWrite` calls `runInLoop`

## Reproduction (Without Fix)

### Debug Output

Excerpt of the output from the reproduction binary shared above with the extra debug logging I added:

```
[WRITEBATCHER tid=X] enqueueWrite: calling runInLoop (immediate)
[EVENTBASE tid=X] runInLoop: adding to loopCallbacks_ (runOnceCallbacks_=(nil), thisIteration=1)
... 6 seconds of silence on this thread ...
[EVENTBASE tid=X] loopMain: eb_event_base_loop returned 0
[EVENTBASE tid=X] runLoopCallbacks: starting with 2 callbacks
```

(See below for captured `strace` output showing the 6-second `epoll_wait`)

## The Fix

Add a call to `eb_event_base_loopbreak()` when adding to `loopCallbacks_` while the loop is running:

```cpp
void EventBase::runInLoop(LoopCallback* callback, bool thisIteration, ...) {
  // ... existing code ...
  if (runOnceCallbacks_ != nullptr && thisIteration) {
    runOnceCallbacks_->push_back(*callback);
  } else {
    loopCallbacks_.push_back(*callback);
    // NEW: Wake up the EventBase if it's blocked in eb_event_base_loop()
    if (isRunning()) {
      evb_->eb_event_base_loopbreak();
    }
  }
}
```

This causes `eb_event_base_loop()` to return immediately, allowing the loop to process the pending callbacks.  This `if`/`else` sequence was duplicated so rather than fixing this in the same way in two different places, I've factored this out in a private helper.

## Results

Based on `thrift_latency_test.cpp` above, running on AMD EPYC 9655P:

| Metric | Before Fix | After Fix |
|--------|------------|-----------|
| RPC Latency | ~6500 ms | ~1 ms |
| Test Duration | ~6.5 seconds | ~6 ms |

---

## Captured Traces

### Before Fix (Issue Reproduction)

#### `strace` output

key events for thread 1910218, the server IO thread:

```
# Thread 1910218 returns from a short 6ms epoll_wait with an event
[pid 1910218] 13:50:40.269315 epoll_wait(10, [...], 32, 6) = 1

# While processing that event, WriteBatcher adds callbacks to loopCallbacks_
[WRITEBATCHER tid=1910218] enqueueWrite: calling runInLoop (immediate)
[EVENTBASE tid=1910218] runInLoop: adding to loopCallbacks_ (runOnceCallbacks_=(nil), thisIteration=1)
[EVENTBASE tid=1910218] runInLoop: adding to loopCallbacks_ (runOnceCallbacks_=(nil), thisIteration=0)

# PROBLEM: libevent goes back into epoll_wait INSIDE eb_event_base_loop!
# It doesn't know about our loopCallbacks_ - only folly knows about those.
[pid 1910218] 13:50:40.270073 epoll_wait(10,  <unfinished ...>

# 5 seconds later, epoll_wait times out (timeout was 5042ms)
[pid 1910218] 13:50:45.317251 <... epoll_wait resumed>[], 32, 5042) = 0

# NOW eb_event_base_loop returns and we finally process the callbacks
[EVENTBASE tid=1910218] loopMain: eb_event_base_loop returned 0
[EVENTBASE tid=1910218] runLoopCallbacks: starting with 2 callbacks
```

#### Debug output

```
Making RPC call...
[WRITEBATCHER tid=1911408] enqueueWrite: calling runInLoop (immediate)
[EVENTBASE tid=1911408] runInLoop: adding to loopCallbacks_ (runOnceCallbacks_=(nil), thisIteration=1)
[WRITEBATCHER tid=1911408] enqueueWrite: calling runInLoop (immediate)
[EVENTBASE tid=1911408] runInLoop: adding to loopCallbacks_ (runOnceCallbacks_=(nil), thisIteration=1)
RPC call completed in 7062 ms
ERROR: RPC took too long! Expected < 100ms
```

#### Observations

1. **WriteBatcher calls `runInLoop(this, true)`**: The `thisIteration=1` parameter indicates
   the callback should run immediately in the current loop iteration.

2. **Callback goes to `loopCallbacks_` instead of `runOnceCallbacks_`**: The log shows
   `runOnceCallbacks_=(nil)` because we're NOT inside `runLoopCallbacks()` at this point.
   We're inside a libevent callback (epoll event handler), so the callback is queued.

3. **libevent goes back into `epoll_wait` after processing the event**: This is the bug.
   The flow is:
   - `eb_event_base_loop(EVLOOP_ONCE)` calls `epoll_wait`
   - An event fires, `epoll_wait` returns
   - libevent calls the event handler (which triggers `WriteBatcher`)
   - `WriteBatcher` adds callbacks to folly's `loopCallbacks_`
   - Event handler returns to libevent
   - **libevent goes back into `epoll_wait`** because it doesn't know about folly's `loopCallbacks_`!
   - The 5042ms timeout expires
   - `eb_event_base_loop` finally returns
   - folly's `runLoopCallbacks()` processes the 2 queued callbacks

4. **The ~5 second delay is a single `epoll_wait` timeout**: The timeout of 5042ms is set by
   libevent based on the next timer event. The callbacks sit in `loopCallbacks_` for the
   entire duration because libevent has no way to know they're waiting.

---

### After Fix

#### strace output

```
# WriteBatcher enqueues callback - now with eb_event_base_loopbreak() called
[pid 1939305] 13:53:45.777230 epoll_wait(26, [WRITEBATCHER tid=1939302] enqueueWrite: calling runInLoop (immediate)
[pid 1939305] 13:53:45.780801 epoll_wait(26, [WRITEBATCHER tid=1939302] enqueueWrite: calling runInLoop (immediate)

# RPC completes in just 8ms!
RPC call completed in 8 ms
OK: RPC latency is acceptable
```

#### Debug output

```
Making RPC call...
[WRITEBATCHER tid=1939834] enqueueWrite: calling runInLoop (immediate)
[EVENTBASE tid=1939834] runInLoop: adding to loopCallbacks_ (runOnceCallbacks_=(nil), thisIteration=1)
[WRITEBATCHER tid=1939834] enqueueWrite: calling runInLoop (immediate)
[EVENTBASE tid=1939834] runInLoop: adding to loopCallbacks_ (runOnceCallbacks_=(nil), thisIteration=1)
RPC call completed in 1 ms
OK: RPC latency is acceptable
```

#### Observations

1. **Same callback path**: The callback still goes to `loopCallbacks_` (since `runOnceCallbacks_`
   is still null), but now we also call `eb_event_base_loopbreak()`.

2. **Immediate wakeup**: The `eb_event_base_loopbreak()` call causes `epoll_wait` to return
   immediately, allowing the `EventBase` to process the pending callback.

3. **RPC latency reduced from ~6 seconds to ~1-8ms**: this helps all OSS FBOSS users keep their sanity.

4. **No timeout waiting**: The `epoll_wait` no longer blocks for the full timeout period.
   The loop breaks immediately and processes callbacks.

---

## Conclusion

The fix adds a single call to `eb_event_base_loopbreak()` when adding callbacks to
`loopCallbacks_` while the loop is running. This ensures the `EventBase` wakes up promptly
to process the callback instead of waiting for the next event or timeout.

This is a fix for any code path that uses `runInLoop()` with `thisIteration=true`
while inside an epoll callback handler, as the callback will otherwise be delayed until
the next event loop timeout (typically 5-7 seconds).

It has been reported that this issue has not been observed inside Meta, and I cannot explain why.