### PR TITLE
Fix EAGAIN/EWOULDBLOCK check in AsyncUDPSocketTest recvmsg error handling

### DIFF
--- a/folly/io/async/test/AsyncUDPSocketTest.cpp
+++ b/folly/io/async/test/AsyncUDPSocketTest.cpp
@@ -371,7 +371,7 @@ class UDPNotifyClient : public UDPClient {
 
     ssize_t ret = sock.recvmsg(&msg, 0);
     if (ret < 0) {
-      if (errno != EAGAIN || errno != EWOULDBLOCK) {
+      if (errno != EAGAIN && errno != EWOULDBLOCK) {
         onReadError(
             folly::AsyncSocketException(
                 folly::AsyncSocketException::NETWORK_ERROR, "error"));


### PR DESCRIPTION
Use && instead of || when checking errno. Since errno has a single value, (errno != EAGAIN || errno != EWOULDBLOCK) is always true. The correct logic is to only report errors when errno is neither EAGAIN nor EWOULDBLOCK.