### PR TITLE
Fix compatibility with fmt 12.2.0

### DIFF
--- a/CMake/FindFmt.cmake
+++ b/CMake/FindFmt.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_path(LIBFMT_INCLUDE_DIR fmt/core.h)
+find_path(LIBFMT_INCLUDE_DIR fmt/format.h)
 mark_as_advanced(LIBFMT_INCLUDE_DIR)
 
 find_library(LIBFMT_LIBRARY NAMES fmt fmtd)

--- a/folly/Format.h
+++ b/folly/Format.h
@@ -20,7 +20,7 @@
 
 /**
  * folly::format has been superseded by
- * [fmt](https://fmt.dev/latest/index.html). `#include <fmt/core.h>`
+ * [fmt](https://fmt.dev/latest/index.html). `#include <fmt/format.h>`
  *
  * format() performs text-formatting, similar to Python's str.format. The full
  * specification is on github:

--- a/folly/IPAddress.cpp
+++ b/folly/IPAddress.cpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/String.h>
 #include <folly/detail/IPAddressSource.h>

--- a/folly/IPAddressV4.cpp
+++ b/folly/IPAddressV4.cpp
@@ -19,7 +19,7 @@
 #include <ostream>
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/Conv.h>
 #include <folly/IPAddress.h>

--- a/folly/IPAddressV6.cpp
+++ b/folly/IPAddressV6.cpp
@@ -20,7 +20,7 @@
 #include <ostream>
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/IPAddress.h>
 #include <folly/IPAddressV4.h>

--- a/folly/SocketAddress.cpp
+++ b/folly/SocketAddress.cpp
@@ -31,7 +31,7 @@
 
 #include <boost/functional/hash.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/Exception.h>
 #include <folly/hash/Hash.h>

--- a/folly/algorithm/simd/test/FindFixedBenchmark.cpp
+++ b/folly/algorithm/simd/test/FindFixedBenchmark.cpp
@@ -19,7 +19,7 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cstdint>

--- a/folly/algorithm/simd/test/FindFixedTest.cpp
+++ b/folly/algorithm/simd/test/FindFixedTest.cpp
@@ -20,7 +20,7 @@
 
 #include <folly/algorithm/simd/FindFixed.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <folly/portability/GTest.h>

--- a/folly/cli/Args.cpp
+++ b/folly/cli/Args.cpp
@@ -24,7 +24,7 @@
 #include <system_error>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/FileUtil.h>
 

--- a/folly/concurrency/CacheLocality.cpp
+++ b/folly/concurrency/CacheLocality.cpp
@@ -29,7 +29,7 @@
 #include <optional>
 #include <unordered_map>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 #include <folly/Indestructible.h>
 #include <folly/Memory.h>

--- a/folly/container/test/F14InterprocessTest.cpp
+++ b/folly/container/test/F14InterprocessTest.cpp
@@ -24,7 +24,7 @@
 #include <boost/interprocess/allocators/adaptive_pool.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/Random.h>
 #include <folly/Traits.h>

--- a/folly/container/test/SparseByteSetBenchmark.cpp
+++ b/folly/container/test/SparseByteSetBenchmark.cpp
@@ -24,7 +24,7 @@
 #include <random>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Benchmark.h>
 #include <folly/Format.h>
 #include <folly/portability/GFlags.h>

--- a/folly/detail/IPAddressSource.h
+++ b/folly/detail/IPAddressSource.h
@@ -26,7 +26,7 @@
 
 #include <glog/logging.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/detail/IPAddress.h>
 
 // BSDish platforms don't provide standard access to s6_addr16

--- a/folly/executors/test/IOThreadPoolDeadlockDetectorObserverTest.cpp
+++ b/folly/executors/test/IOThreadPoolDeadlockDetectorObserverTest.cpp
@@ -16,7 +16,7 @@
 
 #include <memory>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <glog/logging.h>
 #include <folly/concurrency/DeadlockDetector.h>

--- a/folly/fibers/detail/AtomicBatchDispatcher.cpp
+++ b/folly/fibers/detail/AtomicBatchDispatcher.cpp
@@ -18,7 +18,7 @@
 
 #include <cassert>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace folly {
 namespace fibers {

--- a/folly/futures/detail/Core.cpp
+++ b/folly/futures/detail/Core.cpp
@@ -18,7 +18,7 @@
 
 #include <new>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Utility.h>
 #include <folly/lang/Assume.h>
 

--- a/folly/hash/test/HashBenchmark.cpp
+++ b/folly/hash/test/HashBenchmark.cpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <folly/Benchmark.h>

--- a/folly/io/async/fdsock/AsyncFdSocket.cpp
+++ b/folly/io/async/fdsock/AsyncFdSocket.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <limits>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include "AsyncFdSocket.h"
 

--- a/folly/io/test/FsUtilTest.cpp
+++ b/folly/io/test/FsUtilTest.cpp
@@ -20,7 +20,7 @@
 #include <fstream>
 #include <random>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <folly/String.h>

--- a/folly/io/tool/HugePageUtil.cpp
+++ b/folly/io/tool/HugePageUtil.cpp
@@ -18,7 +18,7 @@
 
 #include <glog/logging.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Range.h>
 #include <folly/io/HugePages.h>
 #include <folly/portability/GFlags.h>

--- a/folly/lang/Exception.h
+++ b/folly/lang/Exception.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstring>
 #include <exception>
 #include <functional>
 #include <string>

--- a/folly/lang/test/BitsTest.cpp
+++ b/folly/lang/test/BitsTest.cpp
@@ -20,7 +20,7 @@
 #include <random>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/Random.h>
 #include <folly/portability/GTest.h>

--- a/folly/logging/CustomLogFormatter.cpp
+++ b/folly/logging/CustomLogFormatter.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/logging/CustomLogFormatter.h>
 
 #include <algorithm>

--- a/folly/logging/LogStreamProcessor.h
+++ b/folly/logging/LogStreamProcessor.h
@@ -18,7 +18,7 @@
 
 #include <cstdlib>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/CPortability.h>
 #include <folly/Conv.h>
 #include <folly/ExceptionString.h>

--- a/folly/math/test/ReproducibleAccumulatorTest.cpp
+++ b/folly/math/test/ReproducibleAccumulatorTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/math/ReproducibleAccumulator.h>
 

--- a/folly/observer/WithJitter-inl.h
+++ b/folly/observer/WithJitter-inl.h
@@ -22,7 +22,7 @@
 #include <utility>
 
 #include <fmt/chrono.h>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <folly/DefaultKeepAliveExecutor.h>

--- a/folly/python/import.h
+++ b/folly/python/import.h
@@ -18,7 +18,7 @@
 
 #include <atomic>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/Likely.h>
 #include <folly/Portability.h>

--- a/folly/result/demo/basketball.cpp
+++ b/folly/result/demo/basketball.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Portability.h> // FOLLY_HAS_RESULT
 #include <folly/result/coro.h>
 #include <folly/result/epitaph.h>

--- a/folly/result/rich_error_base.h
+++ b/folly/result/rich_error_base.h
@@ -27,7 +27,7 @@
 
 #include <iosfwd>
 #include <iterator>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 // Old `fmt` isn't actually supported, but ... it needs to build :(
 #if FMT_VERSION < 80000

--- a/folly/result/rich_error_code.h
+++ b/folly/result/rich_error_code.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <optional>
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/lang/Pretty.h>
 #include <folly/result/rich_error_base.h>

--- a/folly/result/test/rich_error_code_test.cpp
+++ b/folly/result/test/rich_error_code_test.cpp
@@ -20,7 +20,7 @@
 #include <optional>
 #include <typeinfo>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/format.h>
 #include <folly/Traits.h>
 #include <folly/Utility.h>

--- a/folly/result/test/rich_error_codes.h
+++ b/folly/result/test/rich_error_codes.h
@@ -19,7 +19,7 @@
 #include <cstdint>
 #include <type_traits>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/format.h>
 #include <folly/Traits.h>
 #include <folly/result/rich_error.h>

--- a/folly/settings/CommandLineParser.cpp
+++ b/folly/settings/CommandLineParser.cpp
@@ -21,7 +21,7 @@
 #include <optional>
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/format.h>
 #include <folly/ExceptionString.h>
 #include <folly/Function.h>

--- a/folly/synchronization/test/SmallLocksBenchmark.cpp
+++ b/folly/synchronization/test/SmallLocksBenchmark.cpp
@@ -23,7 +23,7 @@
 #include <thread>
 #include <vector>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/Benchmark.h>
 #include <folly/SharedMutex.h>

--- a/folly/system/MemoryMapping.cpp
+++ b/folly/system/MemoryMapping.cpp
@@ -23,7 +23,7 @@
 #include <cerrno>
 #include <utility>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <folly/Portability.h>

--- a/folly/test/FileTest.cpp
+++ b/folly/test/FileTest.cpp
@@ -19,7 +19,7 @@
 #include <fstream>
 #include <random>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <folly/String.h>

--- a/folly/test/IPAddressBenchmark.cpp
+++ b/folly/test/IPAddressBenchmark.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/IPAddress.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <glog/logging.h>
 
 #include <folly/Benchmark.h>

--- a/folly/test/IPAddressTest.cpp
+++ b/folly/test/IPAddressTest.cpp
@@ -20,7 +20,7 @@
 
 #include <string>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/MacAddress.h>
 #include <folly/String.h>

--- a/folly/test/MacAddressTest.cpp
+++ b/folly/test/MacAddressTest.cpp
@@ -16,7 +16,7 @@
 
 #include <folly/MacAddress.h>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <folly/IPAddressV6.h>
 #include <folly/portability/GTest.h>

--- a/folly/test/MemsetBenchmark.cpp
+++ b/folly/test/MemsetBenchmark.cpp
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <deque>
 #include <string>
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <folly/Benchmark.h>
 #include <folly/Preprocessor.h>
 #include <folly/portability/GFlags.h>


### PR DESCRIPTION
## Problem

fmtlib/fmt deprecated `<fmt/core.h>` in commit [0007426](https://github.com/fmtlib/fmt/commit/0007426c2d8d22df6e56d3b4d109415242e683e0). Starting from fmt 12.2.0, using `<fmt/core.h>` causes compilation errors because the deprecated include is now opt-in only.

## Fix

Replace all `#include <fmt/core.h>` with `#include <fmt/format.h>`, which is the standard header in fmt 12.2.0+.