### PR TITLE
Fix memset/memcpy linkage on aarch64

### DIFF
--- a/folly/CMakeLists.txt
+++ b/folly/CMakeLists.txt
@@ -879,6 +879,9 @@ folly_add_library(
   NAME memset-impl
   SRCS
     FollyMemset.cpp
+    $<$<BOOL:${IS_AARCH64_ARCH}>:memset_select_aarch64.cpp>
+  DEPS
+    $<$<BOOL:${IS_AARCH64_ARCH}>:folly_external_aor_memset_aarch64>
 )
 
 folly_add_library(
@@ -894,12 +897,20 @@ folly_add_library(
   EXCLUDE_FROM_MONOLITH
   SRCS
     FollyMemset.cpp
+    $<$<BOOL:${IS_AARCH64_ARCH}>:memset_select_aarch64.cpp>
+  DEPS
+    $<$<BOOL:${IS_AARCH64_ARCH}>:folly_external_aor_memset_aarch64-use>
+  COMPILE_OPTIONS
+    $<$<BOOL:${IS_AARCH64_ARCH}>:-DFOLLY_MEMSET_IS_MEMSET>
 )
 
 folly_add_library(
   NAME memcpy-impl
   SRCS
     FollyMemcpy.cpp
+    $<$<BOOL:${IS_AARCH64_ARCH}>:memcpy_select_aarch64.cpp>
+  DEPS
+    $<$<BOOL:${IS_AARCH64_ARCH}>:folly_external_aor_memcpy_aarch64>
 )
 
 folly_add_library(
@@ -915,6 +926,11 @@ folly_add_library(
   EXCLUDE_FROM_MONOLITH
   SRCS
     FollyMemcpy.cpp
+    $<$<BOOL:${IS_AARCH64_ARCH}>:memcpy_select_aarch64.cpp>
+  DEPS
+    $<$<BOOL:${IS_AARCH64_ARCH}>:folly_external_aor_memcpy_aarch64-use>
+  COMPILE_OPTIONS
+    $<$<BOOL:${IS_AARCH64_ARCH}>:-DFOLLY_MEMCPY_IS_MEMCPY>
 )
 
 # x86 assembly memcpy implementation (not supported on MSVC)


### PR DESCRIPTION
This PR fixes linkage of memcpy/memset on aarch64. Without these changes, the memcpy and memset benchmarks do not link.