### PR TITLE
Static lib handling for glog

### DIFF
--- a/CMake/folly-config.cmake.in
+++ b/CMake/folly-config.cmake.in
@@ -20,6 +20,11 @@ set_and_check(FOLLY_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_DIR@")
 # folly's prefix directory in the FOLLY_PREFIX_DIR variable
 set(FOLLY_PREFIX_DIR "${PACKAGE_PREFIX_DIR}")
 
+# Find glog before loading targets, since targets reference the glog::glog target
+if(NOT TARGET glog::glog)
+  find_package(Glog QUIET)
+endif()
+
 # Include the folly-targets.cmake file, which is generated from our CMake rules
 if (NOT TARGET Folly::folly)
   include("${FOLLY_CMAKE_DIR}/folly-targets.cmake")

--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -75,7 +75,7 @@ endif()
 
 find_package(Glog MODULE)
 set(FOLLY_HAVE_LIBGLOG ${GLOG_FOUND})
-list(APPEND FOLLY_LINK_LIBRARIES ${GLOG_LIBRARY})
+list(APPEND FOLLY_LINK_LIBRARIES glog::glog)
 list(APPEND FOLLY_INCLUDE_DIRECTORIES ${GLOG_INCLUDE_DIR})
 # Glog 0.7+ requires GLOG_USE_GLOG_EXPORT to be defined so that headers
 # include glog/export.h which defines GLOG_EXPORT.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,7 +449,7 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       follybenchmark
       folly
       ${LIBGMOCK_LIBRARIES}
-      ${GLOG_LIBRARY}
+      glog::glog
   )
   apply_folly_compile_options_to_target(folly_test_support)
 

--- a/build/fbcode_builder/manifests/gflags
+++ b/build/fbcode_builder/manifests/gflags
@@ -10,10 +10,15 @@ builder = cmake
 subdir = gflags-2.2.2
 
 [cmake.defines]
-BUILD_SHARED_LIBS = ON
 BUILD_STATIC_LIBS = ON
 #BUILD_gflags_nothreads_LIB = OFF
 BUILD_gflags_LIB = ON
+
+[cmake.defines.os=windows]
+BUILD_SHARED_LIBS = ON
+
+[cmake.defines.shared_libs=on]
+BUILD_SHARED_LIBS = ON
 
 [homebrew]
 gflags

--- a/build/fbcode_builder/manifests/glog
+++ b/build/fbcode_builder/manifests/glog
@@ -13,9 +13,14 @@ subdir = glog-0.5.0
 gflags
 
 [cmake.defines]
-BUILD_SHARED_LIBS=ON
 BUILD_TESTING=NO
 WITH_PKGCONFIG=ON
+
+[cmake.defines.os=windows]
+BUILD_SHARED_LIBS=ON
+
+[cmake.defines.shared_libs=on]
+BUILD_SHARED_LIBS=ON
 
 [cmake.defines.os=freebsd]
 HAVE_TR1_UNORDERED_MAP=OFF


### PR DESCRIPTION
Summary: Move BUILD_SHARED_LIBS=ON from the unconditional cmake.defines section to a shared_libs=on conditional section in the glog manifest, so that static builds don't force shared library generation.

Reviewed By: bigfootjon

Differential Revision: D93644456


