### PR TITLE
Wrap include dirs in BUILD_INTERFACE for FetchContent

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -332,7 +332,16 @@ endif()
 target_link_libraries(folly_deps INTERFACE fmt::fmt)
 
 list(REMOVE_DUPLICATES FOLLY_INCLUDE_DIRECTORIES)
-target_include_directories(folly_deps INTERFACE ${FOLLY_INCLUDE_DIRECTORIES})
+if(NOT "${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+  # When consumed via add_subdirectory/FetchContent, wrap each include
+  # directory in BUILD_INTERFACE so absolute build-tree paths don't leak
+  # into the parent project's install-time INTERFACE_INCLUDE_DIRECTORIES.
+  foreach(_dir IN LISTS FOLLY_INCLUDE_DIRECTORIES)
+    target_include_directories(folly_deps INTERFACE $<BUILD_INTERFACE:${_dir}>)
+  endforeach()
+else()
+  target_include_directories(folly_deps INTERFACE ${FOLLY_INCLUDE_DIRECTORIES})
+endif()
 target_link_libraries(folly_deps INTERFACE
   ${FOLLY_LINK_LIBRARIES}
   ${FOLLY_SHINY_DEPENDENCIES}


### PR DESCRIPTION
Summary:
When folly is consumed via FetchContent, build-tree paths in FOLLY_INCLUDE_DIRECTORIES (e.g. the fast_float include dir) leak into INTERFACE_INCLUDE_DIRECTORIES without a BUILD_INTERFACE wrapper. CMake validates these paths during generation and errors out because they're absolute build-tree paths that won't exist at install time.

Wrap each include directory individually in $<BUILD_INTERFACE:> so the paths are only used during the build and excluded from the export/install config. The foreach is necessary because $<BUILD_INTERFACE:${LIST}> doesn't expand CMake lists correctly — it only wraps the first element.

Differential Revision: D93368778


