### PR TITLE
Improve C++17 compatibility

### DIFF
--- a/build/fbcode_builder/CMake/FindDoubleConversion.cmake
+++ b/build/fbcode_builder/CMake/FindDoubleConversion.cmake
@@ -11,6 +11,7 @@ find_path(DOUBLE_CONVERSION_INCLUDE_DIR double-conversion/double-conversion.h)
 find_library(DOUBLE_CONVERSION_LIBRARY NAMES double-conversion)
 
 include(FindPackageHandleStandardArgs)
+
 find_package_handle_standard_args(
   DoubleConversion
   DEFAULT_MSG

--- a/folly/lang/Exception.cpp
+++ b/folly/lang/Exception.cpp
@@ -121,7 +121,8 @@ static constexpr uint64_t __gxx_dependent_exception_class =
 struct __cxa_exception {
   std::type_info* exceptionType;
   void(_GLIBCXX_CDTOR_CALLABI* exceptionDestructor)(void*);
-  std::unexpected_handler unexpectedHandler;
+  void (*unexpectedHandler)(); // std::unexpected_handler has been removed from
+                              // C++17.
   std::terminate_handler terminateHandler;
   __cxa_exception* nextException;
   int handlerCount;


### PR DESCRIPTION
Replace std::unexpected_handler, since it has been removed from C++17.

Resolves issue: https://github.com/facebook/folly/issues/2322