### PR TITLE
Call `std::countr_zero` only on non-zero words

### DIFF
--- a/folly/container/StdBitset.h
+++ b/folly/container/StdBitset.h
@@ -22,6 +22,7 @@
 #include <bit>
 #include <bitset>
 #include <cassert>
+#include <folly/Likely.h>
 
 namespace folly {
 
@@ -77,7 +78,7 @@ size_t std_bitset_find_next(const std::bitset<N>& bitset, size_t start) {
 
   while (word_idx < max_words) {
     size_t word = data[word_idx];
-    if (word) [[unlikely]] {
+    if (FOLLY_UNLIKELY(word)) {
       size_t idx_in_word = std::countr_zero(word);
       // we found the first
       return word_idx * kWordSize + idx_in_word;


### PR DESCRIPTION
Currently, the code calls `std::countr_zero` on all words and checks if the trailing zero count is not 64. Alternatively we can test if the word is non-zero and only then call `std::countr_zero`.  