### PR TITLE
Fix libunwind cmake to include lzma in static builds

### DIFF
--- a/build/fbcode_builder/CMake/FindLibUnwind.cmake
+++ b/build/fbcode_builder/CMake/FindLibUnwind.cmake
@@ -12,19 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# When using prepackaged LLVM libunwind on Ubuntu, its includes are installed in a subdirectory.
-find_path(LIBUNWIND_INCLUDE_DIR NAMES libunwind.h PATH_SUFFIXES libunwind)
-mark_as_advanced(LIBUNWIND_INCLUDE_DIR)
-
-find_library(LIBUNWIND_LIBRARY NAMES unwind)
-mark_as_advanced(LIBUNWIND_LIBRARY)
-
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(
-  LIBUNWIND
-  REQUIRED_VARS LIBUNWIND_LIBRARY LIBUNWIND_INCLUDE_DIR)
 
-if(LIBUNWIND_FOUND)
-  set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY})
+# Prefer pkg-config: picks up transitive deps (e.g. lzma, zlib) that
+# static libunwind needs but a bare find_library would miss.
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(PC_LIBUNWIND QUIET libunwind)
+endif()
+
+if(PC_LIBUNWIND_FOUND)
+  find_path(LIBUNWIND_INCLUDE_DIR NAMES libunwind.h
+    HINTS ${PC_LIBUNWIND_INCLUDE_DIRS}
+    PATH_SUFFIXES libunwind)
+  mark_as_advanced(LIBUNWIND_INCLUDE_DIR)
+
+  # Resolve each library from the static set (Libs + Libs.private) to a
+  # full path.  This gives the linker everything it needs for a fully-static
+  # link without leaking imported targets through cmake exports.
+  set(LIBUNWIND_LIBRARIES "")
+  foreach(_lib IN LISTS PC_LIBUNWIND_STATIC_LIBRARIES)
+    find_library(_libunwind_dep_${_lib} NAMES ${_lib}
+      HINTS ${PC_LIBUNWIND_STATIC_LIBRARY_DIRS})
+    if(_libunwind_dep_${_lib})
+      list(APPEND LIBUNWIND_LIBRARIES ${_libunwind_dep_${_lib}})
+    else()
+      # Fall back to bare name; the linker will resolve -l<name>.
+      list(APPEND LIBUNWIND_LIBRARIES ${_lib})
+    endif()
+    unset(_libunwind_dep_${_lib} CACHE)
+  endforeach()
+  set(LIBUNWIND_LIBRARY "${LIBUNWIND_LIBRARIES}")
+
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibUnwind
+    REQUIRED_VARS LIBUNWIND_LIBRARIES LIBUNWIND_INCLUDE_DIR)
+else()
+  # Fallback for systems without pkg-config.
+  # When using prepackaged LLVM libunwind on Ubuntu, its includes are
+  # installed in a subdirectory.
+  find_path(LIBUNWIND_INCLUDE_DIR NAMES libunwind.h PATH_SUFFIXES libunwind)
+  mark_as_advanced(LIBUNWIND_INCLUDE_DIR)
+
+  find_library(LIBUNWIND_LIBRARY NAMES unwind)
+  mark_as_advanced(LIBUNWIND_LIBRARY)
+
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibUnwind
+    REQUIRED_VARS LIBUNWIND_LIBRARY LIBUNWIND_INCLUDE_DIR)
+endif()
+
+if(LibUnwind_FOUND)
+  if(NOT LIBUNWIND_LIBRARIES)
+    set(LIBUNWIND_LIBRARIES ${LIBUNWIND_LIBRARY})
+  endif()
   set(LIBUNWIND_INCLUDE_DIRS ${LIBUNWIND_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
Summary: The existing FindLibUnwind.cmake uses a bare find_library which misses transitive dependencies (e.g. lzma, zlib) that static libunwind needs. Switch to preferring pkg-config which picks up the full set of static dependencies from Libs.private, with a fallback to the original find_library approach for systems without pkg-config.

Reviewed By: bigfootjon

Differential Revision: D93644458


