### PR TITLE
Replace boost::thread::barrier with folly::test::Barrier

### DIFF
--- a/folly/concurrency/container/test/SingleWriterFixedHashMapTest.cpp
+++ b/folly/concurrency/container/test/SingleWriterFixedHashMapTest.cpp
@@ -22,8 +22,8 @@
 #include <folly/portability/GTest.h>
 #include <folly/synchronization/test/Barrier.h>
 
-#include <boost/thread/barrier.hpp>
 #include <glog/logging.h>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <atomic>
 #include <iomanip>

--- a/folly/concurrency/test/BUCK
+++ b/folly/concurrency/test/BUCK
@@ -230,9 +230,9 @@ fbcode_target(
         "//folly/lang:keep",
         "//folly/portability:gflags",
         "//folly/portability:gtest",
+        "//folly/synchronization/test:barrier",
     ],
     external_deps = [
-        ("boost", None, "boost_thread"),
         "glog",
     ],
 )
@@ -282,6 +282,7 @@ fbcode_target(
         "//folly/init:init",
         "//folly/lang:keep",
         "//folly/portability:gflags",
+        "//folly/synchronization/test:barrier",
     ],
     external_deps = [
         ("boost", None, "boost_thread"),
@@ -298,6 +299,7 @@ fbcode_target(
         "//folly:thread_local",
         "//folly/concurrency:singleton_relaxed_counter",
         "//folly/portability:gtest",
+        "//folly/synchronization/test:barrier",
     ],
     external_deps = [
         ("boost", None, "boost_thread"),

--- a/folly/concurrency/test/SingletonRelaxedCounterBench.cpp
+++ b/folly/concurrency/test/SingletonRelaxedCounterBench.cpp
@@ -19,7 +19,7 @@
 #include <cstddef>
 #include <thread>
 
-#include <boost/thread/barrier.hpp>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
@@ -52,7 +52,7 @@ namespace folly {
 BENCHMARK(MultiThreadPerformance, iters) {
   BenchmarkSuspender braces;
 
-  boost::barrier barrier(1 + FLAGS_num_threads);
+  folly::test::Barrier barrier(1 + FLAGS_num_threads);
 
   std::vector<std::thread> threads(FLAGS_num_threads);
 

--- a/folly/concurrency/test/SingletonRelaxedCounterTest.cpp
+++ b/folly/concurrency/test/SingletonRelaxedCounterTest.cpp
@@ -19,7 +19,7 @@
 #include <cstddef>
 #include <thread>
 
-#include <boost/thread/barrier.hpp>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/ThreadLocal.h>
 #include <folly/portability/GTest.h>
@@ -92,7 +92,7 @@ TEST_F(SingletonRelaxedCounterTest, MultithreadCorrectness) {
   for (size_t j = 0; j < kNumIters; ++j) {
     std::vector<std::thread> threads(kNumThreads);
 
-    boost::barrier barrier{kNumThreads + 1};
+    folly::test::Barrier barrier{kNumThreads + 1};
 
     for (auto& thread : threads) {
       thread = std::thread([&] {

--- a/folly/concurrency/test/UnboundedQueueTest.cpp
+++ b/folly/concurrency/test/UnboundedQueueTest.cpp
@@ -22,8 +22,8 @@
 #include <folly/portability/GFlags.h>
 #include <folly/portability/GTest.h>
 
-#include <boost/thread/barrier.hpp>
 #include <glog/logging.h>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <atomic>
 #include <iomanip>
@@ -248,7 +248,7 @@ inline uint64_t run_once(
     const ProdFunc& prodFn,
     const ConsFunc& consFn,
     const EndFunc& endFn) {
-  boost::barrier barrier(1 + nprod + ncons);
+  folly::test::Barrier barrier(1 + nprod + ncons);
 
   /* producers */
   std::vector<std::thread> prodThr(nprod);

--- a/folly/executors/task_queue/test/BUCK
+++ b/folly/executors/task_queue/test/BUCK
@@ -12,10 +12,10 @@ fbcode_target(
         "//folly:benchmark",
         "//folly/executors/task_queue:unbounded_blocking_queue",
         "//folly/init:init",
+        "//folly/synchronization/test:barrier",
     ],
     external_deps = [
         "glog",
-        ("boost", None, "boost_thread"),
     ],
 )
 

--- a/folly/executors/task_queue/test/UnboundedBlockingQueueBench.cpp
+++ b/folly/executors/task_queue/test/UnboundedBlockingQueueBench.cpp
@@ -21,8 +21,8 @@
 #include <thread>
 #include <vector>
 
-#include <boost/thread/barrier.hpp>
 #include <glog/logging.h>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
@@ -56,7 +56,7 @@ BENCHMARK(drain_full_queue, iters) {
   std::vector<size_t> counts(nthreads);
   std::vector<std::thread> threads(nthreads);
 
-  boost::barrier barrier(1 + nthreads);
+  folly::test::Barrier barrier(1 + nthreads);
 
   for (auto i = 0u; i < nthreads; ++i) {
     threads[i] = std::thread([&, i] {

--- a/folly/futures/test/BUCK
+++ b/folly/futures/test/BUCK
@@ -352,9 +352,7 @@ fbcode_target(
         "//folly/futures:core",
         "//folly/portability:gtest",
         "//folly/synchronization:baton",
-    ],
-    external_deps = [
-        ("boost", None, "boost_thread"),
+        "//folly/synchronization/test:barrier",
     ],
 )
 
@@ -766,9 +764,7 @@ fbcode_target(
         "//folly/executors:manual_executor",
         "//folly/futures:core",
         "//folly/portability:gtest",
-    ],
-    external_deps = [
-        ("boost", None, "boost_thread"),
+        "//folly/synchronization/test:barrier",
     ],
 )
 

--- a/folly/futures/test/CollectTest.cpp
+++ b/folly/futures/test/CollectTest.cpp
@@ -16,7 +16,7 @@
 
 #include <numeric>
 
-#include <boost/thread/barrier.hpp>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/DefaultKeepAliveExecutor.h>
 #include <folly/Random.h>
@@ -694,7 +694,7 @@ TEST(Collect, parallel) {
   auto f = collect(fs);
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -723,7 +723,7 @@ TEST(Collect, parallelWithError) {
   auto f = collect(fs);
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -754,7 +754,7 @@ TEST(Collect, allParallel) {
   auto f = collectAll(fs);
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -784,7 +784,7 @@ TEST(Collect, allParallelWithError) {
   auto f = collectAll(fs);
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -862,7 +862,7 @@ TEST(Collect, collectNParallel) {
       });
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();

--- a/folly/futures/test/WindowTest.cpp
+++ b/folly/futures/test/WindowTest.cpp
@@ -16,7 +16,7 @@
 
 #include <vector>
 
-#include <boost/thread/barrier.hpp>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/Conv.h>
 #include <folly/executors/ManualExecutor.h>
@@ -210,7 +210,7 @@ TEST(Window, parallel) {
   auto f = collect(window(input, [&](int i) { return ps[i].getFuture(); }, 3));
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -239,7 +239,7 @@ TEST(Window, parallelWithError) {
   auto f = collect(window(input, [&](int i) { return ps[i].getFuture(); }, 3));
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -271,7 +271,7 @@ TEST(Window, allParallelWithError) {
       collectAll(window(input, [&](int i) { return ps[i].getFuture(); }, 3));
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -372,7 +372,7 @@ TEST(WindowExecutor, parallel) {
       window(&executor, input, [&](int i) { return ps[i].getFuture(); }, 3));
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -405,7 +405,7 @@ TEST(WindowExecutor, parallelWithError) {
       window(&executor, input, [&](int i) { return ps[i].getFuture(); }, 3));
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();
@@ -440,7 +440,7 @@ TEST(WindowExecutor, allParallelWithError) {
       window(&executor, input, [&](int i) { return ps[i].getFuture(); }, 3));
 
   std::vector<std::thread> ts;
-  boost::barrier barrier(ps.size() + 1);
+  folly::test::Barrier barrier(ps.size() + 1);
   for (size_t i = 0; i < ps.size(); i++) {
     ts.emplace_back([&ps, &barrier, i]() {
       barrier.wait();

--- a/folly/io/async/test/BUCK
+++ b/folly/io/async/test/BUCK
@@ -638,9 +638,9 @@ non_fbcode_target(
     raw_headers = ["RequestContextHelper.h"],
     deps = [
         "fbsource//xplat/folly/portability:gtest",
-        "//third-party/boost:boost_thread",
         "//xplat/folly:memory",
         "//xplat/folly/io/async:async_base",
+        "//xplat/folly/synchronization/test:barrier",
         "//xplat/folly/system:thread_name",
     ],
     exported_deps = ["//xplat/folly/io/async:request_context"],
@@ -1583,10 +1583,8 @@ fbcode_target(
         "//folly/io/async:request_context",
         "//folly/portability:gtest",
         "//folly/synchronization:relaxed_atomic",
+        "//folly/synchronization/test:barrier",
         "//folly/system:thread_name",
-    ],
-    external_deps = [
-        ("boost", None, "boost_thread"),
     ],
 )
 

--- a/folly/io/async/test/RequestContextTest.cpp
+++ b/folly/io/async/test/RequestContextTest.cpp
@@ -28,8 +28,8 @@
 #include <folly/synchronization/RelaxedAtomic.h>
 #include <folly/system/ThreadName.h>
 
-#include <boost/thread/barrier.hpp>
 #include <fmt/format.h>
+#include <folly/synchronization/test/Barrier.h>
 
 using namespace folly;
 
@@ -584,7 +584,7 @@ TEST_F(RequestContextTest, AccessAllThreadsDestructionGuard) {
   constexpr auto kNumThreads = 128;
 
   std::vector<std::thread> threads{kNumThreads};
-  boost::barrier barrier{kNumThreads + 1};
+  folly::test::Barrier barrier{kNumThreads + 1};
 
   std::atomic<std::size_t> count{0};
   for (auto& thread : threads) {

--- a/folly/logging/test/BUCK
+++ b/folly/logging/test/BUCK
@@ -344,10 +344,10 @@ fbcode_target(
         "//folly/logging:log_handler",
         "//folly/logging:logging",
         "//folly/portability:gflags",
+        "//folly/synchronization/test:barrier",
     ],
     external_deps = [
         ("boost", None, "boost_preprocessor"),
-        ("boost", None, "boost_thread"),
     ],
 )
 

--- a/folly/logging/test/XlogBench.cpp
+++ b/folly/logging/test/XlogBench.cpp
@@ -20,7 +20,7 @@
 #include <thread>
 
 #include <boost/preprocessor/repetition/repeat.hpp>
-#include <boost/thread/barrier.hpp>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
@@ -60,7 +60,7 @@ template <typename XlogEvery>
 void runXlogEveryNBench(size_t iters, XlogEvery func) {
   BenchmarkSuspender braces;
 
-  boost::barrier barrier(1 + FLAGS_num_threads);
+  folly::test::Barrier barrier(1 + FLAGS_num_threads);
 
   std::vector<std::thread> threads(FLAGS_num_threads);
 

--- a/folly/stats/test/BUCK
+++ b/folly/stats/test/BUCK
@@ -51,9 +51,7 @@ fbcode_target(
         "//folly/lang:keep",
         "//folly/portability:gflags",
         "//folly/stats:digest_builder",
-    ],
-    external_deps = [
-        ("boost", None, "boost_thread"),
+        "//folly/synchronization/test:barrier",
     ],
 )
 

--- a/folly/stats/test/DigestBuilderBenchmark.cpp
+++ b/folly/stats/test/DigestBuilderBenchmark.cpp
@@ -19,7 +19,7 @@
 #include <chrono>
 #include <thread>
 
-#include <boost/thread/barrier.hpp>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/Benchmark.h>
 #include <folly/Range.h>
@@ -59,7 +59,7 @@ unsigned int append(unsigned int iters, size_t bufSize, size_t nThreads) {
   iters = 1000000;
   auto buffer = std::make_shared<DigestBuilder<FreeDigest>>(bufSize, 100);
 
-  auto barrier = std::make_shared<boost::barrier>(nThreads + 1);
+  auto barrier = std::make_shared<folly::test::Barrier>(nThreads + 1);
 
   std::vector<std::thread> threads;
   threads.reserve(nThreads);

--- a/folly/synchronization/test/BUCK
+++ b/folly/synchronization/test/BUCK
@@ -72,10 +72,10 @@ fbcode_target(
     ],
 )
 
-fbcode_target(
-    _kind = cpp_library,
+fb_dirsync_cpp_library(
     name = "barrier",
     headers = ["Barrier.h"],
+    xplat_impl = folly_xplat_library,
 )
 
 fbcode_target(

--- a/folly/test/BUCK
+++ b/folly/test/BUCK
@@ -1243,9 +1243,9 @@ fbcode_target(
         "//folly/portability:sys_resource",
         "//folly/portability:sys_time",
         "//folly/portability:unistd",
+        "//folly/synchronization/test:barrier",
     ],
     external_deps = [
-        ("boost", None, "boost_thread"),
         "boost",
     ],
 )
@@ -1554,9 +1554,9 @@ fbcode_target(
         "//folly/io/async:async_base",
         "//folly/portability:gmock",
         "//folly/portability:gtest",
+        "//folly/synchronization/test:barrier",
     ],
     external_deps = [
-        ("boost", None, "boost_thread"),
         "glog",
     ],
 )
@@ -1616,6 +1616,7 @@ fbcode_target(
         "//folly/lang:keep",
         "//folly/portability:gtest",
         "//folly/synchronization:latch",
+        "//folly/synchronization/test:barrier",
         "//folly/testing:test_util",
     ],
     external_deps = [
@@ -1944,11 +1945,11 @@ fbcode_target(
         "//folly/portability:gtest",
         "//folly/portability:unistd",
         "//folly/synchronization:baton",
+        "//folly/synchronization:latch",
         "//folly/system:thread_id",
         "//folly/testing:test_util",
     ],
     external_deps = [
-        ("boost", None, "boost_thread"),
         "glog",
     ],
 )

--- a/folly/test/MPMCQueueTest.cpp
+++ b/folly/test/MPMCQueueTest.cpp
@@ -23,8 +23,8 @@
 #include <utility>
 
 #include <boost/intrusive_ptr.hpp>
-#include <boost/thread/barrier.hpp>
 #include <fmt/format.h>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/Format.h>
 #include <folly/Memory.h>
@@ -1137,7 +1137,7 @@ void testTryReadUntil() {
   bool rets[2];
   int vals[2];
   std::vector<std::thread> threads;
-  boost::barrier b{3};
+  folly::test::Barrier b{3};
   for (int i = 0; i < 2; i++) {
     threads.emplace_back([&, i] {
       b.wait();
@@ -1172,7 +1172,7 @@ void testTryWriteUntil() {
   stop_watch<> watch;
   bool rets[2];
   std::vector<std::thread> threads;
-  boost::barrier b{3};
+  folly::test::Barrier b{3};
   for (int i = 0; i < 2; i++) {
     threads.emplace_back([&, i] {
       b.wait();

--- a/folly/test/SingletonTest.cpp
+++ b/folly/test/SingletonTest.cpp
@@ -19,8 +19,8 @@
 #include <cstdlib>
 #include <thread>
 
-#include <boost/thread/barrier.hpp>
 #include <glog/logging.h>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/io/async/EventBase.h>
 #include <folly/portability/GMock.h>
@@ -677,7 +677,7 @@ TEST(Singleton, SingletonEagerInitParallel) {
 
     {
       std::vector<std::shared_ptr<std::thread>> threads;
-      boost::barrier barrier(kThreads);
+      folly::test::Barrier barrier(kThreads);
       TestEagerInitParallelExecutor exe(kThreads);
       vault.registrationComplete();
 

--- a/folly/test/SingletonThreadLocalTest.cpp
+++ b/folly/test/SingletonThreadLocalTest.cpp
@@ -22,7 +22,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include <boost/thread/barrier.hpp>
+#include <folly/synchronization/test/Barrier.h>
 
 #include <folly/SingletonThreadLocal.h>
 #include <folly/String.h>
@@ -187,7 +187,7 @@ TEST(SingletonThreadLocalTest, AccessAllThreads) {
   };
   using STL = SingletonThreadLocal<Obj, Tag>;
   constexpr size_t n_threads = 4;
-  boost::barrier barrier{n_threads + 1};
+  folly::test::Barrier barrier{n_threads + 1};
   std::vector<std::thread> threads{n_threads};
 
   // setup


### PR DESCRIPTION
Summary:
Replace usage of boost::thread::barrier with folly::test::Barrier in test
files. This reduces the dependency on boost_thread in folly's test code.

The folly::test::Barrier is a simple barrier implementation suitable for
testing purposes.

Differential Revision: D91102520


