### PR TITLE
Fix typo: seperate to separate

### DIFF
--- a/folly/debugging/symbolizer/test/BUCK
+++ b/folly/debugging/symbolizer/test/BUCK
@@ -82,7 +82,7 @@ fbcode_target(
     _kind = cpp_unittest,
     name = "elf_test",
     srcs = ["ElfTest.cpp"],
-    # Do NOT move segments to a seperate helper .so lib because
+    # Do NOT move segments to a separate helper .so lib because
     # this test expect to find its symbols in /proc/self/exe.
     extract_helper_lib = False,
     resources = [


### PR DESCRIPTION
Fixes typo in BUCK file comment where 'seperate' should be 'separate'.