### PR TITLE
Look for libblake3 and link to it when found

### DIFF
--- a/CMake/folly-deps.cmake
+++ b/CMake/folly-deps.cmake
@@ -179,6 +179,11 @@ if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   list(APPEND FOLLY_LINK_LIBRARIES "execinfo")
 endif ()
 
+find_library(BLAKE3_LIBRARY NAMES blake3)
+if (BLAKE3_LIBRARY)
+  list(APPEND FOLLY_LINK_LIBRARIES ${BLAKE3_LIBRARY})
+endif()
+
 cmake_push_check_state()
 set(CMAKE_REQUIRED_DEFINITIONS -D_XOPEN_SOURCE)
 check_cxx_symbol_exists(swapcontext ucontext.h FOLLY_HAVE_SWAPCONTEXT)


### PR DESCRIPTION
Currently, folly decides whether to use libblake3 symbols solely depending on the existence of `<blake3.h>`:

https://github.com/facebook/folly/blob/5ae1dd9bb1f7da5077b3c7fd5f8a0f193eaba35a/folly/hash/UniqueHashKey.h#L66

... but without any explicit linking directives in the CMake files. Thus, on systems where `<blake3.h>` exists, consumers of folly would fail to link.

This PR introduces optional linking directives to libblake3.

Fixes #2552.