### PR TITLE
Fix misleading zeroTime documentation in TokenBucket.h

### DIFF
--- a/folly/TokenBucket.h
+++ b/folly/TokenBucket.h
@@ -68,8 +68,11 @@ class TokenBucketStorage {
    * Constructor.
    *
    * @param zeroTime Initial time at which to consider the token bucket
-   *                 starting to fill. Defaults to 0, so by default token
-   *                 buckets are "empty" after construction.
+   *                 starting to fill. Defaults to 0, the clock epoch. The
+   *                 balance at any time is min((time - zeroTime) * rate,
+   *                 burstSize), so the default yields a full bucket at all
+   *                 but very low rates. Pass the current time to start with
+   *                 an empty bucket.
    */
   explicit TokenBucketStorage(double zeroTime = 0) noexcept
       : zeroTime_(zeroTime) {}
@@ -100,8 +103,9 @@ class TokenBucketStorage {
    * Thread-safe.
    *
    * @param zeroTime Initial time at which to consider the token bucket
-   *                 starting to fill. Defaults to 0, so by default token
-   *                 bucket is reset to "empty".
+   *                 starting to fill. Defaults to 0, the clock epoch, which
+   *                 yields a full bucket at all but very low rates. Pass the
+   *                 current time to reset to an empty bucket.
    */
   void reset(double zeroTime = 0) noexcept {
     zeroTime_.store(zeroTime, std::memory_order_relaxed);
@@ -265,8 +269,11 @@ class BasicDynamicTokenBucket {
    * Constructor.
    *
    * @param zeroTime Initial time at which to consider the token bucket
-   *                 starting to fill. Defaults to 0, so by default token
-   *                 buckets are "empty" after construction.
+   *                 starting to fill. Defaults to 0, the clock epoch. The
+   *                 balance at any time is min((time - zeroTime) * rate,
+   *                 burstSize), so the default yields a full bucket at all
+   *                 but very low rates. Pass defaultClockNow() to start with
+   *                 an empty bucket.
    */
   explicit BasicDynamicTokenBucket(double zeroTime = 0) noexcept
       : bucket_(zeroTime) {}
@@ -288,8 +295,9 @@ class BasicDynamicTokenBucket {
    * Thread-safe.
    *
    * @param zeroTime Initial time at which to consider the token bucket
-   *                 starting to fill. Defaults to 0, so by default token
-   *                 bucket is reset to "empty".
+   *                 starting to fill. Defaults to 0, the clock epoch, which
+   *                 yields a full bucket at all but very low rates. Pass
+   *                 defaultClockNow() to reset to an empty bucket.
    */
   void reset(double zeroTime = 0) noexcept { bucket_.reset(zeroTime); }
 
@@ -495,8 +503,11 @@ class BasicTokenBucket {
    * @param genRate Number of tokens to generate per second.
    * @param burstSize Maximum burst size. Must be greater than 0.
    * @param zeroTime Initial time at which to consider the token bucket
-   *                 starting to fill. Defaults to 0, so by default token
-   *                 bucket is "empty" after construction.
+   *                 starting to fill. Defaults to 0, the clock epoch. The
+   *                 balance at any time is min((time - zeroTime) * rate,
+   *                 burstSize), so the default yields a full bucket at all
+   *                 but very low rates. Pass defaultClockNow() to start with
+   *                 an empty bucket.
    */
   BasicTokenBucket(
       double genRate, double burstSize, double zeroTime = 0) noexcept


### PR DESCRIPTION
## Summary

The constructors and `reset()` of `TokenBucketStorage`, `BasicDynamicTokenBucket`, and `BasicTokenBucket` document the default `zeroTime = 0` as producing an empty bucket. The actual balance is `min((time - zeroTime) * rate, burstSize)`, so the default of 0 (the clock epoch -- machine boot for `steady_clock`) yields a **full** bucket at all but very low rates, and a partially-filled one at very low rates.

This mismatch is the root cause of the confusion in #2430: a default-constructed `DynamicTokenBucket` at `rate = 0.0001` was expected to hold one token (empty buckets that immediately served single-token consumes at normal rates reinforced that expectation), but it actually held `uptime * rate` tokens (~0.376 on the reporter's machine), so `consumeWithBorrowNonBlocking` correctly borrowed the remaining ~0.624 tokens and returned a wait of `0.624 / 0.0001 = 6241.23s` -- exactly the value in the reported failure. There is no precision bug; the documentation was describing semantics the code never had.

This updates the five affected doc comments to state the real balance formula and how to start with an actually-empty bucket (pass the current time / `defaultClockNow()` as `zeroTime`).

Fixes #2430

## Test plan

Documentation-only change; no code modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)