### PR TITLE
Fix incorrect operator names in Range.h comparison operator comments

### DIFF
--- a/folly/Range.h
+++ b/folly/Range.h
@@ -1466,7 +1466,7 @@ std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool> operator>(
 }
 
 /**
- * operator< through conversion for Range<const char*>
+ * operator<= through conversion for Range<const char*>
  */
 template <class T, class U>
 std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool> operator<=(
@@ -1475,7 +1475,7 @@ std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool> operator<=(
 }
 
 /**
- * operator> through conversion for Range<const char*>
+ * operator>= through conversion for Range<const char*>
  */
 template <class T, class U>
 std::enable_if_t<detail::ComparableAsStringPiece<T, U>::value, bool> operator>=(


### PR DESCRIPTION
Correct the Doxygen comments for operator<= and operator>= which mistakenly referred to operator< and operator> respectively.