### PR TITLE
OID truncation in getExtOid due to insufficient buffer size

### DIFF
--- a/folly/ssl/OpenSSLCertUtils.cpp
+++ b/folly/ssl/OpenSSLCertUtils.cpp
@@ -57,12 +57,16 @@ std::string getExtOid(X509_EXTENSION* extension) {
   std::string ret(buf_size, '\0');
   auto length = OBJ_obj2txt(ret.data(), ret.size(), object, 1);
 
-  if (length > buf_size) {
+  if (length < 0) {
+    return {};
+  }
+
+  if (length >= buf_size) {
     // Reserve one byte for the terminating zero
-    ret.resize(length, '\0');
+    ret.resize(static_cast<size_t>(length) + 1, '\0');
     OBJ_obj2txt(ret.data(), ret.size(), object, 1);
   }
-  ret.resize(length);
+  ret.resize(static_cast<size_t>(length));
   return ret;
 }
 


### PR DESCRIPTION
getExtOid resizes the buffer to length when OBJ_obj2txt requires more space, but the returned length does not include the null terminator. 
This makes the buffer one byte too small and causes the last character of long OIDs to be truncated. Update the condition to length >= buf_size and resize to length + 1 to return the full OID correctly