### PR TITLE
chore: declare contents: read on the OSS build/test workflow

### DIFF
--- a/.github/workflows/oss-build-and-test.yml
+++ b/.github/workflows/oss-build-and-test.yml
@@ -1,5 +1,8 @@
 name: Buck build and test
 on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
+
 jobs:
   get-toolchains-to-install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`oss-build-and-test.yml` is the public OSS CI workflow (push / pull_request / workflow_dispatch). It only checks out the repo and runs the build/test matrix. The six other workflows in this repo already declare permissions; this brings `oss-build-and-test.yml` in line.