### PR TITLE
Migrate folly generate_cmake.py to shared library + add select() support

### DIFF
--- a/folly/detail/CMakeLists.txt
+++ b/folly/detail/CMakeLists.txt
@@ -169,6 +169,11 @@ folly_add_library(
     folly_mpmc_queue
 )
 
+set(FOLLY_DETAIL_PERF_SCOPED_SELECT_DEPS)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND FOLLY_DETAIL_PERF_SCOPED_SELECT_DEPS folly_subprocess)
+endif()
+
 folly_add_library(
   NAME perf_scoped
   SRCS
@@ -179,6 +184,7 @@ folly_add_library(
     folly_conv
     folly_system_pid
     folly_testing_test_util
+    ${FOLLY_DETAIL_PERF_SCOPED_SELECT_DEPS}
   EXTERNAL_DEPS
     Boost::regex
 )

--- a/folly/portability/provide/CMakeLists.txt
+++ b/folly/portability/provide/CMakeLists.txt
@@ -18,8 +18,15 @@ folly_add_library(
   NAME libdwarf
 )
 
+set(FOLLY_PORTABILITY_PROVIDE_LIBUNWIND_SELECT_DEPS)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  list(APPEND FOLLY_PORTABILITY_PROVIDE_LIBUNWIND_SELECT_DEPS folly_portability_provide_libunwind-linux)
+endif()
+
 folly_add_library(
   NAME libunwind
+  DEPS
+    ${FOLLY_PORTABILITY_PROVIDE_LIBUNWIND_SELECT_DEPS}
 )
 
 folly_add_library(


### PR DESCRIPTION
Summary:
- Import shared parsing functions from opensource.buck_to_cmake.buck_parser
  instead of reimplementing extract_list, extract_external_deps, etc.
- Add select() support for deps/exported_deps: non-DEFAULT branches are
  now emitted as conditional CMake variables (if/endif blocks)
- Remove EXTRA_TARGET_DEPS for folly/result/epitaph since the dep is now
  correctly picked up from the select() DEFAULT branch
- Regenerate folly/detail/CMakeLists.txt and folly/portability/provide/CMakeLists.txt
  with newly discovered conditional deps

Differential Revision: D95579501


