### PR TITLE
Fix aarch64 duplicate symbol errors in libfolly

### DIFF
--- a/folly/external/aor/CMakeLists.txt
+++ b/folly/external/aor/CMakeLists.txt
@@ -34,6 +34,7 @@ folly_add_library(
 
 folly_add_library(
   NAME memcpy_aarch64-use
+  EXCLUDE_FROM_MONOLITH
   SRCS
     memcpy-advsimd.S
     memcpy-armv8.S
@@ -57,6 +58,7 @@ folly_add_library(
 
 folly_add_library(
   NAME memset_aarch64-use
+  EXCLUDE_FROM_MONOLITH
   SRCS
     memset-advsimd.S
     memset-mops.S


### PR DESCRIPTION
The -use variants of memcpy_aarch64 and memset_aarch64 were being included in the monolithic libfolly.so, causing duplicate symbol errors because they compile the same assembly files as the non-use variants.

Add EXCLUDE_FROM_MONOLITH to memcpy_aarch64-use and memset_aarch64-use to match the pattern used for memcpy-use and memset-use in the main folly/CMakeLists.txt. The -use variants are meant for explicit opt-in to override libc memcpy/memset, not for inclusion in the main library.