### PR TITLE
Add missing <memory> include in EvictingCacheMap.h

### DIFF
--- a/folly/container/EvictingCacheMap.h
+++ b/folly/container/EvictingCacheMap.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <exception>
 #include <functional>
+#include <memory>
 
 #include <boost/intrusive/list.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>


### PR DESCRIPTION
## Summary

`folly/container/EvictingCacheMap.h` uses `std::unique_ptr` and `std::make_unique` (in `insertImpl`, `extractNode`, and related code) but does not include `<memory>`, relying on it being pulled in transitively by other headers. With toolchains/stdlib combinations where no included header transitively provides `<memory>`, compilation fails.

This adds the missing `#include <memory>`.

Fixes #2598

## Test plan

Header-only, one-line standard-library include addition; no behavior change. The header now self-declares everything it uses from `<memory>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)