### PR TITLE
Auto-inject --disable-shared for autoconf builders

### DIFF
--- a/build/fbcode_builder/getdeps/builder.py
+++ b/build/fbcode_builder/getdeps/builder.py
@@ -426,6 +426,8 @@ class AutoconfBuilder(BuilderBase):
             inst_dir,
         )
         self.args = args or []
+        if not build_opts.shared_libs and "--disable-shared" not in self.args:
+            self.args.append("--disable-shared")
         self.conf_env_args = conf_env_args or {}
 
     @property


### PR DESCRIPTION
Summary: When shared_libs is off, automatically pass --disable-shared to autoconf-based builds so they don't produce .so files. This avoids needing to add this flag individually to every autoconf manifest.

Reviewed By: bigfootjon

Differential Revision: D93644457


