### PR TITLE
Make folly_detail_perf_scoped depend on folly_subprocess

### DIFF
--- a/folly/detail/CMakeLists.txt
+++ b/folly/detail/CMakeLists.txt
@@ -169,6 +169,11 @@ folly_add_library(
     folly_mpmc_queue
 )
 
+set(FOLLY_PERF_SCOPED_DEPS folly_conv folly_system_pid folly_testing_test_util)
+if (NOT WIN32)
+  list(APPEND FOLLY_PERF_SCOPED_DEPS folly_subprocess)
+endif()
+
 folly_add_library(
   NAME perf_scoped
   SRCS
@@ -176,9 +181,7 @@ folly_add_library(
   HEADERS
     PerfScoped.h
   DEPS
-    folly_conv
-    folly_system_pid
-    folly_testing_test_util
+    ${FOLLY_PERF_SCOPED_DEPS}
   EXTERNAL_DEPS
     Boost::regex
 )


### PR DESCRIPTION
On Linux platforms PerfScoped.cpp pulls in Subprocess.h, so linking in folly_detail_perf_scoped either on its own or via the catch-all target fails unless folly_subprocess is explicitly passed in as well. Make the dependency explicit instead.