### PR TITLE
Add StableRadixSort improvements and HybridAlloc support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,6 +454,12 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
   apply_folly_compile_options_to_target(folly_test_support)
 
   folly_define_tests(
+    DIRECTORY algorithm/test/
+      TEST algorithm_binary_heap_test SOURCES BinaryHeapTest.cpp
+      TEST algorithm_stable_radix_sort_test SOURCES StableRadixSortTest.cpp
+      BENCHMARK algorithm_stable_radix_sort_benchmark
+        SOURCES StableRadixSortBenchmark.cpp
+
     DIRECTORY algorithm/simd/detail/test/
       TEST algorithm_simd_detail_simd_any_of_test SOURCES SimdAnyOfTest.cpp
       TEST algorithm_simd_detail_simd_for_each_test SOURCES SimdForEachTest.cpp
@@ -508,6 +514,7 @@ if (BUILD_TESTS OR BUILD_BENCHMARKS)
       TEST container_foreach_test SOURCES ForeachTest.cpp
       BENCHMARK container_hash_maps_bench SOURCES HashMapsBench.cpp
       TEST container_heap_vector_types_test SOURCES heap_vector_types_test.cpp
+
       TEST container_map_util_test WINDOWS_DISABLED SOURCES MapUtilTest.cpp
       TEST container_merge_test SOURCES MergeTest.cpp
       TEST container_regex_match_cache_test SOURCES RegexMatchCacheTest.cpp

--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -235,6 +235,16 @@
 #define FOLLY_ALWAYS_INLINE inline
 #endif
 
+// Prefer __restrict over __restrict__ for MSVC compatibility.
+// All major compilers (GCC, Clang, MSVC, Intel) support __restrict
+// directly or via their respective compatibility modes.
+#if defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER) || \
+    defined(__INTEL_COMPILER)
+#define FOLLY_RESTRICT __restrict
+#else
+#define FOLLY_RESTRICT
+#endif
+
 // attribute hidden
 #if defined(_MSC_VER)
 #define FOLLY_ATTR_VISIBILITY_HIDDEN

--- a/folly/algorithm/BUCK
+++ b/folly/algorithm/BUCK
@@ -16,6 +16,10 @@ fb_dirsync_cpp_library(
     headers = ["StableRadixSort.h"],
     use_raw_headers = True,
     exported_deps = [
+        "//folly:constexpr_math",
+        "//folly:memset",
         "//folly:traits",
+        "//folly/container:iterator",
+        "//folly/lang:assume",
     ],
 )

--- a/folly/algorithm/CMakeLists.txt
+++ b/folly/algorithm/CMakeLists.txt
@@ -27,6 +27,10 @@ folly_add_library(
   HEADERS
     StableRadixSort.h
   EXPORTED_DEPS
+    folly_constexpr_math
+    folly_container_iterator
+    folly_lang_assume
+    folly_memset
     folly_traits
 )
 

--- a/folly/algorithm/StableRadixSort.h
+++ b/folly/algorithm/StableRadixSort.h
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,397 +14,1697 @@
  * limitations under the License.
  */
 
+// Compile-time configurable radix sort supporting LSD/MSD traversal,
+// sequential/parallel execution (via OpenMP), configurable digit width,
+// sign handling for signed/floating-point types, and NaN positioning.
+//
+// For high-level usage see stable_radix_sort() and the RadixSortOptions struct.
+
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <bit>
-#include <cstddef>
-#include <cstdint>
-#include <cstring>
+#include <cassert>
+#include <cmath>
+#include <concepts>
 #include <iterator>
+#include <limits>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
+#include <folly/ConstexprMath.h>
+#include <folly/FollyMemset.h>
 #include <folly/Traits.h>
+#include <folly/container/Iterator.h>
+#include <folly/lang/Align.h>
+#include <folly/lang/Assume.h>
+#include <folly/memory/HybridAlloc.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 namespace folly {
+/**
+ * @brief Radix sort traversal strategy.
+ *
+ * @details
+ * - Lsd: Least Significant Digit first. Processes digits from least to most
+ *   significant byte. Stable, iterative, and uses a single flat array.
+ *
+ * - Msd: Most Significant Digit first. Recursively partitions by the most
+ *   significant digit. Forms a tree of sub-problems.
+ *
+ * # Memory layout & algorithm flow
+ *
+ * ## LSD (iterative, multi-pass)
+ *
+ *   Pass 1 (LSB)       Pass 2             Pass 3             Pass 4 (MSB)
+ *   +----------------+ +----------------+ +----------------+ +----------------+
+ *   | array -> buffer| | buffer -> array| | array -> buffer| | buffer -> array|
+ *   +----------------+ +----------------+ +----------------+ +----------------+
+ *   -> sorted
+ *
+ *   - Works on the whole array every pass.
+ *   - Each pass scatters elements into 256 (or 65536) buckets.
+ *   - No recursion, very good cache locality.
+ *
+ * ## MSD (recursive, depth-first)
+ *
+ *   Level 0 (byte 7)      Level 1 (byte 6)          Level 2 (byte 5) ...
+ *   +-------------------------------------+
+ *   |          whole array                |
+ *   +-----------------+-------------------+
+ *                     |
+ *                     | split by most significant byte
+ *              +------+------+
+ *              |      |      |
+ *        +-----+  +-----+  +-----+
+ *        |bucket0|  |bucket1|  ... (up to 256 buckets)
+ *        +--+---+  +--+---+
+ *           |         |
+ *           | recursive sort on next byte
+ *        +--+---+  +--+---+
+ *        |      |  |      |
+ *       ...    ...  ...   ...
+ *
+ *   - High-order bits decide global order early.
+ *   - Once a bucket contains <= threshold, fallback to LSD or insertion sort.
+ *
+ * # Performance considerations
+ *
+ * ## 32-bit keys (e.g., `uint32_t`)
+ *
+ *   - LSD with 8-bit chunks: only 4 passes, each pass scans the whole array.
+ *   - Very predictable memory access, minimal recursion overhead.
+ *   - Usually faster than MSD on modern CPUs (better cache and SIMD friendly).
+ *
+ * ## 64-bit keys (e.g., `uint64_t`)
+ *
+ *   - LSD with 8-bit chunks needs 8 passes -> more memory writes.
+ *   - LSD with 16-bit chunks reduces passes to 4 but uses 65536 buckets,
+ *     increasing histogram memory traffic.
+ *   - MSD can be faster because the highest bytes often distribute data widely.
+ *     After the first pass, sub-problems become much smaller, reducing total
+ *     work. Recursion overhead is amortized over large inputs.
+ *
+ * ## Rule of thumb
+ *
+ *   - For 32-bit integers or small element types, prefer `Lsd`.
+ *   - For 64-bit integers, especially with skewed distributions or when
+ *     the most significant byte has high entropy, `Msd` may outperform `Lsd`.
+ *   - Always benchmark with your actual data.
+ */
+enum class RadixSortStrategy { Lsd, Msd };
 
 /**
- * Stable LSD (Least Significant Digit) Radix Sort
+ * @brief Execution policy for radix sort.
  *
- * A stable, O(n) radix sort implementation using counting sort with
- * alternating buffers. Unlike MSD radix sort (e.g., boost::spreadsort),
- * LSD radix sort processes digits from least to most significant, which
- * inherently preserves stability.
+ * @details
+ * Controls whether the sort runs sequentially or uses parallel execution
  *
- * Key features:
- * - Stable: elements with equal keys preserve their original relative order
- * - O(n) time complexity: k passes of O(n + 256) where k = sizeof(key)/8
- * - O(n) space complexity: requires a temporary buffer
- * - Supports ascending and descending order
- * - Supports custom projections for sorting by member fields
- * - Handles floating-point keys via IEEE 754 bit transformation
- *
- * Example usage:
- *
- *   // Sort vector of integers
- *   std::vector<uint64_t> values = {5, 2, 8, 1, 9};
- *   folly::stable_radix_sort(values.begin(), values.end());
- *
- *   // Sort by struct member
- *   struct Item { double score; int id; };
- *   std::vector<Item> items = ...;
- *   folly::stable_radix_sort(
- *       items.begin(), items.end(),
- *       [](const Item& item) { return item.score; });
- *
- *   // Sort descending
- *   folly::stable_radix_sort_descending(values.begin(), values.end());
+ * @note Parallel execution is only available when _OPENMP is defined.
  */
-
-namespace stable_radix_sort_keys {
-
-/**
- * FloatKey - Converts IEEE 754 floats/doubles to sortable unsigned integers.
- *
- * IEEE 754 floats are almost sortable in their bit representation, except:
- * - The sign bit inverts the comparison for negative numbers
- * - Negative numbers sort in reverse order
- *
- * This transformation maps the float ordering to unsigned integer ordering:
- * - -inf maps to 0x0000...
- * - -0.0 maps to 0x7FFF...  (just below +0.0)
- * - +0.0 maps to 0x8000...
- * - +inf maps to 0xFFFF...
- *
- * Template parameters:
- *   Float - float or double
- *   Descending - if true, inverts the key for descending sort
- */
-template <typename Float, bool Descending = false>
-struct FloatKey {
-  static_assert(
-      std::is_floating_point_v<Float>,
-      "FloatKey requires a floating-point type");
-
-  using UInt = uint_bits_t<sizeof(Float) * 8>;
-  static_assert(sizeof(Float) == sizeof(UInt));
-
-  UInt operator()(Float f) const noexcept {
-    UInt bits = std::bit_cast<UInt>(f);
-    constexpr UInt kSignBit = UInt{1} << (sizeof(UInt) * 8 - 1);
-    // If negative: flip all bits (makes most negative -> 0)
-    // If positive: flip only sign bit (makes positive > all negatives)
-    UInt mask = (bits & kSignBit) ? ~UInt{0} : kSignBit;
-    UInt sortable = bits ^ mask;
-    return Descending ? ~sortable : sortable;
-  }
+enum class RadixExecutionPolicy {
+  Seq, // Sequential execution
+  Par, // Parallel execution (requires OpenMP)
+  /* Unseq,    */
+  /* ParUnseq, */
 };
 
 /**
- * IntegralKey - Handles signed/unsigned integers for radix sort.
- *
- * For unsigned types: identity (no transformation needed)
- * For signed types: flips sign bit to map signed ordering to unsigned
- *
- * Template parameters:
- *   Int - any integral type
- *   Descending - if true, inverts the key for descending sort
+ * @brief Sort order for radix sort.
  */
-template <typename Int, bool Descending = false>
-struct IntegralKey {
-  static_assert(
-      std::is_integral_v<Int>, "IntegralKey requires an integral type");
+enum class RadixSortOrder { Ascending, Descending };
 
-  using UInt = std::make_unsigned_t<Int>;
+/**
+ * @brief Number of bits processed per radix pass.
+ *
+ * @details
+ * Determines the bucket count as 2^RadixBitsPerPass.
+ * - `Bits8`  : 8 bits per pass → 256 buckets, 4 passes for 32‑bit keys.
+ * - `Bits16` : 16 bits per pass → 65536 buckets, 2 passes for 32‑bit keys.
+ *
+ * `Bits16` can be faster for large arrays because it halves the number of
+ * passes, but the larger histogram incurs more memory traffic.
+ */
+enum class RadixBitsPerPass { Bits8 = 8, Bits16 = 16 };
 
-  UInt operator()(Int value) const noexcept {
-    constexpr UInt kSignBit =
-        std::is_signed_v<Int> ? (UInt{1} << (sizeof(UInt) * 8 - 1)) : 0;
-    UInt result = static_cast<UInt>(value) ^ kSignBit;
-    return Descending ? ~result : result;
-  }
+/**
+ * @brief Integer type used for bucket counters in the histogram.
+ *
+ * @details
+ * - `UInt32` (32‑bit): Sufficient for arrays with fewer than 2³² elements.
+ *   Uses less memory for the counter array.
+ * - `UInt64` (64‑bit): Prevents overflow for arrays with 2³² or more elements,
+ *   but doubles the memory footprint of the counter arrays compared to
+ * `UInt32`.
+ *
+ * The choice affects both memory usage and the maximum array size that can
+ * be sorted without counter overflow.
+ */
+enum class RadixHistogramStorageType { UInt32 = 32, UInt64 = 64 };
+
+/**
+ * @brief Controls where NaN values are placed in the sorted order
+ *        when sorting floating-point types.
+ *
+ * @details
+ * This enum is used together with `RadixNaNsAssumption`. When the assumption
+ * is `Existence`, the sort will apply the selected positioning strategy.
+ * When the assumption is `NonExistence`, this setting is ignored (no NaN
+ * handling overhead).
+ *
+ * @warning Requires IEEE 754 compliance (std::numeric_limits<T>::is_iec559)
+ *          to be guaranteed at compile time for predictable behavior.
+ */
+enum class RadixNaNsPosHandling {
+  /// No special treatment. NaN values may appear in arbitrary positions
+  /// because IEEE 754 does not define a total order for NaN.
+  Unhandled,
+
+  /// All NaN values are placed at the very beginning of the sorted output,
+  /// before -inf (the smallest finite value).
+  AtFirst,
+
+  /// All NaN values are placed at the very end, after +inf.
+  AtLast
 };
 
 /**
- * IdentityKey - Returns the value unchanged (for unsigned integers).
+ * @brief Informs the sort whether the input floating‑point array may contain
+ *        NaN values.
+ *
+ * @details
+ * The default is `NonExistence`, which provides the best performance by
+ * skipping all NaN‑related logic. If `Existence` is chosen, the sort will
+ * use the strategy specified by `RadixNaNsPosHandling` to position NaN
+ * values.
+ *
+ * @note This enum applies only to floating‑point types (float, double, etc.).
+ *       For integer types, it has no effect.
  */
-template <bool Descending = false>
-struct IdentityKey {
+enum class RadixNaNsAssumption {
+  /// NaN values may be present; the sort will use `RadixNaNsPosHandling`
+  /// to determine their final position.
+  Existence,
+
+  /// Assume that no NaN values occur in the input. The sort will skip
+  /// all NaN‑handling code, and `RadixNaNsPosHandling` is ignored.
+  NonExistence
+};
+
+/**
+ * @brief Complete set of compile-time options for radix sort.
+ */
+struct RadixSortOptions {
+  RadixSortStrategy SortStrategy = RadixSortStrategy::Lsd;
+  RadixExecutionPolicy ExecutionPolicy = RadixExecutionPolicy::Seq;
+  RadixSortOrder SortOrder = RadixSortOrder::Ascending;
+  RadixBitsPerPass BitsPerPass = RadixBitsPerPass::Bits8;
+  RadixHistogramStorageType HistogramStorageType =
+      RadixHistogramStorageType::UInt32;
+  RadixNaNsPosHandling NaNsPosHandling = RadixNaNsPosHandling::Unhandled;
+  RadixNaNsAssumption NaNsAssumption = RadixNaNsAssumption::NonExistence;
+
+  /// MSD sub-problem size below which LSD is used
+  size_t MsdFallbackToLsdThreshold = 256U * 256U;
+  /// Stack-allocate histogram if under this
+  size_t HistogramStackThresholdBytes = 16U * 1024U;
+};
+
+namespace detail {
+
+// Allocator concepts and RAII
+template <typename Alloc>
+concept standard_allocator = requires(
+    Alloc a, typename std::allocator_traits<Alloc>::size_type n) {
+  typename std::allocator_traits<Alloc>::value_type;
+  requires std::copy_constructible<Alloc>;
+  requires std::same_as<
+      typename std::allocator_traits<Alloc>::pointer,
+      typename std::allocator_traits<Alloc>::value_type*>;
+  {
+    a.allocate(n)
+  } -> std::same_as<typename std::allocator_traits<Alloc>::pointer>;
+  {
+    a.deallocate(
+        std::declval<typename std::allocator_traits<Alloc>::pointer>(), n)
+  } -> std::same_as<void>;
+};
+
+template <standard_allocator Alloc>
+class AllocatorHolder {
+  using Traits = std::allocator_traits<Alloc>;
+
+ public:
+  using value_type = typename Traits::value_type;
+  using pointer = typename Traits::pointer;
+  using size_type = typename Traits::size_type;
+
+  explicit AllocatorHolder(size_type size, Alloc const& alloc)
+      : alloc_(alloc),
+        size_(size),
+        buffer_(size == 0 ? nullptr : Traits::allocate(alloc_, size)) {
+    construct();
+  }
+
+  AllocatorHolder(AllocatorHolder const&) = delete;
+  AllocatorHolder& operator=(AllocatorHolder const&) = delete;
+
+  ~AllocatorHolder() { destroy(); }
+
+  pointer data() noexcept { return buffer_; }
+
+ private:
+  void construct() {
+    if constexpr (
+        !std::is_trivially_default_constructible_v<value_type> ||
+        !std::is_trivially_destructible_v<value_type>) {
+      size_type i = 0;
+      try {
+        for (; i < size_; ++i) {
+          Traits::construct(alloc_, buffer_ + i);
+        }
+      } catch (...) {
+        for (size_type j = 0; j < i; ++j) {
+          Traits::destroy(alloc_, buffer_ + j);
+        }
+        Traits::deallocate(alloc_, buffer_, size_);
+        throw;
+      }
+    }
+  }
+
+  void destroy() noexcept {
+    if (buffer_ == nullptr) {
+      return;
+    }
+    if constexpr (!std::is_trivially_destructible_v<value_type>) {
+      for (size_type i = 0; i < size_; ++i) {
+        Traits::destroy(alloc_, buffer_ + i);
+      }
+    }
+    Traits::deallocate(alloc_, buffer_, size_);
+  }
+
+  [[no_unique_address]] Alloc alloc_;
+  size_type size_{0};
+  pointer buffer_{nullptr};
+};
+
+/// RAII wrapper around FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD / hybridFree.
+template <class T>
+class HybridAllocHolder {
+  static_assert(
+      std::is_object_v<T>, "HybridAllocHolder requires an object type");
+
+ public:
+  using value_type = T;
+  using pointer = T*;
+  using size_type = std::size_t;
+
+  HybridAllocHolder(void* ptr, size_type size)
+      : data_(static_cast<pointer>(ptr)), size_(size) {}
+
+  HybridAllocHolder(HybridAllocHolder const&) = delete;
+  HybridAllocHolder& operator=(HybridAllocHolder const&) = delete;
+  HybridAllocHolder(HybridAllocHolder&&) = delete;
+  HybridAllocHolder& operator=(HybridAllocHolder&&) = delete;
+
+  ~HybridAllocHolder() {
+    if (data_ == nullptr) {
+      return;
+    }
+    if constexpr (!std::is_trivially_destructible_v<value_type>) {
+      for (size_type i = 0; i < size_; ++i) {
+        std::destroy_at(data_ + i);
+      }
+    }
+    hybridFree(data_);
+  }
+
+  pointer data() noexcept { return data_; }
+  const pointer data() const noexcept { return data_; }
+  size_type size() const noexcept { return size_; }
+
+  T& operator[](size_type i) noexcept { return data_[i]; }
+  const T& operator[](size_type i) const noexcept { return data_[i]; }
+
+ private:
+  pointer data_{nullptr};
+  size_type size_{0};
+};
+
+// User key maps must return arithmetic keys.
+template <typename KeyMap, typename T>
+concept arithmetic_key_map = std::regular_invocable<KeyMap, T> &&
+    std::is_arithmetic_v<std::invoke_result_t<KeyMap, T>>;
+
+// Internal projections must return unsigned radix keys.
+template <typename Projection, typename T>
+concept unsigned_integral_projection = requires(Projection p, T t) {
+  requires std::regular_invocable<Projection, T>;
+  { p(t) } -> std::unsigned_integral;
+};
+
+// Adjusts sort order for reverse iterators at compile time.
+template <typename Iter, RadixSortOrder Order>
+struct RadixRealSortOrder {
+  static constexpr RadixSortOrder value = Order;
+};
+
+// Reverse iterators invert the requested sort order.
+template <typename WrappedIter, RadixSortOrder Order>
+struct RadixRealSortOrder<std::reverse_iterator<WrappedIter>, Order> {
+  static constexpr RadixSortOrder value = (Order == RadixSortOrder::Ascending)
+      ? RadixSortOrder::Descending
+      : RadixSortOrder::Ascending;
+};
+
+// Default key map for arithmetic value types.
+struct radix_key_map_fn {
   template <typename T>
-  T operator()(T value) const noexcept {
-    return Descending ? ~value : value;
+  constexpr T operator()(T val) const noexcept {
+    return val;
   }
 };
+inline constexpr radix_key_map_fn radix_key_map{};
 
-} // namespace stable_radix_sort_keys
+///< Sign-bit traits
 
-namespace stable_radix_sort_detail {
+// Provides bit masks and indices for the sign bit of an arithmetic type.
+template <typename T>
+struct SignBitTraits {
+  static_assert(std::is_arithmetic_v<T>, "arithmetic type required");
+  using type = T;
+  using uint_t = folly::uint_bits_t<sizeof(T) * CHAR_BIT>;
+  static constexpr size_t kSignBitIndex = sizeof(T) * CHAR_BIT - 1;
+  static constexpr uint_t kAllBitMask = ~uint_t(0);
+  static constexpr uint_t kSignBitMask = kAllBitMask << kSignBitIndex;
+};
 
-// Size threshold below which we fall back to insertion sort
-inline constexpr size_t kRadixSortThreshold = 16;
+///< Radix sort traits (compile-time parameter bundle)
 
-// Radix configuration
-inline constexpr size_t kRadixBits = 8;
-static_assert(kRadixBits == 8, "extractRadixDigit assumes 8-bit radix");
-inline constexpr size_t kRadixBuckets = 1 << kRadixBits; // 256
-inline constexpr size_t kRadixMask = kRadixBuckets - 1;
+// Compile-time parameter pack combining user options, element type, and key.
+template <
+    RadixSortOptions RadixOptions,
+    typename T,
+    detail::arithmetic_key_map<T> KeyMap>
+struct RadixSortTraits : SignBitTraits<std::invoke_result_t<KeyMap, T>> {
+  // Re-export user options
+  static constexpr auto kSortStrategy = RadixOptions.SortStrategy;
+  static constexpr auto kExecutionPolicy = RadixOptions.ExecutionPolicy;
+  static constexpr auto kSortOrder = RadixOptions.SortOrder;
+  static constexpr auto kNaNsPosHandling = RadixOptions.NaNsPosHandling;
+  static constexpr auto kNaNsAssumption = RadixOptions.NaNsAssumption;
+  static constexpr auto kHistogramStackThresholdBytes =
+      RadixOptions.HistogramStackThresholdBytes;
+  static constexpr auto kMsdFallbackToLsdThreshold =
+      RadixOptions.MsdFallbackToLsdThreshold;
 
-template <typename Key>
-inline constexpr size_t kRadixPasses = sizeof(Key);
+  // Core type aliases
+  using value_t = T;
+  using key_t = std::invoke_result_t<KeyMap, T>;
+  using uint_t = typename SignBitTraits<key_t>::uint_t;
+  using hist_t = std::conditional_t<
+      RadixOptions.HistogramStorageType == RadixHistogramStorageType::UInt32,
+      std::uint32_t,
+      std::uint64_t>;
 
-/**
- * Extract the radix digit at the given pass index from a key.
- * Pass 0 extracts the least significant digit.
- */
-template <typename Key>
-inline uint8_t extractRadixDigit(Key key, size_t pass) noexcept {
-  static_assert(std::is_unsigned_v<Key>, "Key must be unsigned");
-  // kRadixPasses ensures pass is always < sizeof(Key), so shift is safe
-  return static_cast<uint8_t>((key >> (pass * kRadixBits)) & kRadixMask);
+  // Radix parameters
+  static constexpr size_t kBitsPerPass =
+      static_cast<std::underlying_type_t<RadixBitsPerPass>>(
+          RadixOptions.BitsPerPass);
+  static constexpr size_t kNumPasses = sizeof(uint_t) * CHAR_BIT / kBitsPerPass;
+  static constexpr size_t kNumBuckets = constexpr_pow(2, kBitsPerPass);
+  static constexpr size_t kRadixMask = kNumBuckets - 1U;
+
+  // Pass order (for LSD vs MSD)
+  static constexpr size_t kFirstPass =
+      kSortStrategy == RadixSortStrategy::Lsd ? 0 : kNumPasses - 1;
+  static constexpr size_t kLastPass =
+      kSortStrategy == RadixSortStrategy::Lsd ? kNumPasses - 1 : 0;
+
+  // Whether sign correction is applied on the first pass
+  static constexpr bool kIsSignHandlingOnFirstPass =
+      (kSortStrategy == RadixSortStrategy::Msd || kNumPasses == 1) &&
+      std::is_signed_v<key_t>;
+
+  // Compile-time sequence of all pass indices
+  static constexpr auto kPassIndices = std::make_index_sequence<kNumPasses>{};
+};
+
+///< Unsigned integer projection
+
+/// Projects elements to unsigned integers for radix sorting.
+/// Composes a user KeyMap with bit-level transformations for signed integers
+/// and IEEE 754 floats, handling sign bits and NaN positioning.
+struct radix_uint_projection_fn {
+  template <
+      RadixNaNsPosHandling NaNsPosHandling,
+      typename Arithmetic,
+      typename KeyMap>
+  struct Projector {
+    KeyMap km_;
+
+    using Traits = SignBitTraits<Arithmetic>;
+    using uint_t = typename Traits::uint_t;
+
+    /// Transforms an arithmetic key into an unsigned integer.
+    /// Unsigned → identity. Signed → flips sign bit (if IsSignBitHandling).
+    /// IEEE 754 → maps negative floats to [0, 0x7F..FF], positive to
+    /// [0x80..00, 0xFF..FF]; NaN goes to 0 or max if requested.
+    template <bool IsSignBitHandling = !std::unsigned_integral<Arithmetic>>
+    static constexpr auto transform(Arithmetic key) noexcept -> uint_t {
+      if constexpr (
+          std::same_as<Arithmetic, bool> ||
+          std::unsigned_integral<Arithmetic>) {
+        // Unsigned types need no transformation.
+        return key;
+      } else if constexpr (std::signed_integral<Arithmetic>) {
+        // Two's complement signed integers: flip sign bit for correct order.
+        return IsSignBitHandling
+            ? static_cast<uint_t>(key) ^ Traits::kSignBitMask
+            : static_cast<uint_t>(key);
+      } else if constexpr (std::floating_point<Arithmetic>) {
+        static_assert(
+            !(NaNsPosHandling != RadixNaNsPosHandling::Unhandled &&
+              !std::numeric_limits<Arithmetic>::is_iec559),
+            "NaN pos handling requires IEEE 754 floating-point");
+
+        // Handle NaNs if requested.
+        if constexpr (NaNsPosHandling != RadixNaNsPosHandling::Unhandled) {
+          if (std::isnan(key)) {
+            // Map NaN to either the smallest or largest possible key so
+            // that it sorts to the beginning or end of the sequence.
+            return NaNsPosHandling == RadixNaNsPosHandling::AtFirst
+                ? uint_t(0)
+                : std::numeric_limits<uint_t>::max();
+          }
+        }
+        const auto v = std::bit_cast<uint_t>(key);
+
+        // signMask is 0 for positive floats, ~0 for negative.
+        // Computed as 0 - (v >> kSignBitIndex) with unsigned wrap.
+        const auto signMask = (uint_t(0) - (v >> Traits::kSignBitIndex));
+
+        // Apply sign-bit flip and, for negatives, invert all bits except sign.
+        uint_t base = IsSignBitHandling
+            ? (v ^ signMask) | (Traits::kSignBitMask & ~signMask)
+            : (v ^ signMask);
+
+        // Shift finite values up by one if NaN occupies slot 0.
+        if constexpr (NaNsPosHandling == RadixNaNsPosHandling::AtFirst) {
+          base += 1U;
+        }
+        return base;
+      } else {
+        assume_unreachable();
+      }
+    }
+
+    template <bool IsSignBitHandling = !std::unsigned_integral<Arithmetic>>
+    constexpr auto operator()(const auto& x) const noexcept -> uint_t {
+      return transform<IsSignBitHandling>(km_(x));
+    }
+
+    constexpr auto getKeyMap() const noexcept -> const KeyMap& { return km_; }
+  };
+
+  template <RadixNaNsPosHandling NaNsPosHandling, typename T, typename KeyMap>
+  constexpr auto operator()(
+      std::in_place_type_t<T>, KeyMap&& keyMap) const noexcept {
+    using arithmetic_t = std::invoke_result_t<KeyMap, T>;
+    return Projector<NaNsPosHandling, arithmetic_t, std::decay_t<KeyMap>>{
+        std::forward<KeyMap>(keyMap)};
+  }
+};
+inline constexpr radix_uint_projection_fn radix_uint_projection{};
+
+///< Radix digit extraction
+
+/// Returns the bucket index for a key in a given radix pass.
+/// Shifts by `pass * kBitsPerPass` and masks with `kRadixMask`.
+/// In descending order, inverts the key first.
+template <typename RadixTraits>
+#if !defined(DEBUG) && !defined(_DEBUG)
+FOLLY_ALWAYS_INLINE
+#endif
+    constexpr auto nthRadix(
+        typename RadixTraits::uint_t x, size_t pass) noexcept -> size_t {
+  if constexpr (RadixTraits::kSortOrder == RadixSortOrder::Ascending) {
+    return (x >> RadixTraits::kBitsPerPass * pass) & RadixTraits::kRadixMask;
+  } else if constexpr (RadixTraits::kSortOrder == RadixSortOrder::Descending) {
+    return ((~x) >> RadixTraits::kBitsPerPass * pass) & RadixTraits::kRadixMask;
+  } else {
+    assume_unreachable();
+  }
 }
 
-/**
- * Stable insertion sort for small inputs.
- * O(n^2) but fast for small n due to low overhead.
- */
-template <typename RandomIt, typename Projection>
-void insertionSort(RandomIt first, RandomIt last, Projection proj) {
-  for (auto i = first; i != last; ++i) {
-    auto key = proj(*i);
-    auto j = i;
-    while (j != first) {
-      auto prev = j;
+/// Returns the most significant set bit index of an arithmetic value.
+/// Used to skip radix passes whose higher-order bits are all zero.
+/// For floating-point, evaluates the IEEE 754 bit representation.
+template <typename T>
+#if !defined(DEBUG) && !defined(_DEBUG)
+FOLLY_ALWAYS_INLINE
+#endif
+    constexpr auto highestOneBitIndex(T value) noexcept -> size_t {
+  static_assert(std::is_arithmetic_v<T>, "T must be arithmetic");
+  using uint_t = uint_bits_t<sizeof(T) * CHAR_BIT>;
+
+  uint_t bits;
+  if constexpr (std::is_integral_v<T>) {
+    // Preserve two's complement bit pattern
+    bits = static_cast<uint_t>(value);
+  } else if constexpr (std::is_floating_point_v<T>) {
+    bits = std::bit_cast<uint_t>(value);
+  } else {
+    assume_unreachable();
+  }
+
+  return std::bit_width(static_cast<uint_t>(bits | uint_t(1))) - 1;
+}
+
+///< Radix parallel computing utils
+
+/// Thread-chunk descriptors for distributing work across OpenMP threads.
+struct ThreadChunkInfo {
+  uint32_t threads; ///< Total OpenMP threads.
+  uint32_t remain; ///< Threads that process one extra element.
+  size_t step; ///< floor(n / threads) — base elements per thread.
+};
+
+/// Per-thread chunk statistics used for sortedness detection.
+template <typename T>
+struct ThreadChunkStats {
+  bool isSorted; ///< Whether the chunk is locally sorted (ascending).
+  T minVal; ///< Minimum value in the chunk.
+  T maxVal; ///< Maximum value in the chunk.
+};
+
+/// Returns the half-open [beg, end) range assigned to thread `tid`.
+#if !defined(DEBUG) && !defined(_DEBUG)
+FOLLY_ALWAYS_INLINE
+#endif
+constexpr auto computeThreadChunkRange(
+    size_t tid, size_t step, size_t remain) noexcept
+    -> std::pair<size_t, size_t> {
+  size_t begIndex, endIndex;
+  if (tid < remain) {
+    begIndex = tid * (step + 1);
+    endIndex = begIndex + (step + 1);
+  } else {
+    begIndex = remain * (step + 1) + (tid - remain) * step;
+    endIndex = begIndex + step;
+  }
+  return std::pair{begIndex, endIndex};
+}
+
+///< Radix sort fallback sorting mode
+
+/// Maximum element count for which insertion sort is used instead of radix
+/// sort.
+inline constexpr size_t kRadixSortThreshold = 64U;
+
+/// Partitions boolean values into false/true groups in a single pass.
+template <std::random_access_iterator RandIter, bool Descending>
+constexpr void sortBool(RandIter first, RandIter last) {
+  size_t cnt = 0;
+  for (auto curr = first; curr < last; ++curr) {
+    const auto v = *curr;
+    *curr = Descending ? false : true;
+    *(first + cnt) = v;
+    cnt += static_cast<size_t>(Descending ? v : !v);
+  }
+}
+
+/// Insertion sort over a bidirectional iterator range.
+template <
+    std::bidirectional_iterator BiIter,
+    std::indirect_strict_weak_order<BiIter> Compare = std::ranges::less>
+constexpr void insertionSort(BiIter first, BiIter last, Compare comp = {}) {
+  if (first == last) [[unlikely]] {
+    return;
+  }
+  for (auto current = std::next(first); current != last; ++current) {
+    auto value = std::move(*current);
+    auto hole = current;
+    auto prev = hole;
+    while (prev != first && comp(value, *std::prev(prev))) {
       --prev;
-      if (proj(*prev) <= key) {
-        break;
-      }
-      std::swap(*prev, *j);
-      j = prev;
+      *hole = std::move(*prev);
+      hole = prev;
     }
+    *hole = std::move(value);
   }
 }
 
-/**
- * Core LSD radix sort implementation with alternating buffers.
- *
- * Uses counting sort for each pass, processing from least to most
- * significant byte. The alternating buffer pattern avoids copying
- * data between passes - we simply swap source and destination pointers.
- */
-template <typename T, typename Projection>
-void stableRadixSortImpl(T* data, T* buffer, size_t n, Projection proj) {
-  using Key = std::invoke_result_t<Projection, const T&>;
-  static_assert(std::is_unsigned_v<Key>, "Key type must be unsigned");
-
-  constexpr size_t kPasses = kRadixPasses<Key>;
-
-  T* src = data;
-  T* dst = buffer;
-
-  // Phase 1: Count occurrences of each byte value for every pass in a single
-  // sweep. The per-digit histogram is permutation-invariant, so counting once
-  // on the original input yields the same counts each pass needs.
-  alignas(64) std::array<std::array<size_t, kRadixBuckets>, kPasses> counts{};
-  for (size_t i = 0; i < n; ++i) {
-    auto key = proj(src[i]);
-    for (size_t pass = 0; pass < kPasses; ++pass) {
-      ++counts[pass][extractRadixDigit(key, pass)];
-    }
-  }
-
-  for (size_t pass = 0; pass < kPasses; ++pass) {
-    const auto& passCounts = counts[pass];
-
-    // Check if this pass can be skipped (all elements have the same byte value)
-    size_t nonzeroCount = 0;
-    for (size_t c : passCounts) {
-      if (c != 0 && ++nonzeroCount > 1) {
-        break;
-      }
-    }
-    if (nonzeroCount <= 1) {
-      continue;
-    }
-
-    // Phase 2: Convert counts to starting offsets (prefix sum)
-    alignas(64) std::array<size_t, kRadixBuckets> offsets{};
-    size_t total = 0;
-    for (size_t i = 0; i < kRadixBuckets; ++i) {
-      offsets[i] = total;
-      total += passCounts[i];
-    }
-
-    // Phase 3: Scatter elements to output (preserves stability)
-    for (size_t i = 0; i < n; ++i) {
-      auto key = proj(src[i]);
-      size_t& offset = offsets[extractRadixDigit(key, pass)];
-      dst[offset] = src[i];
-      ++offset;
-    }
-
-    // Swap source and destination for next pass
-    std::swap(src, dst);
-  }
-
-  // If the final result is in the buffer, copy it back to data
-  if (src != data) {
-    std::copy(src, src + n, data);
-  }
-}
-
-/**
- * Wrapper that handles buffer allocation and fallback to std::stable_sort.
- */
-template <typename ContiguousIt, typename Projection>
-void stableRadixSort(ContiguousIt first, ContiguousIt last, Projection proj) {
-  using T = typename std::iterator_traits<ContiguousIt>::value_type;
-  static_assert(
-      std::contiguous_iterator<ContiguousIt>,
-      "stable_radix_sort requires contiguous iterators");
-
-  size_t n = static_cast<size_t>(std::distance(first, last));
-
-  // Fall back to insertion sort for small inputs (handles n <= 1 as well)
-  if (n < kRadixSortThreshold) {
-    insertionSort(first, last, proj);
+/// Fallback LSD radix sort used by MSD for small sub-problems.
+template <
+    typename RadixTraits,
+    typename Projection,
+    bool IsSignBitHandling = false>
+void integerRadixSort(
+    typename RadixTraits::value_t* FOLLY_RESTRICT data,
+    const size_t n,
+    typename RadixTraits::value_t* FOLLY_RESTRICT buffer,
+    const size_t passes,
+    typename RadixTraits::hist_t* FOLLY_RESTRICT hist1d,
+    Projection proj,
+    size_t depth = 0) {
+  if (n == 0) {
     return;
   }
 
-  // Allocate temporary buffer
-  auto buffer = std::make_unique_for_overwrite<T[]>(n);
+  for (size_t pass = 0; pass < passes; ++pass) {
+    using hist_t = typename RadixTraits::hist_t;
+    __folly_memset(hist1d, 0, RadixTraits::kNumBuckets * sizeof(hist_t));
 
-  // Get pointer to data
-  T* data = std::to_address(first);
+    for (size_t i = 0; i < n; i++) {
+      auto x = proj.template operator()<IsSignBitHandling>(data[i]);
+      ++hist1d[nthRadix<RadixTraits>(x, pass)];
+    }
 
-  stableRadixSortImpl(data, buffer.get(), n, proj);
+    for (size_t i = 1; i < RadixTraits::kNumBuckets; i++) {
+      hist1d[i] += hist1d[i - 1];
+    }
+
+    for (size_t i = n; i-- > 0;) {
+      auto x = proj.template operator()<IsSignBitHandling>(data[i]);
+      buffer[--hist1d[nthRadix<RadixTraits>(x, pass)]] = std::move(data[i]);
+    }
+    std::swap(data, buffer);
+  }
+
+  if (depth + passes & 1) {
+    std::move(data, data + n, buffer);
+  }
 }
 
-/**
- * Default projection that handles common types.
- */
-template <typename T, bool Descending>
-struct DefaultProjection {
-  auto operator()(const T& value) const noexcept {
-    static_assert(
-        std::is_floating_point_v<T> || is_non_bool_integral_v<T>,
-        "stable_radix_sort requires floating-point or integral types");
-    if constexpr (std::is_floating_point_v<T>) {
-      return stable_radix_sort_keys::FloatKey<T, Descending>{}(value);
-    } else {
-      return stable_radix_sort_keys::IntegralKey<T, Descending>{}(value);
+///< Implementations for LSD/MSD and sequential/parallel execution.
+
+// Dispatcher selected by options, iterator, allocator, and projection.
+template <
+    typename RadixTraits,
+    std::random_access_iterator RandIter,
+    standard_allocator Allocator,
+    unsigned_integral_projection<std::iter_value_t<RandIter>> Projection>
+struct RadixSortImplDispatcher;
+
+///< LSD + Seq — sequential, least-significant-digit-first
+template <
+    typename RadixTraits,
+    std::random_access_iterator RandIter,
+    standard_allocator Allocator,
+    unsigned_integral_projection<std::iter_value_t<RandIter>> Projection>
+  requires(
+      RadixTraits::kSortStrategy == RadixSortStrategy::Lsd &&
+      RadixTraits::kExecutionPolicy == RadixExecutionPolicy::Seq)
+struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
+    : RadixTraits {
+  // Re-export frequently used types and constants from the base trait.
+  using Traits = RadixTraits;
+  using Base = RadixTraits;
+  using Base::kHistogramStackThresholdBytes;
+  using Base::kLastPass;
+  using Base::kNumBuckets;
+  using Base::kNumPasses;
+  using Base::kPassIndices;
+  using Base::kSortOrder;
+  using typename Base::hist_t;
+  using typename Base::key_t;
+  using typename Base::value_t;
+  using hist2d_t = hist_t (*)[kNumBuckets];
+
+  /// Single-pass histogram builder and sortedness checker.
+  /// Returns true if the input is already in the desired order.
+  static constexpr auto buildHistogram(
+      const value_t* data, const size_t n, hist2d_t hist2d, Projection proj)
+      -> bool {
+    // Choose the comparison that indicates "not out of order":
+    // for ascending, we expect prev <= key; for descending, prev >= key.
+    auto comp = std::conditional_t<
+        kSortOrder == RadixSortOrder::Ascending,
+        std::greater_equal<>,
+        std::less_equal<>>{};
+    auto prev = kSortOrder == RadixSortOrder::Ascending
+        ? std::numeric_limits<key_t>::lowest()
+        : std::numeric_limits<key_t>::max();
+
+    const auto& keyMap = proj.getKeyMap();
+    bool isSorted = true;
+
+    for (size_t i = 0; i < n; ++i) {
+      const auto key = keyMap(data[i]);
+      isSorted = isSorted && comp(key, prev);
+      prev = key;
+
+      // Build histograms for all passes in a single scan (fold over
+      // kPassIndices at compile time). Scanning once instead of kNumPasses
+      // times keeps the loop in L1 cache.
+      [&]<size_t... Is>(std::index_sequence<Is...>) {
+        ((++hist2d[Is][nthRadix<Traits>(Projection::transform(key), Is)]), ...);
+      }(kPassIndices);
+    }
+    return isSorted;
+  }
+
+  /// Converts per-pass bucket counts to prefix-sum offsets.
+  /// Returns non-empty bucket count per pass (used to skip trivial passes).
+  template <size_t... Is>
+  static auto prefixSum(hist2d_t hist2d, std::index_sequence<Is...>)
+      -> std::array<size_t, sizeof...(Is)> {
+    std::array<size_t, sizeof...(Is)> nonEmptyCounts;
+    auto process = [&](size_t index) -> void {
+      nonEmptyCounts[index] = (hist2d[index][0] != 0);
+      for (size_t i = 1; i < kNumBuckets; ++i) {
+        nonEmptyCounts[index] += (hist2d[index][i] != 0);
+        hist2d[index][i] += hist2d[index][i - 1];
+      }
+    };
+    (process(Is), ...);
+    return nonEmptyCounts;
+  }
+
+  /// Scatters all passes. Sign-bit correction deferred to the last pass.
+  /// Returns pointer to the sorted data (may be data or buffer depending on
+  /// pass-count parity).
+  static constexpr auto doScatter(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      value_t* FOLLY_RESTRICT buffer,
+      const std::array<size_t, kNumPasses>& nonEmptyCounts,
+      hist2d_t hist2d,
+      Projection proj) -> value_t* {
+    // All passes except the last one: sign-bit correction is not needed.
+    for (size_t pass = 0; pass < kLastPass; ++pass) {
+      if (nonEmptyCounts[pass] <= 1) {
+        continue; // All elements have the same digit; no reordering needed.
+      }
+      for (size_t i = n; i-- > 0;) {
+        const auto x = proj.template operator()<false>(data[i]);
+        buffer[--hist2d[pass][nthRadix<Traits>(x, pass)]] = std::move(data[i]);
+      }
+      std::swap(data, buffer);
+    }
+
+    // Last pass: apply full sign-bit handling if the key type is signed.
+    if (nonEmptyCounts[kLastPass] > 1) {
+      for (size_t i = n; i-- > 0;) {
+        const auto x = proj(data[i]); // uses the default `IsSignBitHandling`
+        buffer[--hist2d[kLastPass][nthRadix<Traits>(x, kLastPass)]] =
+            std::move(data[i]);
+      }
+      std::swap(data, buffer);
+    }
+    return data;
+  }
+
+  /// Entry point: builds histogram, computes prefix sums, scatters all passes.
+  /// Always leaves the sorted result in the original array.
+  static constexpr void sort(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      const Allocator& allocator,
+      Projection proj) {
+    auto* const original = data;
+
+    // Allocate temporary element buffer.
+    AllocatorHolder<Allocator> holder(n, allocator);
+    auto* FOLLY_RESTRICT buffer = holder.data();
+
+    const size_t histSize = kNumPasses * kNumBuckets;
+    const size_t histBytes = histSize * sizeof(hist_t);
+
+    // Allocate histogram storage, preferring stack if size is small.
+    HybridAllocHolder<hist_t> histStorage{
+        FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
+            histBytes,
+            hardware_constructive_interference_size,
+            kHistogramStackThresholdBytes),
+        histSize};
+    __folly_memset(histStorage.data(), 0, histBytes);
+    auto hist2d = reinterpret_cast<hist2d_t>(histStorage.data());
+
+    // Step 1: build histograms and check sortedness.
+    if (bool sorted = buildHistogram(data, n, hist2d, proj)) {
+      return; // Already sorted; nothing to do.
+    }
+
+    // Step 2: convert counts to offsets and get non-empty bucket counts.
+    std::array nonEmptyCounts = prefixSum(hist2d, kPassIndices);
+
+    // Step 3: scatter all passes.
+    // The result may end up in the temporary buffer if the number of passes
+    // executed is odd.
+    auto* result = doScatter(data, n, buffer, nonEmptyCounts, hist2d, proj);
+
+    // Step 4: if the sorted data is not in the original array, move it back.
+    if (result != original) {
+      std::move(result, result + n, original);
     }
   }
 };
 
-/**
- * Projection wrapper that applies type-appropriate transformation.
- */
-template <bool Descending, typename Projection>
-struct TransformingProjection {
-  Projection inner;
+///< MSD + Seq — sequential, most-significant-digit-first
+template <
+    typename RadixTraits,
+    std::random_access_iterator RandIter,
+    standard_allocator Allocator,
+    unsigned_integral_projection<std::iter_value_t<RandIter>> Projection>
+  requires(
+      RadixTraits::kSortStrategy == RadixSortStrategy::Msd &&
+      RadixTraits::kExecutionPolicy == RadixExecutionPolicy::Seq &&
+      RadixTraits::kNumPasses > 1)
+struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
+    : RadixTraits {
+  // Re-export frequently used types and constants from the base trait.
+  using Traits = RadixTraits;
+  using Base = RadixTraits;
+  using Base::kBitsPerPass;
+  using Base::kFirstPass;
+  using Base::kHistogramStackThresholdBytes;
+  using Base::kIsSignHandlingOnFirstPass;
+  using Base::kMsdFallbackToLsdThreshold;
+  using Base::kNumBuckets;
+  using Base::kNumPasses;
+  using Base::kSortOrder;
+  using typename Base::hist_t;
+  using typename Base::key_t;
+  using typename Base::uint_t;
+  using typename Base::value_t;
+  using hist2d_t = hist_t (*)[kNumBuckets];
 
-  template <typename T>
-  auto operator()(const T& value) const noexcept {
-    auto extracted = inner(value);
-    using Extracted = decltype(extracted);
-    static_assert(
-        std::is_floating_point_v<Extracted> ||
-            is_non_bool_integral_v<Extracted>,
-        "projection must return floating-point or integral");
-    if constexpr (std::is_floating_point_v<Extracted>) {
-      return stable_radix_sort_keys::FloatKey<Extracted, Descending>{}(
-          extracted);
-    } else if constexpr (std::is_signed_v<Extracted>) {
-      return stable_radix_sort_keys::IntegralKey<Extracted, Descending>{}(
-          extracted);
+  /// First-pass scan: builds MSB histogram, checks sortedness, computes msb.
+  /// Returns {msb index, is sorted}.
+  static constexpr auto firstPassScan(
+      const value_t* data, const size_t n, hist2d_t hist2d, Projection proj)
+      -> std::pair<size_t, bool> {
+    auto prev = kSortOrder == RadixSortOrder::Ascending
+        ? std::numeric_limits<key_t>::lowest()
+        : std::numeric_limits<key_t>::max();
+    auto comp = std::conditional_t<
+        kSortOrder == RadixSortOrder::Ascending,
+        std::greater_equal<>,
+        std::less_equal<>>{};
+
+    const auto& keyMap = proj.getKeyMap();
+    uint_t combined = 0;
+    bool sorted = true;
+    for (size_t i = 0; i < n; ++i) {
+      const auto key = keyMap(data[i]);
+      sorted = sorted && comp(key, prev);
+      prev = key;
+      // OR all keys' bit patterns to find the overall msb.
+      // This determines the actual pass count in the sort step,
+      // skipping passes for leading-zero bytes at no extra scan cost.
+      combined |= std::bit_cast<uint_t>(key);
+      const auto x = Projection::transform(key);
+      ++hist2d[kFirstPass][nthRadix<Traits>(x, kFirstPass)];
+    }
+
+    return {highestOneBitIndex(combined), sorted};
+  }
+
+  /// Builds the histogram for a given non-first pass.
+  static constexpr void buildHistogram(
+      const value_t* data,
+      const size_t n,
+      hist2d_t hist2d,
+      const size_t pass,
+      Projection proj) {
+    for (size_t i = 0; i < n; ++i) {
+      auto x = proj.template operator()<false>(data[i]);
+      ++hist2d[pass][nthRadix<Traits>(x, pass)];
+    }
+  }
+
+  /// Converts bucket counts to prefix-sum offsets for a pass.
+  static constexpr auto prefixSum(hist2d_t hist2d, const size_t pass)
+      -> size_t {
+    size_t nonEmptyCount = (hist2d[pass][0] != 0);
+    for (size_t i = 1; i < kNumBuckets; ++i) {
+      nonEmptyCount += (hist2d[pass][i] != 0);
+      hist2d[pass][i] += hist2d[pass][i - 1];
+    }
+    return nonEmptyCount;
+  }
+
+  /// Scatters elements into the buffer for a given pass.
+  template <bool IsSignBitHandling = kIsSignHandlingOnFirstPass>
+  static constexpr void doScatter(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      value_t* FOLLY_RESTRICT buffer,
+      const size_t pass,
+      hist2d_t hist2d,
+      Projection proj) {
+    for (size_t i = n; i-- > 0;) {
+      auto x = proj.template operator()<IsSignBitHandling>(data[i]);
+      buffer[--hist2d[pass][nthRadix<Traits>(x, pass)]] = std::move(data[i]);
+    }
+  }
+
+  /// Iterates over buckets after scatter; recurses into multi-element buckets.
+  static constexpr void recurseBuckets(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      value_t* FOLLY_RESTRICT buffer,
+      const size_t pass,
+      hist2d_t hist2d,
+      Projection proj,
+      size_t depth = 0) {
+    for (size_t i = 0; i < kNumBuckets; ++i) {
+      size_t chunkBeg = hist2d[pass][i];
+      size_t chunkEnd = (i + 1 < kNumBuckets) ? hist2d[pass][i + 1] : n;
+
+      if (size_t chunkSize = chunkEnd - chunkBeg; chunkSize > 1) {
+        // Recurse to the next lower digit, increasing depth.
+        doMsdRecursion(
+            buffer + chunkBeg,
+            chunkSize,
+            data + chunkBeg,
+            pass - 1,
+            hist2d,
+            proj,
+            depth + 1);
+      } else if (chunkSize == 1 && (depth & 1) == 0) {
+        // For singleton buckets at even depth, move the element back to the
+        // original array because the buffer roles alternate each recursion.
+        data[chunkBeg] = std::move(buffer[chunkBeg]);
+      }
+    }
+  }
+
+  /// Recursively sorts sub-problem for a given pass.
+  /// Falls back to LSD if sub-problem is small or no lower digits remain.
+  static constexpr void doMsdRecursion(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      value_t* FOLLY_RESTRICT buffer,
+      const size_t pass,
+      hist2d_t hist2d,
+      Projection proj,
+      size_t depth = 0) {
+    auto* hist1d = hist2d[pass];
+    // Fallback to LSD when the sub-problem is small or no lower digits remain.
+    if (n <= kMsdFallbackToLsdThreshold || pass < 1) {
+      // `pass + 1` because LSD expects the number of passes, not the index.
+      integerRadixSort<Traits>(data, n, buffer, pass + 1, hist1d, proj, depth);
+      return;
+    }
+
+    // Step 1 : Clear the histogram for the current pass.
+    __folly_memset(hist1d, 0, kNumBuckets * sizeof(hist_t));
+
+    // Step 2 : build histogram for the current pass.
+    buildHistogram(data, n, hist2d, pass, proj);
+
+    // Step 3 :
+    if (size_t nonEmptyCount = prefixSum(hist2d, pass); nonEmptyCount <= 1) {
+      // If all elements share the same digit, skip scatter and go to next pass.
+      return doMsdRecursion(data, n, buffer, pass - 1, hist2d, proj, depth);
+    }
+
+    // Step 4 : scatter using the current pass (no sign-bit handling for
+    // non-first passes).
+    doScatter<false>(data, n, buffer, pass, hist2d, proj);
+    // Step 5 : recurse into each bucket.
+    recurseBuckets(data, n, buffer, pass, hist2d, proj, depth);
+  }
+
+  /// Entry point: first-pass scan, then recursive MSD partitioning.
+  /// Always leaves the sorted result in the original array.
+  static constexpr void sort(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      const Allocator& allocator,
+      Projection proj) {
+    AllocatorHolder<Allocator> holder(n, allocator);
+    auto* FOLLY_RESTRICT buffer = holder.data();
+
+    const size_t histSize = kNumPasses * kNumBuckets;
+    const size_t histBytes = histSize * sizeof(hist_t);
+
+    // Pre-allocate histogram memory for all passes at once,
+    // prevent memory allocation overhead in every recursion.
+    HybridAllocHolder<hist_t> histStorage{
+        FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
+            histBytes,
+            hardware_constructive_interference_size,
+            kHistogramStackThresholdBytes),
+        histSize};
+    auto hist2d = reinterpret_cast<hist2d_t>(histStorage.data());
+
+    // Only the first pass histogram needs to be cleared; other passes will be
+    // cleared individually in `doMsdRecursion`.
+    __folly_memset(hist2d[kFirstPass], 0, kNumBuckets * sizeof(hist_t));
+
+    // First pass scan: builds MSB histogram, checks sortedness, computes msb.
+    const auto [msb, sorted] = firstPassScan(data, n, hist2d, proj);
+    if (sorted) {
+      return;
+    }
+
+    // Compute the actual number of passes needed based on the highest set bit.
+    // Example: for 32-bit with 8-bit chunks, msb=24 -> passes=(24+8)/8=4.
+    const auto passes = (msb + kBitsPerPass) / kBitsPerPass;
+
+    // If the full number of passes is needed, the first pass histogram is
+    // ready.
+    if (passes == kNumPasses && prefixSum(hist2d, kFirstPass) > 1) {
+      // Scatter using the first pass (with sign-bit handling if needed).
+      doScatter(data, n, buffer, kFirstPass, hist2d, proj);
+      recurseBuckets(data, n, buffer, kFirstPass, hist2d, proj);
     } else {
-      return Descending ? ~extracted : extracted;
+      // Start recursion from the highest pass that actually contains data.
+      doMsdRecursion(data, n, buffer, passes - 1, hist2d, proj);
     }
   }
 };
 
-} // namespace stable_radix_sort_detail
+#ifdef _OPENMP
+/// Each thread builds a private histogram; prefixSum merges them.
+template <typename RadixTraits, typename Allocator, typename Projection>
+struct RadixSortParHelpers : RadixTraits {
+  using Traits = RadixTraits;
+  using Base = RadixTraits;
+  using Base::kFirstPass;
+  using Base::kHistogramStackThresholdBytes;
+  using Base::kIsSignHandlingOnFirstPass;
+  using Base::kNaNsAssumption;
+  using Base::kNumBuckets;
+  using Base::kSortOrder;
+  using typename Base::hist_t;
+  using typename Base::key_t;
+  using typename Base::uint_t;
+  using typename Base::value_t;
+  using hist2d_t = hist_t (*)[kNumBuckets];
 
-/**
- * stable_radix_sort - Sort elements in ascending order.
- *
- * Sorts elements using LSD radix sort. This is a stable sort: elements
- * with equal keys preserve their original relative order.
- *
- * Note: For floating-point types, the sort uses an augmented ordering
- * equivalent to std::stable_sort(first, last, augmented_less) where:
- *
- *   template <std::floating_point T>
- *   struct augmented_less {
- *     bool operator()(T lhs, T rhs) const noexcept {
- *       if (lhs < rhs) return true;
- *       if (rhs < lhs) return false;
- *       return std::signbit(lhs) > std::signbit(rhs);
- *     }
- *   };
- *
- * In other words, -0.0 sorts before +0.0. For all other values, the
- * ordering matches operator<.
- *
- * Requirements:
- * - ContiguousIt must be a contiguous iterator
- * - Value type must be floating-point or integral
- *
- * Complexity: O(n * k) where k = sizeof(value_type) / 8
- * Space: O(n) for temporary buffer
- */
-template <typename ContiguousIt>
-void stable_radix_sort(ContiguousIt first, ContiguousIt last) {
-  using T = typename std::iterator_traits<ContiguousIt>::value_type;
-  stable_radix_sort_detail::stableRadixSort(
-      first, last, stable_radix_sort_detail::DefaultProjection<T, false>{});
+  /// Like MSD+Seq::firstPassScan but with per-thread histograms.
+  static auto firstPassScan(
+      const value_t* data,
+      const ThreadChunkInfo info,
+      hist2d_t hist2d,
+      Projection proj) -> std::pair<size_t, bool> {
+    auto comp = std::conditional_t<
+        kSortOrder == RadixSortOrder::Ascending,
+        std::greater_equal<>,
+        std::less_equal<>>{};
+
+    const auto& keyMap = proj.getKeyMap();
+    const uint32_t threads = info.threads;
+    const uint32_t remain = info.remain;
+    const size_t step = info.step;
+    using ThreadChunkStatsWrapped = ThreadChunkStats<key_t>;
+    const auto threadBytes = threads * sizeof(ThreadChunkStatsWrapped);
+    HybridAllocHolder<ThreadChunkStatsWrapped> statsArray{
+        FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
+            threadBytes,
+            hardware_constructive_interference_size,
+            kHistogramStackThresholdBytes),
+        threads};
+    __folly_memset(statsArray.data(), 0, threadBytes);
+
+#pragma omp parallel num_threads((int)threads)
+    {
+      const int tid = omp_get_thread_num();
+      const auto [beg, end] = computeThreadChunkRange(tid, step, remain);
+
+      bool sorted = true;
+      auto minVal = std::numeric_limits<key_t>::max();
+      auto maxVal = std::numeric_limits<key_t>::lowest();
+      auto prev = kSortOrder == RadixSortOrder::Ascending
+          ? std::numeric_limits<key_t>::lowest()
+          : std::numeric_limits<key_t>::max();
+
+      for (size_t i = beg; i < end; ++i) {
+        const auto key = keyMap(data[i]);
+        sorted = sorted && comp(key, prev);
+        prev = key;
+
+        auto x{Projection::template transform<kIsSignHandlingOnFirstPass>(key)};
+        ++hist2d[tid][nthRadix<Traits>(x, kFirstPass)];
+
+        // Skip NaN when computing min/max if NaNs are allowed (they break
+        // ordering).
+        if constexpr (
+            std::is_floating_point_v<key_t> &&
+            kNaNsAssumption == RadixNaNsAssumption::Existence) {
+          if (std::isnan(key))
+            continue;
+        }
+        if (key < minVal) {
+          minVal = key;
+        }
+        if (key > maxVal) {
+          maxVal = key;
+        }
+      }
+      statsArray[tid] = ThreadChunkStats{sorted, minVal, maxVal};
+    }
+
+    // Merge per-thread statistics.
+    auto& [sorted1, minVal1, maxVal1] = statsArray[0];
+    uint_t combined = 0;
+    combined |= std::bit_cast<uint_t>(minVal1) | std::bit_cast<uint_t>(maxVal1);
+    for (size_t i = 1; i < threads; ++i) {
+      const auto [sorted, minVal, maxVal] = statsArray[i];
+      combined |= std::bit_cast<uint_t>(minVal) | std::bit_cast<uint_t>(maxVal);
+      sorted1 = sorted1 && sorted;
+      if constexpr (kSortOrder == RadixSortOrder::Ascending) {
+        sorted1 = sorted1 && (minVal >= statsArray[i - 1].maxVal);
+      } else {
+        sorted1 = sorted1 && (maxVal <= statsArray[i - 1].minVal);
+      }
+    }
+    return {highestOneBitIndex(combined), sorted1};
+  }
+
+  /// Per-thread histogram builder (like the Seq version but parallelized).
+  template <bool IsSignBitHandling = false>
+  static void buildHistogram(
+      value_t* data,
+      const ThreadChunkInfo info,
+      hist2d_t hist2d,
+      const size_t pass,
+      Projection proj) {
+    const uint32_t threads = info.threads;
+    const uint32_t remain = info.remain;
+    const size_t step = info.step;
+#pragma omp parallel num_threads((int)threads)
+    {
+      const int tid = omp_get_thread_num();
+      const auto [beg, end] = computeThreadChunkRange(tid, step, remain);
+
+      for (size_t i = beg; i < end; ++i) {
+        const auto x = proj.template operator()<IsSignBitHandling>(data[i]);
+        ++hist2d[tid][nthRadix<Traits>(x, pass)];
+      }
+    }
+  }
+
+  /// Merges per-thread histogram into global prefix-sum offsets (N-shaped
+  /// scan). After this, hist2d[tid][bucket] is the global start offset for that
+  /// thread and bucket. Returns the number of non-empty buckets.
+  static auto prefixSum(hist2d_t hist2d, size_t threads) -> size_t {
+    for (size_t tid = 1; tid < threads; ++tid) {
+      hist2d[tid][0] += hist2d[tid - 1][0];
+    }
+
+    size_t nonEmpty = (hist2d[threads - 1][0] != 0);
+    for (size_t i = 1; i < kNumBuckets; ++i) {
+      const auto last = hist2d[threads - 1][i - 1];
+      hist2d[0][i] += last;
+
+      for (size_t tid = 1; tid < threads; ++tid) {
+        hist2d[tid][i] += hist2d[tid - 1][i];
+      }
+
+      nonEmpty += (hist2d[threads - 1][i] - last != 0);
+    }
+    return nonEmpty;
+  }
+
+  /// Per-thread scatter (like the Seq version but parallelized).
+  template <bool IsSignBitHandling = false>
+  static void doScatter(
+      value_t* FOLLY_RESTRICT data,
+      const ThreadChunkInfo info,
+      value_t* FOLLY_RESTRICT buffer,
+      const size_t pass,
+      hist2d_t hist2d,
+      Projection proj) {
+    const uint32_t threads = info.threads;
+    const uint32_t remain = info.remain;
+    const size_t step = info.step;
+#pragma omp parallel num_threads((int)threads)
+    {
+      int tid = omp_get_thread_num();
+      auto [beg, end] = computeThreadChunkRange(tid, step, remain);
+      for (size_t i = end; i-- > beg;) {
+        const auto x = proj.template operator()<IsSignBitHandling>(data[i]);
+        buffer[--hist2d[tid][nthRadix<Traits>(x, pass)]] = std::move(data[i]);
+      }
+    }
+  }
+};
+
+///< LSD + Par — parallel version of LSD+Seq (requires _OPENMP)
+/// Algorithm is the same; key difference: each thread builds its own histogram
+/// and scatters elements independently. See LSD + Seq for algorithm details.
+template <
+    typename RadixTraits,
+    std::random_access_iterator RandIter,
+    standard_allocator Allocator,
+    unsigned_integral_projection<std::iter_value_t<RandIter>> Projection>
+  requires(
+      RadixTraits::kSortStrategy == RadixSortStrategy::Lsd &&
+      RadixTraits::kExecutionPolicy == RadixExecutionPolicy::Par)
+struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
+    : public RadixSortParHelpers<RadixTraits, Allocator, Projection> {
+  using Traits = RadixTraits;
+  using Base = RadixSortParHelpers<RadixTraits, Allocator, Projection>;
+  using Base::buildHistogram;
+  using Base::doScatter;
+  using Base::firstPassScan;
+  using Base::kBitsPerPass;
+  using Base::kFirstPass;
+  using Base::kHistogramStackThresholdBytes;
+  using Base::kIsSignHandlingOnFirstPass;
+  using Base::kNumBuckets;
+  using Base::kNumPasses;
+  using Base::prefixSum;
+  using typename Base::hist_t;
+  using typename Base::value_t;
+  using hist2d_t = hist_t (*)[kNumBuckets];
+
+  /// Entry point (parallel LSD). Same algorithm as LSD+Seq; uses per-thread
+  /// histograms and prefixSum merging for parallel passes.
+  static void sort(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      const Allocator& allocator,
+      Projection proj) {
+    auto* const original = data;
+    AllocatorHolder<Allocator> holder(n, allocator);
+    auto* FOLLY_RESTRICT buffer = holder.data();
+
+    const size_t threads = ::omp_get_max_threads();
+    // Per-thread histogram: hist2d[tid][bucket] avoids atomic contention.
+    const size_t histSize = threads * kNumBuckets;
+    const size_t histBytes = histSize * sizeof(hist_t);
+    const ThreadChunkInfo chunkInfo(threads, n % threads, n / threads);
+
+    HybridAllocHolder<hist_t> histStorage{
+        FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
+            histBytes,
+            hardware_constructive_interference_size,
+            kHistogramStackThresholdBytes),
+        histSize};
+    __folly_memset(histStorage.data(), 0, histBytes);
+    auto hist2d = reinterpret_cast<hist2d_t>(histStorage.data());
+
+    // Unlike LSD+Seq's single-scan multi-pass histogram, the 2D per-thread
+    // layout requires iterative histogram-scatter per pass.
+    auto [msb, sorted] = firstPassScan(data, chunkInfo, hist2d, proj);
+    if (sorted) {
+      return;
+    }
+
+    if (size_t numEmptyCount = prefixSum(hist2d, threads); numEmptyCount > 1) {
+      Base::template doScatter<kIsSignHandlingOnFirstPass>(
+          data, chunkInfo, buffer, kFirstPass, hist2d, proj);
+      std::swap(data, buffer);
+    }
+
+    const auto passes = (msb + kBitsPerPass) / kBitsPerPass;
+
+    // Process remaining passes (from 1 to passes-1).
+    for (size_t pass = 1; pass < passes; ++pass) {
+      __folly_memset(histStorage.data(), 0, histBytes);
+
+      if (pass != passes - 1 || passes != kNumPasses) {
+        buildHistogram(data, chunkInfo, hist2d, pass, proj);
+        if (prefixSum(hist2d, threads) > 1) {
+          doScatter(data, chunkInfo, buffer, pass, hist2d, proj);
+          std::swap(data, buffer);
+        }
+      } else {
+        Base::template buildHistogram<true>(
+            data, chunkInfo, hist2d, pass, proj);
+        if (prefixSum(hist2d, threads) > 1) {
+          Base::template doScatter<true>(
+              data, chunkInfo, buffer, pass, hist2d, proj);
+          std::swap(data, buffer);
+        }
+      }
+    }
+
+    // If the sorted data is in the temporary buffer, move it back to the
+    // original array (this happens when the number of passes executed is odd).
+    if (data != original) {
+      std::move(data, data + n, original);
+    }
+  }
+};
+
+///< MSD + Par — parallel version of MSD+Seq (requires _OPENMP)
+/// Algorithm is the same; key difference: each sub-problem at the top level
+/// is processed by separate OpenMP threads. See MSD + Seq for algorithm
+/// details.
+template <
+    typename RadixTraits,
+    std::random_access_iterator RandIter,
+    standard_allocator Allocator,
+    unsigned_integral_projection<std::iter_value_t<RandIter>> Projection>
+  requires(
+      RadixTraits::kSortStrategy == RadixSortStrategy::Msd &&
+      RadixTraits::kExecutionPolicy == RadixExecutionPolicy::Par &&
+      RadixTraits::kNumPasses > 1)
+struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
+    : public RadixSortParHelpers<RadixTraits, Allocator, Projection> {
+  using Traits = RadixTraits;
+  using Base = RadixSortParHelpers<RadixTraits, Allocator, Projection>;
+  using Base::buildHistogram;
+  using Base::doScatter;
+  using Base::firstPassScan;
+  using Base::kBitsPerPass;
+  using Base::kFirstPass;
+  using Base::kHistogramStackThresholdBytes;
+  using Base::kMsdFallbackToLsdThreshold;
+  using Base::kNumBuckets;
+  using Base::kNumPasses;
+  using Base::prefixSum;
+  using typename Base::hist_t;
+  using typename Base::value_t;
+  using hist2d_t = hist_t (*)[kNumBuckets];
+
+  /// Iterates buckets after scatter, parallelized at the bucket level.
+  static void recurseBuckets(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      value_t* FOLLY_RESTRICT buffer,
+      const size_t pass,
+      hist2d_t hist2d,
+      const ThreadChunkInfo info,
+      Projection proj,
+      size_t depth = 0) {
+    // static schedule: bucket sizes vary but static avoids steal overhead
+#pragma omp parallel for schedule(static) \
+    num_threads((int)info.threads) if (info.threads > 1 && !omp_in_parallel())
+    // Compatibility:
+    //   MSVC provides '/openmp' '/openmp:experimental' '/openmp:llvm'
+    //   '/openmp' needs a signed index variable
+    for (int i = 0; i < static_cast<int>(kNumBuckets); ++i) {
+      size_t chunkBeg = hist2d[0][i];
+      size_t chunkEnd = (i + 1 < kNumBuckets) ? hist2d[0][i + 1] : n;
+
+      if (size_t chunkSize = chunkEnd - chunkBeg; chunkSize > 1) {
+        doMsdRecursion(
+            buffer + chunkBeg,
+            chunkSize,
+            data + chunkBeg,
+            pass - 1,
+            info,
+            proj,
+            depth + 1);
+      } else if (chunkSize == 1 && (depth & 1) == 0) {
+        data[chunkBeg] = std::move(buffer[chunkBeg]);
+      }
+    }
+  }
+
+  /// Same logic as MSD+Seq::doMsdRecursion, but disables nested OpenMP
+  /// parallelism once inside a parallel region.
+  static void doMsdRecursion(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      value_t* FOLLY_RESTRICT buffer,
+      const size_t pass,
+      const ThreadChunkInfo info,
+      Projection proj,
+      size_t depth = 0) {
+    // Disable nested parallelism once inside a parallel region. Recursing
+    // with all threads would oversubscribe and hurt cache locality.
+    const uint32_t threads = omp_in_parallel() ? 1U : info.threads;
+    const size_t histSize = size_t{threads} * kNumBuckets;
+    const size_t histBytes = histSize * sizeof(hist_t);
+
+    HybridAllocHolder<hist_t> histStorage{
+        FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
+            histBytes,
+            hardware_constructive_interference_size,
+            kHistogramStackThresholdBytes),
+        histSize};
+    auto hist2d = reinterpret_cast<hist2d_t>(histStorage.data());
+    auto* hist1d = hist2d[0];
+
+    if (n <= kMsdFallbackToLsdThreshold || pass < 1) {
+      integerRadixSort<Traits>(data, n, buffer, pass + 1, hist1d, proj, depth);
+      return;
+    }
+
+    __folly_memset(histStorage.data(), 0, histBytes);
+
+    auto [step, remain] = ::lldiv(n, threads);
+    const ThreadChunkInfo subInfo(threads, remain, step);
+    buildHistogram(data, subInfo, hist2d, pass, proj);
+
+    if (prefixSum(hist2d, threads) <= 1) {
+      doMsdRecursion(data, n, buffer, pass - 1, info, proj, depth);
+      return;
+    }
+    doScatter(data, subInfo, buffer, pass, hist2d, proj);
+    recurseBuckets(data, n, buffer, pass, hist2d, subInfo, proj, depth);
+  }
+
+  /// Entry point (parallel MSD). Same as MSD+Seq with parallel first-pass
+  /// scan; recursion falls back to sequential once inside a parallel region.
+  static void sort(
+      value_t* FOLLY_RESTRICT data,
+      const size_t n,
+      const Allocator& allocator,
+      Projection proj) {
+    AllocatorHolder<Allocator> holder(n, allocator);
+    auto* FOLLY_RESTRICT buffer = holder.data();
+
+    const size_t threads = ::omp_get_max_threads();
+    const size_t histSize = threads * kNumBuckets;
+    const size_t histBytes = histSize * sizeof(hist_t);
+    const ThreadChunkInfo chunkInfo(threads, n % threads, n / threads);
+
+    HybridAllocHolder<hist_t> histStorage{
+        FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
+            histBytes,
+            hardware_constructive_interference_size,
+            kHistogramStackThresholdBytes),
+        histSize};
+    __folly_memset(histStorage.data(), 0, histBytes);
+    auto hist2d = reinterpret_cast<hist2d_t>(histStorage.data());
+
+    auto [msb, sorted] = firstPassScan(data, chunkInfo, hist2d, proj);
+    if (sorted) {
+      return;
+    }
+
+    const auto passes = (msb + kBitsPerPass) / kBitsPerPass;
+    if (passes == kNumPasses && prefixSum(hist2d, threads) > 1) {
+      Base::template doScatter<true>(
+          data, chunkInfo, buffer, kFirstPass, hist2d, proj);
+      recurseBuckets(data, n, buffer, kFirstPass, hist2d, chunkInfo, proj);
+    } else {
+      doMsdRecursion(data, n, buffer, passes - 1, chunkInfo, proj);
+    }
+  }
+};
+#endif
+
+// Selects and invokes the correct RadixSortImplDispatcher.
+template <
+    typename RadixTraits,
+    std::random_access_iterator RandIter,
+    detail::standard_allocator Allocator,
+    unsigned_integral_projection<std::iter_value_t<RandIter>> Projection>
+constexpr void stable_radix_sort_impl(
+    RandIter first,
+    RandIter last,
+    const Allocator& allocator,
+    Projection proj) {
+  static_assert(
+      !(RadixTraits::kNaNsAssumption == RadixNaNsAssumption::NonExistence &&
+        RadixTraits::kNaNsPosHandling != RadixNaNsPosHandling::Unhandled),
+      "If you assumed there are no NaNs, then you shouldn't change the default settings for NaN positions.");
+
+  static_assert(
+      !(RadixTraits::kBitsPerPass == 16U &&
+        sizeof(typename RadixTraits::uint_t) == 1U),
+      "Do not set RadixSortOptions.BitsPerPass = RadixBitsPerPass::Bits16 (two-byte) for one-byte data!");
+
+  static_assert(
+      !(RadixTraits::kSortStrategy == RadixSortStrategy::Msd &&
+        RadixTraits::kNumPasses <= 1),
+      "MSD sort with only one pass is equivalent to counting sort; "
+      "use LSD strategy (RadixSortStrategy::Lsd) for single-pass sorting, "
+      "or ensure at least 2 passes for MSD to avoid unsigned underflow in recurseBuckets (pass(0) - 1).");
+
+#ifndef _OPENMP
+  static_assert(
+      RadixTraits::kExecutionPolicy != RadixExecutionPolicy::Par,
+      "Parallel policy requires _OPENMP defined");
+#endif
+
+  assert(first <= last && "Invalid iterator range: first must be <= last");
+
+  // 1. Special case: boolean elements use a dedicated O(n) partition routine.
+  if constexpr (std::same_as<std::iter_value_t<RandIter>, bool>) {
+    // Invert order if descending is requested.
+    sortBool<RandIter, RadixTraits::kSortOrder != RadixSortOrder::Ascending>(
+        first, last);
+  } else {
+    const size_t size = last - first;
+
+    // 2. Small-array fallback: insertion sort avoids radix-sort overhead.
+    if (size <= kRadixSortThreshold) [[unlikely]] {
+      // Use projection as key extractor; compare according to SortOrder.
+      insertionSort(first, last, [proj](const auto& a, const auto& b) {
+        if constexpr (RadixTraits::kSortOrder == RadixSortOrder::Ascending) {
+          return proj(a) < proj(b);
+        } else {
+          return proj(b) < proj(a);
+        }
+      });
+      return;
+    }
+
+    // 3. Regular path: Dispatch to the selected strategy
+    //    (LSD/Seq or LSD/Par or MSD/Seq or MSD/Par).
+    RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>::sort(
+        &*first, size, allocator, proj);
+  }
 }
 
+} // namespace detail
+
+template <
+    std::random_access_iterator RandIter,
+    detail::arithmetic_key_map<std::iter_value_t<RandIter>> KeyMap =
+        detail::radix_key_map_fn>
+[[deprecated(
+    "use folly::stable_radix_sort with RadixSortOrder::Descending instead")]]
+void stable_radix_sort_descending(
+    RandIter first, RandIter last, KeyMap keyMap = {}) {
+  constexpr RadixSortOptions opts{.SortOrder = RadixSortOrder::Descending};
+  stable_radix_sort<opts>(first, last, keyMap);
+}
+
+///< Public API
+
 /**
- * stable_radix_sort - Sort elements by extracted key in ascending order.
+ * @brief Radix sort a range `[first, last)` with full control over
+ *                options, allocator, and key projection.
  *
- * Sorts elements by the key returned by proj. The key must be a type
- * that can be sorted by radix sort (floating-point, integral, or unsigned).
+ * @details
+ * This is the most general overload. It accepts a `RadixSortOptions` template
+ * argument, an allocator for temporary storage, and an arbitrary `KeyMap`
+ * that projects each element to an arithmetic key (integral or floating‑point).
  *
- * Example:
+ * The function automatically handles reverse iterators by swapping the
+ * sort order and passing the underlying base iterators to the internal
+ * implementation.
+ *
+ * @tparam RadixOptions  Compile‑time sorting options (see `RadixSortOptions`).
+ * @tparam RandIter      Random‑access iterator type.
+ * @tparam Allocator     Allocator type (must satisfy `standard_allocator`).
+ * @tparam KeyMap        A callable `value_t -> arithmetic` (default: identity).
+ * @param first          Inclusive start of the range.
+ * @param last           Exclusive end of the range.
+ * @param allocator      Allocator instance for temporary buffer.
+ * @param keyMap         Key extraction functor.
+ *
+ * @example
+ * @code
  *   struct Item { double score; int id; };
  *   std::vector<Item> items = ...;
- *   folly::stable_radix_sort(
- *       items.begin(), items.end(),
- *       [](const Item& item) { return item.score; });
+ *   constexpr RadixSortOptions opts{
+ *       .SortStrategy = RadixSortStrategy::Msd,
+ *       .SortOrder = RadixSortOrder::Descending};
+ *   folly::stable_radix_sort<opts>(items.begin(), items.end(),
+ *                           std::allocator<Item>{},
+ *                           [](const Item& x) { return x.score; });
+ * @endcode
  */
-template <typename ContiguousIt, typename Projection>
-void stable_radix_sort(ContiguousIt first, ContiguousIt last, Projection proj) {
-  using Wrapped =
-      stable_radix_sort_detail::TransformingProjection<false, Projection>;
-  stable_radix_sort_detail::stableRadixSort(first, last, Wrapped{proj});
+template <
+    RadixSortOptions RadixOptions,
+    std::random_access_iterator RandIter,
+    detail::standard_allocator Allocator,
+    detail::arithmetic_key_map<std::iter_value_t<RandIter>> KeyMap =
+        detail::radix_key_map_fn>
+constexpr void stable_radix_sort(
+    RandIter first,
+    RandIter last,
+    const Allocator& allocator,
+    KeyMap keyMap = {}) {
+  using value_t = std::iter_value_t<RandIter>;
+
+  // Construct the projection functor that maps value -> unsigned key.
+  auto projection =
+      detail::radix_uint_projection.template
+      operator()<RadixOptions.NaNsPosHandling>(
+          std::in_place_type<value_t>, std::move(keyMap));
+
+  // Reverse iterators invert semantic order, so adjust the options before
+  // passing the underlying base iterators to the implementation.
+  constexpr auto adjustedOptions = [] {
+    RadixSortOptions opts = RadixOptions;
+    opts.SortOrder =
+        detail::RadixRealSortOrder<RandIter, RadixOptions.SortOrder>::value;
+    return opts;
+  }();
+
+  using RadixTraits = detail::RadixSortTraits<adjustedOptions, value_t, KeyMap>;
+
+  // If the iterator is a reverse_iterator, unwrap to base and swap first/last.
+  if constexpr (is_reverse_iterator_v<RandIter>) {
+    detail::stable_radix_sort_impl<RadixTraits>(
+        last.base(), first.base(), allocator, std::move(projection));
+  } else {
+    detail::stable_radix_sort_impl<RadixTraits>(
+        first, last, allocator, std::move(projection));
+  }
 }
 
 /**
- * stable_radix_sort_descending - Sort elements in descending order.
+ * @brief Radix sort with explicit options but defaulted allocator.
  *
- * Like stable_radix_sort, but produces descending order.
+ * @details
+ * Convenience overload that uses `std::allocator<value_t>` internally.
+ * All other parameters are the same as the four‑argument overload.
+ *
+ * @tparam RadixOptions  Compile‑time sorting options.
+ * @tparam RandIter      Random‑access iterator type.
+ * @tparam KeyMap        A callable `value_t -> arithmetic` (default: identity).
+ * @param first          Inclusive start of the range.
+ * @param last           Exclusive end of the range.
+ * @param keyMap         Key extraction functor.
  */
-template <typename ContiguousIt>
-void stable_radix_sort_descending(ContiguousIt first, ContiguousIt last) {
-  using T = typename std::iterator_traits<ContiguousIt>::value_type;
-  stable_radix_sort_detail::stableRadixSort(
-      first, last, stable_radix_sort_detail::DefaultProjection<T, true>{});
+template <
+    RadixSortOptions RadixOptions,
+    std::random_access_iterator RandIter,
+    detail::arithmetic_key_map<std::iter_value_t<RandIter>> KeyMap =
+        detail::radix_key_map_fn>
+constexpr void stable_radix_sort(
+    RandIter first, RandIter last, KeyMap keyMap = {}) {
+  using value_t = typename std::iter_value_t<RandIter>;
+  std::allocator<value_t> allocator{};
+  stable_radix_sort<RadixOptions>(first, last, allocator, std::move(keyMap));
 }
 
 /**
- * stable_radix_sort_descending - Sort by extracted key in descending order.
+ * @brief Radix sort with default options and defaulted allocator.
  *
- * Like stable_radix_sort with projection, but produces descending order.
+ * @details
+ * The simplest entry point: sorts `[first, last)` in ascending order
+ * using LSD radix sort with 8‑bit chunks and all other options at their
+ * defaults. This overload is ideal for quick, generic use.
+ *
+ * @tparam RandIter  Random‑access iterator type.
+ * @tparam KeyMap    A callable `value_t -> arithmetic` (default: identity).
+ * @param first      Inclusive start of the range.
+ * @param last       Exclusive end of the range.
+ * @param keyMap     Key extraction functor.
  */
-template <typename ContiguousIt, typename Projection>
-void stable_radix_sort_descending(
-    ContiguousIt first, ContiguousIt last, Projection proj) {
-  using Wrapped =
-      stable_radix_sort_detail::TransformingProjection<true, Projection>;
-  stable_radix_sort_detail::stableRadixSort(first, last, Wrapped{proj});
+template <
+    std::random_access_iterator RandIter,
+    detail::arithmetic_key_map<std::iter_value_t<RandIter>> KeyMap =
+        detail::radix_key_map_fn>
+constexpr void stable_radix_sort(
+    RandIter first, RandIter last, KeyMap keyMap = {}) {
+  using value_t = typename std::iter_value_t<RandIter>;
+  std::allocator<value_t> allocator{};
+  constexpr RadixSortOptions radixOptions{};
+  stable_radix_sort<radixOptions>(first, last, allocator, std::move(keyMap));
 }
 
 } // namespace folly

--- a/folly/algorithm/StableRadixSort.h
+++ b/folly/algorithm/StableRadixSort.h
@@ -233,7 +233,7 @@ struct RadixSortOptions {
   size_t HistogramStackThresholdBytes = 16U * 1024U;
 };
 
-namespace detail {
+namespace stable_radix_sort_detail {
 
 // Allocator concepts and RAII
 template <typename Alloc>
@@ -262,7 +262,7 @@ class AllocatorHolder {
   using pointer = typename Traits::pointer;
   using size_type = typename Traits::size_type;
 
-  explicit AllocatorHolder(size_type size, Alloc const& alloc)
+  constexpr explicit AllocatorHolder(size_type size, Alloc const& alloc)
       : alloc_(alloc),
         size_(size),
         buffer_(size == 0 ? nullptr : Traits::allocate(alloc_, size)) {
@@ -272,12 +272,12 @@ class AllocatorHolder {
   AllocatorHolder(AllocatorHolder const&) = delete;
   AllocatorHolder& operator=(AllocatorHolder const&) = delete;
 
-  ~AllocatorHolder() { destroy(); }
+  constexpr ~AllocatorHolder() { destroy(); }
 
-  pointer data() noexcept { return buffer_; }
+  constexpr pointer data() noexcept { return buffer_; }
 
  private:
-  void construct() {
+  constexpr void construct() {
     if constexpr (
         !std::is_trivially_default_constructible_v<value_type> ||
         !std::is_trivially_destructible_v<value_type>) {
@@ -296,7 +296,7 @@ class AllocatorHolder {
     }
   }
 
-  void destroy() noexcept {
+  constexpr void destroy() noexcept {
     if (buffer_ == nullptr) {
       return;
     }
@@ -313,47 +313,78 @@ class AllocatorHolder {
   pointer buffer_{nullptr};
 };
 
+struct hybrid_alloc_tag {};
+
 /// RAII wrapper around FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD / hybridFree.
 template <class T>
-class HybridAllocHolder {
+class HistogramHeapMemHolder {
   static_assert(
-      std::is_object_v<T>, "HybridAllocHolder requires an object type");
+      std::is_object_v<T>, "HistogramHeapMemHolder requires an object type");
+  static_assert(
+      !std::is_array_v<T>,
+      "HistogramHeapMemHolder does not support array value_type");
 
  public:
   using value_type = T;
   using pointer = T*;
   using size_type = std::size_t;
 
-  HybridAllocHolder(void* ptr, size_type size)
-      : data_(static_cast<pointer>(ptr)), size_(size) {}
+  constexpr HistogramHeapMemHolder(hybrid_alloc_tag, void* ptr, size_type size)
+      : data_(static_cast<pointer>(ptr)), size_(size), is_hybrid_alloc_{true} {}
 
-  HybridAllocHolder(HybridAllocHolder const&) = delete;
-  HybridAllocHolder& operator=(HybridAllocHolder const&) = delete;
-  HybridAllocHolder(HybridAllocHolder&&) = delete;
-  HybridAllocHolder& operator=(HybridAllocHolder&&) = delete;
+  constexpr HistogramHeapMemHolder(pointer ptr, size_type size)
+      : data_(ptr), size_(size) {}
 
-  ~HybridAllocHolder() {
+  constexpr HistogramHeapMemHolder(std::nullptr_t, size_type) = delete;
+
+  HistogramHeapMemHolder(HistogramHeapMemHolder const&) = delete;
+  HistogramHeapMemHolder& operator=(HistogramHeapMemHolder const&) = delete;
+  HistogramHeapMemHolder(HistogramHeapMemHolder&&) = delete;
+  HistogramHeapMemHolder& operator=(HistogramHeapMemHolder&&) = delete;
+
+  constexpr ~HistogramHeapMemHolder() {
     if (data_ == nullptr) {
       return;
     }
-    if constexpr (!std::is_trivially_destructible_v<value_type>) {
-      for (size_type i = 0; i < size_; ++i) {
-        std::destroy_at(data_ + i);
-      }
-    }
-    hybridFree(data_);
+
+    reset();
   }
 
-  pointer data() noexcept { return data_; }
-  const pointer data() const noexcept { return data_; }
-  size_type size() const noexcept { return size_; }
+  constexpr void reset() noexcept {
+    if (std::is_constant_evaluated()) {
+      delete data_;
+    } else {
+      if (!is_hybrid_alloc_) {
+        delete data_;
+      } else {
+        if constexpr (!std::is_trivially_destructible_v<value_type>) {
+          for (size_type i = 0; i < size_; ++i) {
+            std::destroy_at(data_ + i);
+          }
+        }
+        hybridFree(data_); // FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD
+      }
+    }
+    data_ = nullptr;
+  }
 
-  T& operator[](size_type i) noexcept { return data_[i]; }
-  const T& operator[](size_type i) const noexcept { return data_[i]; }
+  constexpr pointer release() noexcept {
+    pointer p = data_;
+    data_ = nullptr;
+    return p;
+  }
+
+  constexpr pointer data() noexcept { return data_; }
+  constexpr const pointer data() const noexcept { return data_; }
+  constexpr size_type size() const noexcept { return size_; }
+
+  constexpr T& operator[](size_type i) noexcept { return data_[i]; }
+  constexpr const T& operator[](size_type i) const noexcept { return data_[i]; }
 
  private:
   pointer data_{nullptr};
   size_type size_{0};
+  bool is_hybrid_alloc_{false};
 };
 
 // User key maps must return arithmetic keys.
@@ -410,7 +441,7 @@ struct SignBitTraits {
 template <
     RadixSortOptions RadixOptions,
     typename T,
-    detail::arithmetic_key_map<T> KeyMap>
+    stable_radix_sort_detail::arithmetic_key_map<T> KeyMap>
 struct RadixSortTraits : SignBitTraits<std::invoke_result_t<KeyMap, T>> {
   // Re-export user options
   static constexpr auto kSortStrategy = RadixOptions.SortStrategy;
@@ -453,6 +484,12 @@ struct RadixSortTraits : SignBitTraits<std::invoke_result_t<KeyMap, T>> {
 
   // Compile-time sequence of all pass indices
   static constexpr auto kPassIndices = std::make_index_sequence<kNumPasses>{};
+
+  struct alignas(std::hardware_constructive_interference_size)
+      SeqRadixHistogram2D {
+    hist_t storage[kNumPasses][kNumBuckets];
+  };
+  using aligned_hist2d_t = SeqRadixHistogram2D;
 };
 
 ///< Unsigned integer projection
@@ -665,7 +702,7 @@ template <
     typename RadixTraits,
     typename Projection,
     bool IsSignBitHandling = false>
-void integerRadixSort(
+constexpr void integerRadixSort(
     typename RadixTraits::value_t* FOLLY_RESTRICT data,
     const size_t n,
     typename RadixTraits::value_t* FOLLY_RESTRICT buffer,
@@ -679,7 +716,11 @@ void integerRadixSort(
 
   for (size_t pass = 0; pass < passes; ++pass) {
     using hist_t = typename RadixTraits::hist_t;
-    __folly_memset(hist1d, 0, RadixTraits::kNumBuckets * sizeof(hist_t));
+    if (std::is_constant_evaluated()) {
+      std::fill_n(hist1d, RadixTraits::kNumBuckets, hist_t{0});
+    } else {
+      __folly_memset(hist1d, 0, RadixTraits::kNumBuckets * sizeof(hist_t));
+    }
 
     for (size_t i = 0; i < n; i++) {
       auto x = proj.template operator()<IsSignBitHandling>(data[i]);
@@ -732,6 +773,7 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
   using Base::kNumPasses;
   using Base::kPassIndices;
   using Base::kSortOrder;
+  using typename Base::aligned_hist2d_t;
   using typename Base::hist_t;
   using typename Base::key_t;
   using typename Base::value_t;
@@ -773,9 +815,10 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
   /// Converts per-pass bucket counts to prefix-sum offsets.
   /// Returns non-empty bucket count per pass (used to skip trivial passes).
   template <size_t... Is>
-  static auto prefixSum(hist2d_t hist2d, std::index_sequence<Is...>)
-      -> std::array<size_t, sizeof...(Is)> {
-    std::array<size_t, sizeof...(Is)> nonEmptyCounts;
+  static constexpr void prefixSum(
+      hist2d_t hist2d,
+      std::index_sequence<Is...>,
+      size_t (&nonEmptyCounts)[sizeof...(Is)]) {
     auto process = [&](size_t index) -> void {
       nonEmptyCounts[index] = (hist2d[index][0] != 0);
       for (size_t i = 1; i < kNumBuckets; ++i) {
@@ -784,7 +827,6 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
       }
     };
     (process(Is), ...);
-    return nonEmptyCounts;
   }
 
   /// Scatters all passes. Sign-bit correction deferred to the last pass.
@@ -794,7 +836,7 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
       value_t* FOLLY_RESTRICT data,
       const size_t n,
       value_t* FOLLY_RESTRICT buffer,
-      const std::array<size_t, kNumPasses>& nonEmptyCounts,
+      const size_t (&nonEmptyCounts)[kNumPasses],
       hist2d_t hist2d,
       Projection proj) -> value_t* {
     // All passes except the last one: sign-bit correction is not needed.
@@ -834,35 +876,35 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
     AllocatorHolder<Allocator> holder(n, allocator);
     auto* FOLLY_RESTRICT buffer = holder.data();
 
-    const size_t histSize = kNumPasses * kNumBuckets;
-    const size_t histBytes = histSize * sizeof(hist_t);
+    auto runSort = [&](auto& hist2d) constexpr {
+      // Step 1: build histograms and check sortedness.
+      if (bool sorted = buildHistogram(data, n, hist2d, proj)) {
+        return; // Already sorted; nothing to do.
+      }
 
-    // Allocate histogram storage, preferring stack if size is small.
-    HybridAllocHolder<hist_t> histStorage{
-        FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
-            histBytes,
-            hardware_constructive_interference_size,
-            kHistogramStackThresholdBytes),
-        histSize};
-    __folly_memset(histStorage.data(), 0, histBytes);
-    auto hist2d = reinterpret_cast<hist2d_t>(histStorage.data());
+      // Step 2: convert counts to offsets and get non-empty bucket counts.
+      size_t nonEmptyCounts[kNumPasses];
+      prefixSum(hist2d, kPassIndices, nonEmptyCounts);
 
-    // Step 1: build histograms and check sortedness.
-    if (bool sorted = buildHistogram(data, n, hist2d, proj)) {
-      return; // Already sorted; nothing to do.
-    }
+      // Step 3: scatter all passes.
+      // The result may end up in the temporary buffer if the number of passes
+      // executed is odd.
+      auto* result = doScatter(data, n, buffer, nonEmptyCounts, hist2d, proj);
 
-    // Step 2: convert counts to offsets and get non-empty bucket counts.
-    std::array nonEmptyCounts = prefixSum(hist2d, kPassIndices);
+      // Step 4: if the sorted data is not in the original array, move it back.
+      if (result != original) {
+        std::move(result, result + n, original);
+      }
+    };
 
-    // Step 3: scatter all passes.
-    // The result may end up in the temporary buffer if the number of passes
-    // executed is odd.
-    auto* result = doScatter(data, n, buffer, nonEmptyCounts, hist2d, proj);
-
-    // Step 4: if the sorted data is not in the original array, move it back.
-    if (result != original) {
-      std::move(result, result + n, original);
+    const size_t histBytes = kNumPasses * kNumBuckets * sizeof(hist_t);
+    if constexpr (histBytes <= kHistogramStackThresholdBytes) {
+      aligned_hist2d_t hist2d{}; // init
+      runSort(hist2d.storage);
+    } else {
+      HistogramHeapMemHolder<aligned_hist2d_t> hist2d{
+          new aligned_hist2d_t(), kNumPasses}; // init
+      runSort(hist2d.data()->storage);
     }
   }
 };
@@ -890,6 +932,7 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
   using Base::kNumBuckets;
   using Base::kNumPasses;
   using Base::kSortOrder;
+  using typename Base::aligned_hist2d_t;
   using typename Base::hist_t;
   using typename Base::key_t;
   using typename Base::uint_t;
@@ -1016,7 +1059,11 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
     }
 
     // Step 1 : Clear the histogram for the current pass.
-    __folly_memset(hist1d, 0, kNumBuckets * sizeof(hist_t));
+    if (std::is_constant_evaluated()) {
+      std::fill_n(hist1d, kNumBuckets, hist_t{0});
+    } else {
+      __folly_memset(hist1d, 0, kNumBuckets * sizeof(hist_t));
+    }
 
     // Step 2 : build histogram for the current pass.
     buildHistogram(data, n, hist2d, pass, proj);
@@ -1044,42 +1091,48 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
     AllocatorHolder<Allocator> holder(n, allocator);
     auto* FOLLY_RESTRICT buffer = holder.data();
 
-    const size_t histSize = kNumPasses * kNumBuckets;
-    const size_t histBytes = histSize * sizeof(hist_t);
+    auto runSort = [&](auto& hist2d) constexpr {
+      // Only the first pass histogram needs to be cleared; other passes will be
+      // cleared individually in `doMsdRecursion`.
+      if (std::is_constant_evaluated()) {
+        std::fill_n(hist2d[kFirstPass], kNumBuckets, hist_t{0});
+      } else {
+        __folly_memset(hist2d[kFirstPass], 0, kNumBuckets * sizeof(hist_t));
+      }
 
+      // First pass scan: builds MSB histogram, checks sortedness, computes msb.
+      const auto [msb, sorted] = firstPassScan(data, n, hist2d, proj);
+      if (sorted) {
+        return;
+      }
+
+      // Compute the actual number of passes needed based on the highest set
+      // bit. Example: for 32-bit with 8-bit chunks, msb=24 ->
+      // passes=(24+8)/8=4.
+      const auto passes = (msb + kBitsPerPass) / kBitsPerPass;
+
+      // If the full number of passes is needed, the first pass histogram is
+      // ready.
+      if (passes == kNumPasses && prefixSum(hist2d, kFirstPass) > 1) {
+        // Scatter using the first pass (with sign-bit handling if needed).
+        doScatter(data, n, buffer, kFirstPass, hist2d, proj);
+        recurseBuckets(data, n, buffer, kFirstPass, hist2d, proj);
+      } else {
+        // Start recursion from the highest pass that actually contains data.
+        doMsdRecursion(data, n, buffer, passes - 1, hist2d, proj);
+      }
+    };
+
+    const size_t histBytes = kNumPasses * kNumBuckets * sizeof(hist_t);
     // Pre-allocate histogram memory for all passes at once,
     // prevent memory allocation overhead in every recursion.
-    HybridAllocHolder<hist_t> histStorage{
-        FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
-            histBytes,
-            hardware_constructive_interference_size,
-            kHistogramStackThresholdBytes),
-        histSize};
-    auto hist2d = reinterpret_cast<hist2d_t>(histStorage.data());
-
-    // Only the first pass histogram needs to be cleared; other passes will be
-    // cleared individually in `doMsdRecursion`.
-    __folly_memset(hist2d[kFirstPass], 0, kNumBuckets * sizeof(hist_t));
-
-    // First pass scan: builds MSB histogram, checks sortedness, computes msb.
-    const auto [msb, sorted] = firstPassScan(data, n, hist2d, proj);
-    if (sorted) {
-      return;
-    }
-
-    // Compute the actual number of passes needed based on the highest set bit.
-    // Example: for 32-bit with 8-bit chunks, msb=24 -> passes=(24+8)/8=4.
-    const auto passes = (msb + kBitsPerPass) / kBitsPerPass;
-
-    // If the full number of passes is needed, the first pass histogram is
-    // ready.
-    if (passes == kNumPasses && prefixSum(hist2d, kFirstPass) > 1) {
-      // Scatter using the first pass (with sign-bit handling if needed).
-      doScatter(data, n, buffer, kFirstPass, hist2d, proj);
-      recurseBuckets(data, n, buffer, kFirstPass, hist2d, proj);
+    if constexpr (histBytes <= kHistogramStackThresholdBytes) {
+      aligned_hist2d_t hist2d; // not init
+      runSort(hist2d.storage);
     } else {
-      // Start recursion from the highest pass that actually contains data.
-      doMsdRecursion(data, n, buffer, passes - 1, hist2d, proj);
+      HistogramHeapMemHolder<aligned_hist2d_t> hist2d{
+          new aligned_hist2d_t, kNumPasses}; // not init
+      runSort(hist2d.data()->storage);
     }
   }
 };
@@ -1119,7 +1172,8 @@ struct RadixSortParHelpers : RadixTraits {
     const size_t step = info.step;
     using ThreadChunkStatsWrapped = ThreadChunkStats<key_t>;
     const auto threadBytes = threads * sizeof(ThreadChunkStatsWrapped);
-    HybridAllocHolder<ThreadChunkStatsWrapped> statsArray{
+    HistogramHeapMemHolder<ThreadChunkStatsWrapped> statsArray{
+        hybrid_alloc_tag{},
         FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
             threadBytes,
             hardware_constructive_interference_size,
@@ -1297,7 +1351,8 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
     const size_t histBytes = histSize * sizeof(hist_t);
     const ThreadChunkInfo chunkInfo(threads, n % threads, n / threads);
 
-    HybridAllocHolder<hist_t> histStorage{
+    HistogramHeapMemHolder<hist_t> histStorage{
+        hybrid_alloc_tag{},
         FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
             histBytes,
             hardware_constructive_interference_size,
@@ -1432,7 +1487,8 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
     const size_t histSize = size_t{threads} * kNumBuckets;
     const size_t histBytes = histSize * sizeof(hist_t);
 
-    HybridAllocHolder<hist_t> histStorage{
+    HistogramHeapMemHolder<hist_t> histStorage{
+        hybrid_alloc_tag{},
         FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
             histBytes,
             hardware_constructive_interference_size,
@@ -1475,7 +1531,8 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
     const size_t histBytes = histSize * sizeof(hist_t);
     const ThreadChunkInfo chunkInfo(threads, n % threads, n / threads);
 
-    HybridAllocHolder<hist_t> histStorage{
+    HistogramHeapMemHolder<hist_t> histStorage{
+        hybrid_alloc_tag{},
         FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(
             histBytes,
             hardware_constructive_interference_size,
@@ -1505,7 +1562,7 @@ struct RadixSortImplDispatcher<RadixTraits, RandIter, Allocator, Projection>
 template <
     typename RadixTraits,
     std::random_access_iterator RandIter,
-    detail::standard_allocator Allocator,
+    stable_radix_sort_detail::standard_allocator Allocator,
     unsigned_integral_projection<std::iter_value_t<RandIter>> Projection>
 constexpr void stable_radix_sort_impl(
     RandIter first,
@@ -1565,12 +1622,12 @@ constexpr void stable_radix_sort_impl(
   }
 }
 
-} // namespace detail
+} // namespace stable_radix_sort_detail
 
 template <
     std::random_access_iterator RandIter,
-    detail::arithmetic_key_map<std::iter_value_t<RandIter>> KeyMap =
-        detail::radix_key_map_fn>
+    stable_radix_sort_detail::arithmetic_key_map<std::iter_value_t<RandIter>>
+        KeyMap = stable_radix_sort_detail::radix_key_map_fn>
 [[deprecated(
     "use folly::stable_radix_sort with RadixSortOrder::Descending instead")]]
 void stable_radix_sort_descending(
@@ -1618,9 +1675,9 @@ void stable_radix_sort_descending(
 template <
     RadixSortOptions RadixOptions,
     std::random_access_iterator RandIter,
-    detail::standard_allocator Allocator,
-    detail::arithmetic_key_map<std::iter_value_t<RandIter>> KeyMap =
-        detail::radix_key_map_fn>
+    stable_radix_sort_detail::standard_allocator Allocator,
+    stable_radix_sort_detail::arithmetic_key_map<std::iter_value_t<RandIter>>
+        KeyMap = stable_radix_sort_detail::radix_key_map_fn>
 constexpr void stable_radix_sort(
     RandIter first,
     RandIter last,
@@ -1630,7 +1687,7 @@ constexpr void stable_radix_sort(
 
   // Construct the projection functor that maps value -> unsigned key.
   auto projection =
-      detail::radix_uint_projection.template
+      stable_radix_sort_detail::radix_uint_projection.template
       operator()<RadixOptions.NaNsPosHandling>(
           std::in_place_type<value_t>, std::move(keyMap));
 
@@ -1638,19 +1695,20 @@ constexpr void stable_radix_sort(
   // passing the underlying base iterators to the implementation.
   constexpr auto adjustedOptions = [] {
     RadixSortOptions opts = RadixOptions;
-    opts.SortOrder =
-        detail::RadixRealSortOrder<RandIter, RadixOptions.SortOrder>::value;
+    opts.SortOrder = stable_radix_sort_detail::
+        RadixRealSortOrder<RandIter, RadixOptions.SortOrder>::value;
     return opts;
   }();
 
-  using RadixTraits = detail::RadixSortTraits<adjustedOptions, value_t, KeyMap>;
+  using RadixTraits = stable_radix_sort_detail::
+      RadixSortTraits<adjustedOptions, value_t, KeyMap>;
 
   // If the iterator is a reverse_iterator, unwrap to base and swap first/last.
   if constexpr (is_reverse_iterator_v<RandIter>) {
-    detail::stable_radix_sort_impl<RadixTraits>(
+    stable_radix_sort_detail::stable_radix_sort_impl<RadixTraits>(
         last.base(), first.base(), allocator, std::move(projection));
   } else {
-    detail::stable_radix_sort_impl<RadixTraits>(
+    stable_radix_sort_detail::stable_radix_sort_impl<RadixTraits>(
         first, last, allocator, std::move(projection));
   }
 }
@@ -1672,8 +1730,8 @@ constexpr void stable_radix_sort(
 template <
     RadixSortOptions RadixOptions,
     std::random_access_iterator RandIter,
-    detail::arithmetic_key_map<std::iter_value_t<RandIter>> KeyMap =
-        detail::radix_key_map_fn>
+    stable_radix_sort_detail::arithmetic_key_map<std::iter_value_t<RandIter>>
+        KeyMap = stable_radix_sort_detail::radix_key_map_fn>
 constexpr void stable_radix_sort(
     RandIter first, RandIter last, KeyMap keyMap = {}) {
   using value_t = typename std::iter_value_t<RandIter>;
@@ -1697,8 +1755,8 @@ constexpr void stable_radix_sort(
  */
 template <
     std::random_access_iterator RandIter,
-    detail::arithmetic_key_map<std::iter_value_t<RandIter>> KeyMap =
-        detail::radix_key_map_fn>
+    stable_radix_sort_detail::arithmetic_key_map<std::iter_value_t<RandIter>>
+        KeyMap = stable_radix_sort_detail::radix_key_map_fn>
 constexpr void stable_radix_sort(
     RandIter first, RandIter last, KeyMap keyMap = {}) {
   using value_t = typename std::iter_value_t<RandIter>;

--- a/folly/algorithm/test/BUCK
+++ b/folly/algorithm/test/BUCK
@@ -23,6 +23,15 @@ fb_dirsync_cpp_unittest(
     ],
 )
 
+fb_dirsync_cpp_unittest(
+    name = "stable_radix_sort_constexpr_test",
+    srcs = ["StableRadixSortConstexprTest.cpp"],
+    headers = [],
+    deps = [
+        "//folly/algorithm:stable_radix_sort",
+    ],
+)
+
 fb_dirsync_cpp_benchmark(
     name = "stable_radix_sort_benchmark",
     srcs = ["StableRadixSortBenchmark.cpp"],

--- a/folly/algorithm/test/StableRadixSortBenchmark.cpp
+++ b/folly/algorithm/test/StableRadixSortBenchmark.cpp
@@ -18,9 +18,12 @@
 
 #include <folly/stats/detail/DoubleRadixSort.h>
 
+#if __has_include(<boost/sort/pdqsort/pdqsort.hpp>)
 #include <boost/sort/pdqsort/pdqsort.hpp>
 #include <boost/sort/spreadsort/float_sort.hpp>
 #include <boost/sort/spreadsort/integer_sort.hpp>
+#define FOLLY_HAVE_BOOST_SORT 1
+#endif
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
@@ -31,14 +34,40 @@
 #include <type_traits>
 #include <vector>
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#include <ppl.h>
+#endif
+
 namespace {
 
 constexpr uint32_t kSeed = 42;
 
+constexpr auto kLsdSeq = folly::RadixSortOptions{
+    .SortStrategy = folly::RadixSortStrategy::Lsd,
+    .ExecutionPolicy = folly::RadixExecutionPolicy::Seq,
+};
+
+constexpr auto kMsdSeq = folly::RadixSortOptions{
+    .SortStrategy = folly::RadixSortStrategy::Msd,
+    .ExecutionPolicy = folly::RadixExecutionPolicy::Seq,
+};
+
+#ifdef _OPENMP
+constexpr auto kLsdPar = folly::RadixSortOptions{
+    .SortStrategy = folly::RadixSortStrategy::Lsd,
+    .ExecutionPolicy = folly::RadixExecutionPolicy::Par,
+};
+
+constexpr auto kMsdPar = folly::RadixSortOptions{
+    .SortStrategy = folly::RadixSortStrategy::Msd,
+    .ExecutionPolicy = folly::RadixExecutionPolicy::Par,
+};
+#endif
+
 template <typename T>
 std::span<const T> generateData(size_t n) {
   static std::vector<T> data = [] {
-    std::vector<T> v(100000);
+    std::vector<T> v(1000000);
     std::mt19937_64 gen(kSeed);
     if constexpr (std::is_floating_point_v<T>) {
       std::uniform_real_distribution<T> dist(-1e9, 1e9);
@@ -52,8 +81,18 @@ std::span<const T> generateData(size_t n) {
   return {data.data(), n};
 }
 
+// --- Sequential benchmarks ---
+
 template <typename T>
 void benchmarkStdSort(size_t n) {
+  auto data = generateData<T>(n);
+  std::vector<T> copy(data.begin(), data.end());
+  std::sort(copy.begin(), copy.end());
+  folly::doNotOptimizeAway(copy);
+}
+
+template <typename T>
+void benchmarkStdStableSort(size_t n) {
   auto data = generateData<T>(n);
   std::vector<T> copy(data.begin(), data.end());
   std::stable_sort(copy.begin(), copy.end());
@@ -61,13 +100,22 @@ void benchmarkStdSort(size_t n) {
 }
 
 template <typename T>
-void benchmarkRadixSort(size_t n) {
+void benchmarkRadixSortLsdSeq(size_t n) {
   auto data = generateData<T>(n);
   std::vector<T> copy(data.begin(), data.end());
-  folly::stable_radix_sort(copy.begin(), copy.end());
+  folly::stable_radix_sort<kLsdSeq>(copy.begin(), copy.end());
   folly::doNotOptimizeAway(copy);
 }
 
+template <typename T>
+void benchmarkRadixSortMsdSeq(size_t n) {
+  auto data = generateData<T>(n);
+  std::vector<T> copy(data.begin(), data.end());
+  folly::stable_radix_sort<kMsdSeq>(copy.begin(), copy.end());
+  folly::doNotOptimizeAway(copy);
+}
+
+#ifdef FOLLY_HAVE_BOOST_SORT
 template <typename T>
 void benchmarkSpreadsort(size_t n) {
   auto data = generateData<T>(n);
@@ -87,6 +135,12 @@ void benchmarkPdqsort(size_t n) {
   boost::sort::pdqsort(copy.begin(), copy.end());
   folly::doNotOptimizeAway(copy);
 }
+#else
+template <typename T>
+void benchmarkSpreadsort(size_t) {}
+template <typename T>
+void benchmarkPdqsort(size_t) {}
+#endif
 
 void benchmarkDoubleDetailRadixSort(size_t n) {
   auto data = generateData<double>(n);
@@ -97,41 +151,322 @@ void benchmarkDoubleDetailRadixSort(size_t n) {
   folly::doNotOptimizeAway(copy);
 }
 
+#ifdef _OPENMP
+// --- Parallel benchmarks (only with OpenMP) ---
+
+#if defined(__cpp_lib_parallel_algorithm) || (defined(_MSC_VER) && !defined(__clang__))
+#include <execution>
+
+template <typename T>
+void benchmarkStdSortPar(size_t n) {
+  auto data = generateData<T>(n);
+  std::vector<T> copy(data.begin(), data.end());
+  std::sort(std::execution::par, copy.begin(), copy.end());
+  folly::doNotOptimizeAway(copy);
+}
+
+template <typename T>
+void benchmarkStdStableSortPar(size_t n) {
+  auto data = generateData<T>(n);
+  std::vector<T> copy(data.begin(), data.end());
+  std::stable_sort(std::execution::par, copy.begin(), copy.end());
+  folly::doNotOptimizeAway(copy);
+}
+#endif
+
+template <typename T>
+void benchmarkRadixSortLsdPar(size_t n) {
+  auto data = generateData<T>(n);
+  std::vector<T> copy(data.begin(), data.end());
+  folly::stable_radix_sort<kLsdPar>(copy.begin(), copy.end());
+  folly::doNotOptimizeAway(copy);
+}
+
+template <typename T>
+void benchmarkRadixSortMsdPar(size_t n) {
+  auto data = generateData<T>(n);
+  std::vector<T> copy(data.begin(), data.end());
+  folly::stable_radix_sort<kMsdPar>(copy.begin(), copy.end());
+  folly::doNotOptimizeAway(copy);
+}
+
+#if defined(_MSC_VER) && !defined(__clang__)
+template <typename T>
+void benchmarkMsvcParallelRadixsort(size_t n) {
+  auto data = generateData<T>(n);
+  std::vector<T> copy(data.begin(), data.end());
+  Concurrency::parallel_radixsort(copy.begin(), copy.end());
+  folly::doNotOptimizeAway(copy);
+}
+#endif
+#endif
+
 } // namespace
 
 // clang-format off
-#define BENCHMARK_UINT64(N) \
-  BENCHMARK(Uint64_StdStableSort_##N) { benchmarkStdSort<uint64_t>(N); } \
-  BENCHMARK(Uint64_RadixSort_##N) { benchmarkRadixSort<uint64_t>(N); } \
-  BENCHMARK(Uint64_Spreadsort_##N) { benchmarkSpreadsort<uint64_t>(N); } \
-  BENCHMARK(Uint64_Pdqsort_##N) { benchmarkPdqsort<uint64_t>(N); }
 
-#define BENCHMARK_INT64(N) \
-  BENCHMARK(Int64_StdStableSort_##N) { benchmarkStdSort<int64_t>(N); } \
-  BENCHMARK(Int64_RadixSort_##N) { benchmarkRadixSort<int64_t>(N); } \
-  BENCHMARK(Int64_Spreadsort_##N) { benchmarkSpreadsort<int64_t>(N); } \
-  BENCHMARK(Int64_Pdqsort_##N) { benchmarkPdqsort<int64_t>(N); }
+// ============================================================================
+// Section 1: Sequential comparison
+//   Baseline: std::sort
+//   Compared: std::stable_sort, boost::spreadsort, boost::pdqsort,
+//             folly radix LSD/Seq, MSD/Seq, DoubleRadixSort (double only)
+// ============================================================================
 
-#define BENCHMARK_DOUBLE(N) \
-  BENCHMARK(Double_StdStableSort_##N) { benchmarkStdSort<double>(N); } \
-  BENCHMARK(Double_RadixSort_##N) { benchmarkRadixSort<double>(N); } \
-  BENCHMARK(Double_Spreadsort_##N) { benchmarkSpreadsort<double>(N); } \
-  BENCHMARK(Double_Pdqsort_##N) { benchmarkPdqsort<double>(N); } \
-  BENCHMARK(Double_DetailRadixSort_##N) { benchmarkDoubleDetailRadixSort(N); }
+// Uint64 — Sequential
+#define BENCHMARK_UINT64_SEQ(N) \
+  BENCHMARK(Uint64_StdSort_##N)          { benchmarkStdSort<uint64_t>(N); } \
+  BENCHMARK_RELATIVE(Uint64_StableSort_##N)   { benchmarkStdStableSort<uint64_t>(N); } \
+  BENCHMARK_RELATIVE(Uint64_Spreadsort_##N)   { benchmarkSpreadsort<uint64_t>(N); } \
+  BENCHMARK_RELATIVE(Uint64_Pdqsort_##N)      { benchmarkPdqsort<uint64_t>(N); } \
+  BENCHMARK_RELATIVE(Uint64_LsdSeq_##N)       { benchmarkRadixSortLsdSeq<uint64_t>(N); } \
+  BENCHMARK_RELATIVE(Uint64_MsdSeq_##N)       { benchmarkRadixSortMsdSeq<uint64_t>(N); }
 
-#define BENCHMARK_ALL_TYPES(N) \
-  BENCHMARK_UINT64(N) \
-  BENCHMARK_DRAW_LINE(); \
-  BENCHMARK_INT64(N) \
-  BENCHMARK_DRAW_LINE(); \
-  BENCHMARK_DOUBLE(N) \
-  BENCHMARK_DRAW_LINE();
+// Int64 — Sequential
+#define BENCHMARK_INT64_SEQ(N) \
+  BENCHMARK(Int64_StdSort_##N)          { benchmarkStdSort<int64_t>(N); } \
+  BENCHMARK_RELATIVE(Int64_StableSort_##N)   { benchmarkStdStableSort<int64_t>(N); } \
+  BENCHMARK_RELATIVE(Int64_Spreadsort_##N)   { benchmarkSpreadsort<int64_t>(N); } \
+  BENCHMARK_RELATIVE(Int64_Pdqsort_##N)      { benchmarkPdqsort<int64_t>(N); } \
+  BENCHMARK_RELATIVE(Int64_LsdSeq_##N)       { benchmarkRadixSortLsdSeq<int64_t>(N); } \
+  BENCHMARK_RELATIVE(Int64_MsdSeq_##N)       { benchmarkRadixSortMsdSeq<int64_t>(N); }
+
+// Int32 — Sequential
+#define BENCHMARK_INT32_SEQ(N) \
+  BENCHMARK(Int32_StdSort_##N)          { benchmarkStdSort<int32_t>(N); } \
+  BENCHMARK_RELATIVE(Int32_StableSort_##N)   { benchmarkStdStableSort<int32_t>(N); } \
+  BENCHMARK_RELATIVE(Int32_Spreadsort_##N)   { benchmarkSpreadsort<int32_t>(N); } \
+  BENCHMARK_RELATIVE(Int32_Pdqsort_##N)      { benchmarkPdqsort<int32_t>(N); } \
+  BENCHMARK_RELATIVE(Int32_LsdSeq_##N)       { benchmarkRadixSortLsdSeq<int32_t>(N); } \
+  BENCHMARK_RELATIVE(Int32_MsdSeq_##N)       { benchmarkRadixSortMsdSeq<int32_t>(N); }
+
+// Uint32 — Sequential
+#define BENCHMARK_UINT32_SEQ(N) \
+  BENCHMARK(Uint32_StdSort_##N)          { benchmarkStdSort<uint32_t>(N); } \
+  BENCHMARK_RELATIVE(Uint32_StableSort_##N)   { benchmarkStdStableSort<uint32_t>(N); } \
+  BENCHMARK_RELATIVE(Uint32_Spreadsort_##N)   { benchmarkSpreadsort<uint32_t>(N); } \
+  BENCHMARK_RELATIVE(Uint32_Pdqsort_##N)      { benchmarkPdqsort<uint32_t>(N); } \
+  BENCHMARK_RELATIVE(Uint32_LsdSeq_##N)       { benchmarkRadixSortLsdSeq<uint32_t>(N); } \
+  BENCHMARK_RELATIVE(Uint32_MsdSeq_##N)       { benchmarkRadixSortMsdSeq<uint32_t>(N); }
+
+// Double — Sequential (includes DoubleRadixSort)
+#define BENCHMARK_DOUBLE_SEQ(N) \
+  BENCHMARK(Double_StdSort_##N)          { benchmarkStdSort<double>(N); } \
+  BENCHMARK_RELATIVE(Double_StableSort_##N)   { benchmarkStdStableSort<double>(N); } \
+  BENCHMARK_RELATIVE(Double_Spreadsort_##N)   { benchmarkSpreadsort<double>(N); } \
+  BENCHMARK_RELATIVE(Double_Pdqsort_##N)      { benchmarkPdqsort<double>(N); } \
+  BENCHMARK_RELATIVE(Double_LsdSeq_##N)       { benchmarkRadixSortLsdSeq<double>(N); } \
+  BENCHMARK_RELATIVE(Double_MsdSeq_##N)       { benchmarkRadixSortMsdSeq<double>(N); } \
+  BENCHMARK_RELATIVE(Double_DetailRadix_##N)  { benchmarkDoubleDetailRadixSort(N); }
+
+BENCHMARK_DRAW_TEXT("Uint64 — Sequential");
+BENCHMARK_UINT64_SEQ(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT64_SEQ(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT64_SEQ(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT64_SEQ(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT64_SEQ(1000000)
+
+BENCHMARK_DRAW_TEXT("Int64 — Sequential");
+BENCHMARK_INT64_SEQ(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT64_SEQ(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT64_SEQ(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT64_SEQ(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT64_SEQ(1000000)
+
+BENCHMARK_DRAW_TEXT("Double — Sequential");
+BENCHMARK_DOUBLE_SEQ(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DOUBLE_SEQ(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DOUBLE_SEQ(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DOUBLE_SEQ(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DOUBLE_SEQ(1000000)
+
+BENCHMARK_DRAW_TEXT("Int32 — Sequential");
+BENCHMARK_INT32_SEQ(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT32_SEQ(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT32_SEQ(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT32_SEQ(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT32_SEQ(1000000)
+
+BENCHMARK_DRAW_TEXT("Uint32 — Sequential");
+BENCHMARK_UINT32_SEQ(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT32_SEQ(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT32_SEQ(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT32_SEQ(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT32_SEQ(1000000)
+
+#ifdef _OPENMP
+// ============================================================================
+// Section 2: Parallel comparison (requires OpenMP)
+//   Baseline: std::sort(std::execution::par)
+//   Compared: std::stable_sort(par), folly radix LSD/Par, MSD/Par,
+//             MSVC parallel_radixsort (integral only, MSVC only)
+// ============================================================================
+
+// MSVC-only: std::execution::par + MSVC parallel_radixsort
+#if defined(_MSC_VER) && !defined(__clang__)
+  #define BENCHMARK_UINT64_PAR(N) \
+    BENCHMARK(Uint64_StdSortPar_##N)        { benchmarkStdSortPar<uint64_t>(N); } \
+    BENCHMARK_RELATIVE(Uint64_StableSortPar_##N) { benchmarkStdStableSortPar<uint64_t>(N); } \
+    BENCHMARK_RELATIVE(Uint64_LsdPar_##N)        { benchmarkRadixSortLsdPar<uint64_t>(N); } \
+    BENCHMARK_RELATIVE(Uint64_MsdPar_##N)        { benchmarkRadixSortMsdPar<uint64_t>(N); } \
+    BENCHMARK_RELATIVE(Uint64_MsvcRadix_##N)     { benchmarkMsvcParallelRadixsort<uint64_t>(N); }
+
+  #define BENCHMARK_INT64_PAR(N) \
+    BENCHMARK(Int64_StdSortPar_##N)        { benchmarkStdSortPar<int64_t>(N); } \
+    BENCHMARK_RELATIVE(Int64_StableSortPar_##N) { benchmarkStdStableSortPar<int64_t>(N); } \
+    BENCHMARK_RELATIVE(Int64_LsdPar_##N)        { benchmarkRadixSortLsdPar<int64_t>(N); } \
+    BENCHMARK_RELATIVE(Int64_MsdPar_##N)        { benchmarkRadixSortMsdPar<int64_t>(N); } \
+    BENCHMARK_RELATIVE(Int64_MsvcRadix_##N)     { benchmarkMsvcParallelRadixsort<int64_t>(N); }
+
+  #define BENCHMARK_DOUBLE_PAR(N) \
+    BENCHMARK(Double_StdSortPar_##N)        { benchmarkStdSortPar<double>(N); } \
+    BENCHMARK_RELATIVE(Double_StableSortPar_##N) { benchmarkStdStableSortPar<double>(N); } \
+    BENCHMARK_RELATIVE(Double_LsdPar_##N)        { benchmarkRadixSortLsdPar<double>(N); } \
+    BENCHMARK_RELATIVE(Double_MsdPar_##N)        { benchmarkRadixSortMsdPar<double>(N); }
+
+  #define BENCHMARK_INT32_PAR(N) \
+    BENCHMARK(Int32_StdSortPar_##N)        { benchmarkStdSortPar<int32_t>(N); } \
+    BENCHMARK_RELATIVE(Int32_StableSortPar_##N) { benchmarkStdStableSortPar<int32_t>(N); } \
+    BENCHMARK_RELATIVE(Int32_LsdPar_##N)        { benchmarkRadixSortLsdPar<int32_t>(N); } \
+    BENCHMARK_RELATIVE(Int32_MsdPar_##N)        { benchmarkRadixSortMsdPar<int32_t>(N); } \
+    BENCHMARK_RELATIVE(Int32_MsvcRadix_##N)     { benchmarkMsvcParallelRadixsort<int32_t>(N); }
+
+  #define BENCHMARK_UINT32_PAR(N) \
+    BENCHMARK(Uint32_StdSortPar_##N)        { benchmarkStdSortPar<uint32_t>(N); } \
+    BENCHMARK_RELATIVE(Uint32_StableSortPar_##N) { benchmarkStdStableSortPar<uint32_t>(N); } \
+    BENCHMARK_RELATIVE(Uint32_LsdPar_##N)        { benchmarkRadixSortLsdPar<uint32_t>(N); } \
+    BENCHMARK_RELATIVE(Uint32_MsdPar_##N)        { benchmarkRadixSortMsdPar<uint32_t>(N); } \
+    BENCHMARK_RELATIVE(Uint32_MsvcRadix_##N)     { benchmarkMsvcParallelRadixsort<uint32_t>(N); }
+// Clang: only radix sort parallel (no MSVC STL <execution>, no PPL)
+#elif defined(__clang__) && defined(_MSC_VER) && defined(_OPENMP)
+  #define BENCHMARK_UINT64_PAR(N) \
+    BENCHMARK(Uint64_LsdPar_##N)        { benchmarkRadixSortLsdPar<uint64_t>(N); } \
+    BENCHMARK_RELATIVE(Uint64_MsdPar_##N)        { benchmarkRadixSortMsdPar<uint64_t>(N); }
+
+  #define BENCHMARK_INT64_PAR(N) \
+    BENCHMARK(Int64_LsdPar_##N)        { benchmarkRadixSortLsdPar<int64_t>(N); } \
+    BENCHMARK_RELATIVE(Int64_MsdPar_##N)        { benchmarkRadixSortMsdPar<int64_t>(N); }
+
+  #define BENCHMARK_DOUBLE_PAR(N) \
+    BENCHMARK(Double_LsdPar_##N)        { benchmarkRadixSortLsdPar<double>(N); } \
+    BENCHMARK_RELATIVE(Double_MsdPar_##N)        { benchmarkRadixSortMsdPar<double>(N); }
+
+  #define BENCHMARK_INT32_PAR(N) \
+    BENCHMARK(Int32_LsdPar_##N)        { benchmarkRadixSortLsdPar<int32_t>(N); } \
+    BENCHMARK_RELATIVE(Int32_MsdPar_##N)        { benchmarkRadixSortMsdPar<int32_t>(N); }
+
+  #define BENCHMARK_UINT32_PAR(N) \
+    BENCHMARK(Uint32_LsdPar_##N)        { benchmarkRadixSortLsdPar<uint32_t>(N); } \
+    BENCHMARK_RELATIVE(Uint32_MsdPar_##N)        { benchmarkRadixSortMsdPar<uint32_t>(N); }
+// Other compilers with OpenMP and parallel algorithms support
+#elif defined(__cpp_lib_parallel_algorithm)
+  #define BENCHMARK_UINT64_PAR(N) \
+    BENCHMARK(Uint64_StdSortPar_##N)        { benchmarkStdSortPar<uint64_t>(N); } \
+    BENCHMARK_RELATIVE(Uint64_StableSortPar_##N) { benchmarkStdStableSortPar<uint64_t>(N); } \
+    BENCHMARK_RELATIVE(Uint64_LsdPar_##N)        { benchmarkRadixSortLsdPar<uint64_t>(N); } \
+    BENCHMARK_RELATIVE(Uint64_MsdPar_##N)        { benchmarkRadixSortMsdPar<uint64_t>(N); }
+
+  #define BENCHMARK_INT64_PAR(N) \
+    BENCHMARK(Int64_StdSortPar_##N)        { benchmarkStdSortPar<int64_t>(N); } \
+    BENCHMARK_RELATIVE(Int64_StableSortPar_##N) { benchmarkStdStableSortPar<int64_t>(N); } \
+    BENCHMARK_RELATIVE(Int64_LsdPar_##N)        { benchmarkRadixSortLsdPar<int64_t>(N); } \
+    BENCHMARK_RELATIVE(Int64_MsdPar_##N)        { benchmarkRadixSortMsdPar<int64_t>(N); }
+
+  #define BENCHMARK_DOUBLE_PAR(N) \
+    BENCHMARK(Double_StdSortPar_##N)        { benchmarkStdSortPar<double>(N); } \
+    BENCHMARK_RELATIVE(Double_StableSortPar_##N) { benchmarkStdStableSortPar<double>(N); } \
+    BENCHMARK_RELATIVE(Double_LsdPar_##N)        { benchmarkRadixSortLsdPar<double>(N); } \
+    BENCHMARK_RELATIVE(Double_MsdPar_##N)        { benchmarkRadixSortMsdPar<double>(N); }
+
+  #define BENCHMARK_INT32_PAR(N) \
+    BENCHMARK(Int32_StdSortPar_##N)        { benchmarkStdSortPar<int32_t>(N); } \
+    BENCHMARK_RELATIVE(Int32_StableSortPar_##N) { benchmarkStdStableSortPar<int32_t>(N); } \
+    BENCHMARK_RELATIVE(Int32_LsdPar_##N)        { benchmarkRadixSortLsdPar<int32_t>(N); } \
+    BENCHMARK_RELATIVE(Int32_MsdPar_##N)        { benchmarkRadixSortMsdPar<int32_t>(N); }
+
+  #define BENCHMARK_UINT32_PAR(N) \
+    BENCHMARK(Uint32_StdSortPar_##N)        { benchmarkStdSortPar<uint32_t>(N); } \
+    BENCHMARK_RELATIVE(Uint32_StableSortPar_##N) { benchmarkStdStableSortPar<uint32_t>(N); } \
+    BENCHMARK_RELATIVE(Uint32_LsdPar_##N)        { benchmarkRadixSortLsdPar<uint32_t>(N); } \
+    BENCHMARK_RELATIVE(Uint32_MsdPar_##N)        { benchmarkRadixSortMsdPar<uint32_t>(N); }
+#endif
+
+BENCHMARK_DRAW_TEXT("Uint64 — Parallel");
+BENCHMARK_UINT64_PAR(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT64_PAR(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT64_PAR(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT64_PAR(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT64_PAR(1000000)
+
+BENCHMARK_DRAW_TEXT("Int64 — Parallel");
+BENCHMARK_INT64_PAR(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT64_PAR(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT64_PAR(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT64_PAR(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT64_PAR(1000000)
+
+BENCHMARK_DRAW_TEXT("Double — Parallel");
+BENCHMARK_DOUBLE_PAR(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DOUBLE_PAR(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DOUBLE_PAR(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DOUBLE_PAR(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_DOUBLE_PAR(1000000)
+
+BENCHMARK_DRAW_TEXT("Int32 — Parallel");
+BENCHMARK_INT32_PAR(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT32_PAR(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT32_PAR(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT32_PAR(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_INT32_PAR(1000000)
+
+BENCHMARK_DRAW_TEXT("Uint32 — Parallel");
+BENCHMARK_UINT32_PAR(100)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT32_PAR(1000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT32_PAR(10000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT32_PAR(100000)
+BENCHMARK_DRAW_LINE();
+BENCHMARK_UINT32_PAR(1000000)
+#endif
+
 // clang-format on
-
-BENCHMARK_ALL_TYPES(100)
-BENCHMARK_ALL_TYPES(1000)
-BENCHMARK_ALL_TYPES(10000)
-BENCHMARK_ALL_TYPES(100000)
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);

--- a/folly/algorithm/test/StableRadixSortConstexprTest.cpp
+++ b/folly/algorithm/test/StableRadixSortConstexprTest.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/algorithm/StableRadixSort.h>
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+using namespace folly;
+
+namespace {
+// ---------------------------------------------------------------------------
+// constexpr helpers
+// ---------------------------------------------------------------------------
+
+template <typename T, size_t N>
+constexpr bool isSortedArray(const std::array<T, N>& a) {
+  for (size_t i = 1; i < N; ++i) {
+    if (a[i - 1] > a[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T>
+constexpr bool isSortedVec(const std::vector<T>& v) {
+  for (size_t i = 1; i < v.size(); ++i) {
+    if (v[i - 1] > v[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// ===========================================================================
+// constexpr (static_assert) — only tests small enough for Clang's constexpr
+// evaluator (no new[] support).  All ≤64 elements.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// LSD Seq — array, 32 elements (int32_t)
+// ---------------------------------------------------------------------------
+
+constexpr bool lsdSeqArraySmall() {
+  std::array<int32_t, 32> a = {
+      5,  31, 1, 16, 4,  28, 9, 22, 14, 7,  29, 11, 25, 3,  18, 6,
+      20, 13, 2, 30, 10, 27, 8, 24, 15, 12, 26, 17, 23, 19, 21, 0};
+  stable_radix_sort(a.begin(), a.end());
+  return isSortedArray(a);
+}
+static_assert(lsdSeqArraySmall());
+
+// ---------------------------------------------------------------------------
+// LSD Seq — vector, 48 elements (int64_t)
+// ---------------------------------------------------------------------------
+
+constexpr bool lsdSeqVecSmall() {
+  std::vector<int64_t> v = {
+      -10, 50,  -30, 80,   -50, 20,  -70, 40,  90,  -100, 60,  -80,
+      10,  -40, 70,  -20,  30,  -90, 0,   100, -60, 55,   -35, 75,
+      -45, 25,  -65, 45,   85,  -95, 65,  -75, 15,  -25,  35,  -85,
+      5,   -55, 95,  -105, 52,  -38, 78,  -48, 22,  -68,  42,  88};
+  stable_radix_sort(v.begin(), v.end());
+  return isSortedVec(v);
+}
+static_assert(lsdSeqVecSmall());
+
+// ---------------------------------------------------------------------------
+// LSD Seq — array, 50 elements, descending (int32_t)
+// ---------------------------------------------------------------------------
+
+constexpr bool lsdSeqDescending() {
+  constexpr auto kDescOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortOrder = RadixSortOrder::Descending;
+    return opts;
+  }();
+
+  std::array<int32_t, 50> a = {};
+  for (size_t i = 0; i < 50; ++i) {
+    a[i] = static_cast<int32_t>(i - 25);
+  }
+  stable_radix_sort<kDescOpts>(a.begin(), a.end());
+  for (size_t i = 1; i < 50; ++i) {
+    if (a[i - 1] < a[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+static_assert(lsdSeqDescending());
+
+// ---------------------------------------------------------------------------
+// MSD Seq — array, 40 elements (int16_t)
+// ---------------------------------------------------------------------------
+
+constexpr bool msdSeqArraySmall() {
+  constexpr auto kMsdOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortStrategy = RadixSortStrategy::Msd;
+    opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+    return opts;
+  }();
+
+  // int8_t only has 1 pass with 8-bit chunks → MSD needs ≥ 2 passes.
+  std::array<int16_t, 40> a = {
+      500,  -1000, 3000, -5000, 1500, -2500, 4500, -6500, 1000, -3000,
+      5000, -7000, 2000, -4000, 6000, -8000, 3500, -5500, 500,  -1500,
+      2500, -3500, 4000, -6000, 5500, -7500, 1000, -2000, 3000, -4500,
+      6500, -8500, 2000, -5000, 4500, -6500, 1500, -2500, 4000, -6000};
+  stable_radix_sort<kMsdOpts>(a.begin(), a.end());
+  return isSortedArray(a);
+}
+static_assert(msdSeqArraySmall());
+
+// ---------------------------------------------------------------------------
+// MSD Seq — vector, 56 elements (int32_t)
+// ---------------------------------------------------------------------------
+
+constexpr bool msdSeqVecSmall() {
+  constexpr auto kMsdOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortStrategy = RadixSortStrategy::Msd;
+    opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+    return opts;
+  }();
+
+  std::vector<int32_t> v = {
+      100, -200, 300, -400, 500, -600, 700, -800, 150, -250, 350, -450,
+      550, -650, 750, -850, 200, -300, 400, -500, 600, -700, 800, -900,
+      100, -150, 250, -350, 450, -550, 650, -750, 850, -950, 50,  -100,
+      175, -275, 375, -475, 575, -675, 775, -875, 125, -225, 325, -425,
+      525, -625, 725, -825, 925, -125, 225, -325, 425};
+  stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+  return isSortedVec(v);
+}
+static_assert(msdSeqVecSmall());
+
+// ===========================================================================
+// Runtime-only tests — >64 elements.
+// Clang's constexpr evaluator does not support new[], and
+// AllocatorHolder (the sort's temp-buffer allocator) uses new[].
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// LSD Seq — array, 128 elements (uint64_t)
+// ---------------------------------------------------------------------------
+
+void lsdSeqArrayLarge() {
+  std::array<uint64_t, 128> a = {};
+  for (size_t i = 0; i < 128; ++i) {
+    a[i] = (i < 64) ? (127 - i) * 1000ULL : (i - 64) * 7ULL;
+  }
+  stable_radix_sort(a.begin(), a.end());
+  assert(isSortedArray(a));
+}
+
+// ---------------------------------------------------------------------------
+// LSD Seq — vector, 200 elements (uint32_t)
+// ---------------------------------------------------------------------------
+
+void lsdSeqVecLarge() {
+  std::vector<uint32_t> v(200);
+  for (size_t i = 0; i < 200; ++i) {
+    v[i] = static_cast<uint32_t>((199 - i) * 3u + 7u);
+  }
+  stable_radix_sort(v.begin(), v.end());
+  assert(isSortedVec(v));
+}
+
+// ---------------------------------------------------------------------------
+// MSD Seq — array, 100 elements (uint16_t)
+// ---------------------------------------------------------------------------
+
+void msdSeqArrayLarge() {
+  constexpr auto kMsdOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortStrategy = RadixSortStrategy::Msd;
+    opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+    return opts;
+  }();
+
+  std::array<uint16_t, 100> a = {};
+  for (size_t i = 0; i < 100; ++i) {
+    a[i] = static_cast<uint16_t>((99 - i) * 657u + 13u);
+  }
+  stable_radix_sort<kMsdOpts>(a.begin(), a.end());
+  assert(isSortedArray(a));
+}
+
+// ---------------------------------------------------------------------------
+// MSD Seq — vector, 150 elements (uint64_t)
+// ---------------------------------------------------------------------------
+
+void msdSeqVecLarge() {
+  constexpr auto kMsdOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortStrategy = RadixSortStrategy::Msd;
+    opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+    return opts;
+  }();
+
+  std::vector<uint64_t> v(150);
+  for (size_t i = 0; i < 150; ++i) {
+    v[i] = (149 - i) * 123456789ULL + 42ULL;
+  }
+  stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+  assert(isSortedVec(v));
+}
+
+// ---------------------------------------------------------------------------
+// MSD Seq — array, 80 elements, descending (uint32_t)
+// ---------------------------------------------------------------------------
+
+void msdSeqDescending() {
+  constexpr auto kDescMsdOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortStrategy = RadixSortStrategy::Msd;
+    opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+    opts.SortOrder = RadixSortOrder::Descending;
+    return opts;
+  }();
+
+  std::array<uint32_t, 80> a = {};
+  for (size_t i = 0; i < 80; ++i) {
+    a[i] = static_cast<uint32_t>(i * 17u + 3u);
+  }
+  stable_radix_sort<kDescMsdOpts>(a.begin(), a.end());
+  for (size_t i = 1; i < 80; ++i) {
+    assert(a[i - 1] >= a[i]);
+  }
+}
+} // namespace
+int main() {
+  lsdSeqArrayLarge();
+  lsdSeqVecLarge();
+  msdSeqArrayLarge();
+  msdSeqVecLarge();
+  msdSeqDescending();
+  return 0;
+}

--- a/folly/algorithm/test/StableRadixSortTest.cpp
+++ b/folly/algorithm/test/StableRadixSortTest.cpp
@@ -17,28 +17,29 @@
 #include <folly/algorithm/StableRadixSort.h>
 
 #include <algorithm>
+#include <bit>
 #include <cmath>
+#include <cstdint>
+#include <format>
 #include <limits>
+#include <numeric>
 #include <random>
 #include <vector>
 
 #include <folly/portability/GTest.h>
 
-namespace folly {
+using namespace folly;
+
 namespace {
 
-// Helper struct for testing key extractors and stability
-struct Item {
-  double score;
-  int originalIndex;
+thread_local std::mt19937_64 rng{42};
 
-  [[maybe_unused]] friend bool operator==(const Item&, const Item&) = default;
-};
+// ---------------------------------------------------------------------------
+// Augmented comparator that matches radix sort's IEEE 754 total ordering
+// ---------------------------------------------------------------------------
 
-// Augmented comparator that distinguishes -0.0 from +0.0 via signbit,
-// matching the radix sort's natural ordering.
 template <typename T>
-bool augmented_less(const T& a, const T& b) {
+bool augmentedLess(const T& a, const T& b) {
   if constexpr (std::is_floating_point_v<T>) {
     if (a < b) {
       return true;
@@ -46,7 +47,6 @@ bool augmented_less(const T& a, const T& b) {
     if (b < a) {
       return false;
     }
-    // a and b are equal (e.g. -0.0 and +0.0): negative sign sorts first
     return std::signbit(a) > std::signbit(b);
   } else {
     return a < b;
@@ -54,17 +54,24 @@ bool augmented_less(const T& a, const T& b) {
 }
 
 template <typename T>
-bool augmented_greater(const T& a, const T& b) {
-  return augmented_less(b, a);
+bool augmentedGreater(const T& a, const T& b) {
+  return augmentedLess(b, a);
 }
 
-// Validate that stable_radix_sort produces the same result as std::stable_sort
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
 template <typename T>
 void validate(std::vector<T> v) {
   auto expected = v;
-  std::stable_sort(expected.begin(), expected.end(), augmented_less<T>);
+  std::stable_sort(expected.begin(), expected.end(), augmentedLess<T>);
   stable_radix_sort(v.begin(), v.end());
-  EXPECT_EQ(v, expected);
+  ASSERT_EQ(v.size(), expected.size());
+  for (size_t i = 0; i < v.size(); ++i) {
+    SCOPED_TRACE(std::format("index={}", i));
+    EXPECT_EQ(v[i], expected[i]);
+  }
 }
 
 template <typename T, typename Proj>
@@ -72,132 +79,152 @@ void validate(std::vector<T> v, Proj proj) {
   auto expected = v;
   std::stable_sort(
       expected.begin(), expected.end(), [&](const T& a, const T& b) {
-        return augmented_less(proj(a), proj(b));
+        return augmentedLess(proj(a), proj(b));
       });
   stable_radix_sort(v.begin(), v.end(), proj);
-  EXPECT_EQ(v, expected);
+  ASSERT_EQ(v.size(), expected.size());
+  for (size_t i = 0; i < v.size(); ++i) {
+    SCOPED_TRACE(std::format("index={}", i));
+    EXPECT_EQ(v[i], expected[i]);
+  }
 }
+
+constexpr auto kDescOpts = [] {
+  auto opts = RadixSortOptions{};
+  opts.SortOrder = RadixSortOrder::Descending;
+  return opts;
+}();
 
 template <typename T>
 void validateDescending(std::vector<T> v) {
   auto expected = v;
-  std::stable_sort(expected.begin(), expected.end(), augmented_greater<T>);
-  stable_radix_sort_descending(v.begin(), v.end());
-  EXPECT_EQ(v, expected);
+  std::stable_sort(expected.begin(), expected.end(), augmentedGreater<T>);
+  stable_radix_sort<kDescOpts>(v.begin(), v.end());
+  ASSERT_EQ(v.size(), expected.size());
+  for (size_t i = 0; i < v.size(); ++i) {
+    SCOPED_TRACE(std::format("index={}", i));
+    EXPECT_EQ(v[i], expected[i]);
+  }
 }
 
-template <typename T, typename Proj>
-void validateDescending(std::vector<T> v, Proj proj) {
-  auto expected = v;
-  std::stable_sort(
-      expected.begin(), expected.end(), [&](const T& a, const T& b) {
-        return augmented_greater(proj(a), proj(b));
-      });
-  stable_radix_sort_descending(v.begin(), v.end(), proj);
-  EXPECT_EQ(v, expected);
+// ---------------------------------------------------------------------------
+// Random data generators
+// ---------------------------------------------------------------------------
+
+template <typename T>
+std::vector<T> generateRandom(size_t n) {
+  std::vector<T> v(n);
+  if constexpr (std::is_floating_point_v<T>) {
+    std::uniform_real_distribution<T> dist(-1000, 1000);
+    for (auto& x : v) {
+      x = dist(rng);
+    }
+  } else if constexpr (sizeof(T) == 1) {
+    std::uniform_int_distribution<int> dist(0, 255);
+    for (auto& x : v) {
+      x = static_cast<T>(dist(rng));
+    }
+  } else if constexpr (std::is_signed_v<T>) {
+    std::uniform_int_distribution<int64_t> dist(
+        std::numeric_limits<T>::min() / 2, std::numeric_limits<T>::max() / 2);
+    for (auto& x : v) {
+      x = static_cast<T>(dist(rng));
+    }
+  } else {
+    std::uniform_int_distribution<uint64_t> dist;
+    for (auto& x : v) {
+      x = static_cast<T>(dist(rng));
+    }
+  }
+  return v;
 }
 
-// Test fixture
-class StableRadixSortTest : public ::testing::Test {
- protected:
-  std::mt19937 rng{42}; // Fixed seed for reproducibility
+// ---------------------------------------------------------------------------
+// Item struct for stability and key-extractor tests
+// ---------------------------------------------------------------------------
+
+struct Item {
+  double score;
+  int originalIndex;
+
+  bool operator==(const Item&) const = default;
+  bool operator<(const Item& o) const { return augmentedLess(score, o.score); }
+  bool operator>(const Item& o) const { return o < *this; }
+
+  friend std::ostream& operator<<(std::ostream& os, const Item& item) {
+    return os << std::format(
+               "Item{{score={}, index={}}}", item.score, item.originalIndex);
+  }
 };
 
+} // namespace
+
 // ============================================================================
-// Basic functionality tests
+// Basic tests
 // ============================================================================
 
-TEST_F(StableRadixSortTest, EmptyRange) {
-  validate(std::vector<uint64_t>{});
+TEST(RadixSortTest, Empty) {
+  validate(std::vector<uint32_t>{});
 }
 
-TEST_F(StableRadixSortTest, SingleElement) {
-  validate(std::vector<uint64_t>{42});
+TEST(RadixSortTest, SingleElement) {
+  validate(std::vector<uint32_t>{42});
 }
 
-TEST_F(StableRadixSortTest, TwoElements) {
-  validate(std::vector<uint64_t>{5, 3});
+TEST(RadixSortTest, AlreadySorted) {
+  validate(std::vector<uint32_t>{1, 2, 3, 4, 5});
 }
 
-TEST_F(StableRadixSortTest, AlreadySorted) {
-  validate(std::vector<uint64_t>{1, 2, 3, 4, 5});
+TEST(RadixSortTest, ReverseSorted) {
+  validate(std::vector<uint32_t>{5, 4, 3, 2, 1});
 }
 
-TEST_F(StableRadixSortTest, ReverseSorted) {
-  validate(std::vector<uint64_t>{5, 4, 3, 2, 1});
+TEST(RadixSortTest, AllEqual) {
+  validate(std::vector<uint32_t>(100, 42));
 }
 
-TEST_F(StableRadixSortTest, AllEqual) {
-  validate(std::vector<uint64_t>(100, 42));
+TEST(RadixSortTest, SmallArrayBelowThreshold) {
+  std::vector<uint32_t> v(50);
+  std::iota(v.begin(), v.end(), uint32_t(0));
+  std::reverse(v.begin(), v.end());
+  validate(v);
 }
 
 // ============================================================================
 // Unsigned integer types
 // ============================================================================
 
-TEST_F(StableRadixSortTest, Uint32Random) {
-  std::vector<uint32_t> v(1000);
-  std::uniform_int_distribution<uint32_t> dist;
-  for (auto& x : v) {
-    x = dist(rng);
-  }
-  validate(std::move(v));
-}
-
-TEST_F(StableRadixSortTest, Uint64Random) {
-  std::vector<uint64_t> v(1000);
-  std::uniform_int_distribution<uint64_t> dist;
-  for (auto& x : v) {
-    x = dist(rng);
-  }
-  validate(std::move(v));
-}
-
-TEST_F(StableRadixSortTest, Uint16Random) {
-  std::vector<uint16_t> v(1000);
-  std::uniform_int_distribution<uint16_t> dist;
-  for (auto& x : v) {
-    x = dist(rng);
-  }
-  validate(std::move(v));
-}
-
-TEST_F(StableRadixSortTest, Uint8Random) {
-  std::vector<uint8_t> v(1000);
-  std::uniform_int_distribution<int> dist(0, 255);
-  for (auto& x : v) {
-    x = static_cast<uint8_t>(dist(rng));
-  }
-  validate(std::move(v));
+TEST(RadixSortTest, UnsignedIntegers) {
+  // Note: uint8_t is excluded because kNumPasses==1 for 1-byte types
+  // See SingleByte test for 8-bit coverage
+  validate(generateRandom<uint16_t>(1000));
+  validate(generateRandom<uint32_t>(1000));
+  validate(generateRandom<uint64_t>(1000));
 }
 
 // ============================================================================
 // Signed integer types
 // ============================================================================
 
-TEST_F(StableRadixSortTest, Int32Random) {
-  std::vector<int32_t> v(1000);
-  std::uniform_int_distribution<int32_t> dist;
-  for (auto& x : v) {
-    x = dist(rng);
-  }
-  validate(std::move(v));
+TEST(RadixSortTest, SignedIntegers) {
+  // Note: int8_t is excluded because kNumPasses==1 for 1-byte types
+  // See SingleByte test for 8-bit coverage
+  validate(generateRandom<int16_t>(1000));
+  validate(generateRandom<int32_t>(1000));
+  validate(generateRandom<int64_t>(1000));
 }
 
-TEST_F(StableRadixSortTest, Int64Random) {
-  std::vector<int64_t> v(1000);
-  std::uniform_int_distribution<int64_t> dist;
-  for (auto& x : v) {
-    x = dist(rng);
-  }
-  validate(std::move(v));
-}
-
-TEST_F(StableRadixSortTest, Int32NegativeValues) {
-  validate(std::vector<int32_t>{-5, 3, -1, 0, -10, 7, 2, -3});
-}
-
-TEST_F(StableRadixSortTest, Int64Extremes) {
+TEST(RadixSortTest, SignedExtremes) {
+  validate(
+      std::vector<int32_t>{
+          std::numeric_limits<int32_t>::min(),
+          std::numeric_limits<int32_t>::max(),
+          0,
+          -1,
+          1,
+          std::numeric_limits<int32_t>::min() + 1,
+          std::numeric_limits<int32_t>::max() - 1,
+      });
   validate(
       std::vector<int64_t>{
           std::numeric_limits<int64_t>::min(),
@@ -208,31 +235,19 @@ TEST_F(StableRadixSortTest, Int64Extremes) {
           std::numeric_limits<int64_t>::min() + 1,
           std::numeric_limits<int64_t>::max() - 1,
       });
+  validate(std::vector<int32_t>{-5, 3, -1, 0, -10, 7, 2, -3});
 }
 
 // ============================================================================
-// Floating-point types
+// Floating point types
 // ============================================================================
 
-TEST_F(StableRadixSortTest, DoubleRandom) {
-  std::vector<double> v(1000);
-  std::uniform_real_distribution<double> dist(-1000.0, 1000.0);
-  for (auto& x : v) {
-    x = dist(rng);
-  }
-  validate(std::move(v));
+TEST(RadixSortTest, FloatRandom) {
+  validate(generateRandom<float>(1000));
+  validate(generateRandom<double>(1000));
 }
 
-TEST_F(StableRadixSortTest, FloatRandom) {
-  std::vector<float> v(1000);
-  std::uniform_real_distribution<float> dist(-1000.0f, 1000.0f);
-  for (auto& x : v) {
-    x = dist(rng);
-  }
-  validate(std::move(v));
-}
-
-TEST_F(StableRadixSortTest, DoubleSpecialValues) {
+TEST(RadixSortTest, FloatSpecialValues) {
   validate(
       std::vector<double>{
           std::numeric_limits<double>::infinity(),
@@ -243,55 +258,190 @@ TEST_F(StableRadixSortTest, DoubleSpecialValues) {
           -1.0,
           std::numeric_limits<double>::max(),
           std::numeric_limits<double>::lowest(),
-          std::numeric_limits<double>::denorm_min(), // smallest positive
-                                                     // subnormal
+          std::numeric_limits<double>::denorm_min(),
       });
-}
-
-TEST_F(StableRadixSortTest, DoubleNegativeNumbers) {
   validate(std::vector<double>{-0.5, -0.1, -0.9, -0.3, -0.7});
 }
 
-TEST_F(StableRadixSortTest, NegativeZeroPositiveZeroEquality) {
-  // Radix sort uses an augmented ordering where -0.0 sorts before +0.0
-  // (distinguished by signbit). Stability is preserved within each group.
+// ============================================================================
+// Descending order
+// ============================================================================
+
+TEST(RadixSortTest, Descending) {
+  {
+    auto v = generateRandom<uint64_t>(1000);
+    validateDescending(v);
+  }
+  {
+    auto v = generateRandom<int64_t>(1000);
+    validateDescending(v);
+  }
+  {
+    auto v = generateRandom<double>(1000);
+    validateDescending(v);
+  }
+}
+
+// ============================================================================
+// Key extractor
+// ============================================================================
+
+TEST(RadixSortTest, KeyExtractor) {
+  // Integer key
+  struct Record {
+    uint64_t id{};
+    std::string name;
+    bool operator==(const Record&) const = default;
+  };
+  {
+    std::vector<Record> records = {
+        {5, "five"},
+        {2, "two"},
+        {8, "eight"},
+        {1, "one"},
+        {3, "three"},
+    };
+    auto expected = records;
+    std::stable_sort(
+        expected.begin(), expected.end(), [](const Record& a, const Record& b) {
+          return a.id < b.id;
+        });
+    stable_radix_sort(records.begin(), records.end(), [](const Record& r) {
+      return r.id;
+    });
+    ASSERT_EQ(records.size(), expected.size());
+    for (size_t i = 0; i < records.size(); ++i) {
+      SCOPED_TRACE(std::format("index={}", i));
+      EXPECT_EQ(records[i], expected[i]);
+    }
+  }
+
+  // Floating-point key
+  {
+    std::vector<Item> items(100);
+    std::uniform_real_distribution<double> dist(-100.0, 100.0);
+    for (int i = 0; i < 100; ++i) {
+      items[i].score = dist(rng);
+      items[i].originalIndex = i;
+    }
+    validate(items, [](const Item& item) { return item.score; });
+  }
+}
+
+// ============================================================================
+// Stability
+// ============================================================================
+
+TEST(RadixSortTest, Stability) {
+  {
+    std::vector<Item> items;
+    for (int i = 0; i < 100; ++i) {
+      items.push_back({static_cast<double>(i / 10), i});
+    }
+    std::shuffle(items.begin(), items.end(), rng);
+    validate(items, [](const Item& item) { return item.score; });
+  }
+  {
+    std::vector<Item> items;
+    for (int i = 0; i < 30; ++i) {
+      items.push_back({static_cast<double>(i % 3), i});
+    }
+    validate(items, [](const Item& item) { return item.score; });
+  }
+}
+
+// ============================================================================
+// Large input
+// ============================================================================
+
+TEST(RadixSortTest, LargeInput) {
+  {
+    auto v = generateRandom<uint64_t>(100000);
+    validate(v);
+  }
+  {
+    auto v = generateRandom<double>(100000);
+    validate(v);
+  }
+}
+
+// ============================================================================
+// Small input (insertion sort fallback)
+// ============================================================================
+
+TEST(RadixSortTest, SmallInput) {
+  validate(std::vector<uint64_t>{9, 7, 5, 3, 1, 8, 6, 4, 2, 0});
+  validate(std::vector<int64_t>{-5, -3, -1, 0, 2, 4, -4, -2, 1, 3});
+  validate(std::vector<double>{-0.5, 0.3, -0.1, 0.9, -0.7});
+}
+
+// ============================================================================
+// 16-bit chunks (RadixBitsPerPass::Bits16)
+// ============================================================================
+
+TEST(RadixSortTest, ChunkBits16) {
+  constexpr auto kChunk16Opts = [] {
+    return RadixSortOptions{
+        .SortStrategy = RadixSortStrategy::Lsd,
+        .ExecutionPolicy = RadixExecutionPolicy::Seq,
+        .SortOrder = RadixSortOrder::Ascending,
+        .BitsPerPass = RadixBitsPerPass::Bits16};
+  }();
+
+  // uint32 with 16-bit chunks => 2 passes
+  {
+    auto v = generateRandom<uint32_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kChunk16Opts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // int32 with 16-bit chunks
+  {
+    auto v = generateRandom<int32_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kChunk16Opts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+}
+
+// ============================================================================
+// 64-bit bucket counters (BucketCounterType::UInt64)
+// ============================================================================
+
+TEST(RadixSortTest, CounterType64) {
+  constexpr auto kCounter64Opts = [] {
+    return RadixSortOptions{
+        .SortStrategy = RadixSortStrategy::Lsd,
+        .ExecutionPolicy = RadixExecutionPolicy::Seq,
+        .SortOrder = RadixSortOrder::Ascending,
+        .BitsPerPass = RadixBitsPerPass::Bits8,
+        .HistogramStorageType = RadixHistogramStorageType::UInt64};
+  }();
+
+  auto v = generateRandom<uint64_t>(10000);
+  auto expected = v;
+  std::stable_sort(expected.begin(), expected.end());
+  stable_radix_sort<kCounter64Opts>(v.begin(), v.end());
+  EXPECT_EQ(v, expected);
+}
+
+// ============================================================================
+// Negative-zero / Positive-zero ordering
+// ============================================================================
+
+TEST(RadixSortTest, NegativeZero) {
   std::vector<Item> items = {
       {-0.0, 0},
       {+0.0, 1},
       {-0.0, 2},
       {+0.0, 3},
   };
-
   stable_radix_sort(items.begin(), items.end(), [](const Item& item) {
     return item.score;
   });
-
-  // -0.0 values come first (stable among themselves), then +0.0 values
-  EXPECT_EQ(items[0].originalIndex, 0);
-  EXPECT_EQ(items[1].originalIndex, 2);
-  EXPECT_EQ(items[2].originalIndex, 1);
-  EXPECT_EQ(items[3].originalIndex, 3);
-}
-
-TEST_F(StableRadixSortTest, NegativeZeroPositiveZeroEqualityFloat) {
-  // Same test for float type
-  struct FloatItem {
-    float score;
-    int originalIndex;
-  };
-
-  std::vector<FloatItem> items = {
-      {-0.0f, 0},
-      {+0.0f, 1},
-      {-0.0f, 2},
-      {+0.0f, 3},
-  };
-
-  stable_radix_sort(items.begin(), items.end(), [](const FloatItem& item) {
-    return item.score;
-  });
-
-  // -0.0f values come first (stable among themselves), then +0.0f values
   EXPECT_EQ(items[0].originalIndex, 0);
   EXPECT_EQ(items[1].originalIndex, 2);
   EXPECT_EQ(items[2].originalIndex, 1);
@@ -299,203 +449,1510 @@ TEST_F(StableRadixSortTest, NegativeZeroPositiveZeroEqualityFloat) {
 }
 
 // ============================================================================
-// Descending order tests
+// Bool type
 // ============================================================================
 
-TEST_F(StableRadixSortTest, Uint64Descending) {
-  std::vector<uint64_t> v(1000);
-  std::uniform_int_distribution<uint64_t> dist;
-  for (auto& x : v) {
-    x = dist(rng);
+TEST(RadixSortTest, BoolType) {
+  {
+    std::vector<uint8_t> v = {1, 0, 1, 0, 1, 0, 0, 1};
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
-  validateDescending(std::move(v));
-}
-
-TEST_F(StableRadixSortTest, Int64Descending) {
-  std::vector<int64_t> v(1000);
-  std::uniform_int_distribution<int64_t> dist;
-  for (auto& x : v) {
-    x = dist(rng);
+  {
+    std::vector<uint8_t> v(60);
+    for (auto& x : v) {
+      x = static_cast<uint8_t>(rng() % 2);
+    }
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
-  validateDescending(std::move(v));
 }
 
-TEST_F(StableRadixSortTest, DoubleDescending) {
-  std::vector<double> v(1000);
-  std::uniform_real_distribution<double> dist(-1000.0, 1000.0);
-  for (auto& x : v) {
-    x = dist(rng);
+// ============================================================================
+// NaN handling
+// ============================================================================
+
+TEST(RadixSortTest, NaNsFirst) {
+  constexpr auto kNaNsFirst = [] {
+    auto opts = RadixSortOptions{};
+    opts.NaNsPosHandling = RadixNaNsPosHandling::AtFirst;
+    opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+    return opts;
+  }();
+
+  {
+    std::vector<double> v = {
+        NAN,
+        3.0,
+        NAN,
+        1.0,
+        NAN,
+        2.0,
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(),
+    };
+    stable_radix_sort<kNaNsFirst>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(v[0]));
+    EXPECT_TRUE(std::isnan(v[1]));
+    EXPECT_TRUE(std::isnan(v[2]));
+    for (size_t i = 3; i < v.size(); ++i) {
+      EXPECT_TRUE(!std::isnan(v[i]));
+      if (i > 3) {
+        EXPECT_LE(v[i - 1], v[i]);
+      }
+    }
   }
-  validateDescending(std::move(v));
+  // float with NaNsFirst
+  {
+    std::vector<float> v = {NAN, 1.0f, NAN, 2.0f, -1.0f};
+    stable_radix_sort<kNaNsFirst>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(v[0]));
+    EXPECT_TRUE(std::isnan(v[1]));
+  }
+}
+
+TEST(RadixSortTest, NaNsLast) {
+  constexpr auto kNaNsLast = [] {
+    auto opts = RadixSortOptions{};
+    opts.NaNsPosHandling = RadixNaNsPosHandling::AtLast;
+    opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+    return opts;
+  }();
+
+  {
+    std::vector<double> v = {
+        NAN,
+        3.0,
+        NAN,
+        1.0,
+        2.0,
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(),
+    };
+    stable_radix_sort<kNaNsLast>(v.begin(), v.end());
+    size_t j = 0;
+    for (; j < v.size(); ++j) {
+      if (std::isnan(v[j])) {
+        break;
+      }
+    }
+    for (; j < v.size(); ++j) {
+      EXPECT_TRUE(std::isnan(v[j]));
+    }
+  }
+}
+
+TEST(RadixSortTest, NaNsDescending) {
+  constexpr auto kNaNsFirstDesc = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortOrder = RadixSortOrder::Descending;
+    opts.NaNsPosHandling = RadixNaNsPosHandling::AtFirst;
+    opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+    return opts;
+  }();
+  constexpr auto kNaNsLastDesc = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortOrder = RadixSortOrder::Descending;
+    opts.NaNsPosHandling = RadixNaNsPosHandling::AtLast;
+    opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+    return opts;
+  }();
+
+  // NaNsFirst descending: NaN mapped to key=0, descending ~0=max => NaN last
+  {
+    std::vector<double> v = {NAN, 1.0, NAN, 2.0, 3.0};
+    stable_radix_sort<kNaNsFirstDesc>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(v[3]));
+    EXPECT_TRUE(std::isnan(v[4]));
+  }
+  // NaNsLast descending: NaN mapped to key=max, descending ~max=0 => NaN first
+  {
+    std::vector<double> v = {1.0, NAN, 2.0, NAN, 3.0};
+    stable_radix_sort<kNaNsLastDesc>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(v[0]));
+    EXPECT_TRUE(std::isnan(v[1]));
+  }
 }
 
 // ============================================================================
-// Key extractor tests
+// Insertion threshold boundary (63, 64, 65)
 // ============================================================================
 
-TEST_F(StableRadixSortTest, KeyExtractorDouble) {
-  std::vector<Item> items(100);
-  std::uniform_real_distribution<double> dist(-100.0, 100.0);
-  for (int i = 0; i < 100; ++i) {
-    items[i].score = dist(rng);
-    items[i].originalIndex = i;
+TEST(RadixSortTest, InsertionThreshold) {
+  for (auto n : {63, 64, 65}) {
+    std::vector<uint32_t> v(n);
+    std::iota(v.begin(), v.end(), uint32_t(0));
+    std::shuffle(v.begin(), v.end(), rng);
+    SCOPED_TRACE(std::format("n={}", n));
+    validate(v);
+  }
+  for (auto n : {63, 64, 65}) {
+    std::vector<int64_t> v(n);
+    std::iota(v.begin(), v.end(), int64_t(-32));
+    std::shuffle(v.begin(), v.end(), rng);
+    SCOPED_TRACE(std::format("n={}", n));
+    validate(v);
+  }
+  for (auto n : {63, 64}) {
+    std::vector<double> v(n);
+    for (auto& x : v) {
+      x = static_cast<double>(rng() % 1000) / 10.0;
+    }
+    SCOPED_TRACE(std::format("n={}", n));
+    validate(v);
+  }
+}
+
+// ============================================================================
+// All elements map to the same bucket
+// ============================================================================
+
+TEST(RadixSortTest, AllSameBucket) {
+  {
+    std::vector<uint64_t> v(1000, 0);
+    validate(v);
+    for (auto x : v) {
+      EXPECT_EQ(x, uint64_t(0));
+    }
+  }
+  {
+    std::vector<uint32_t> v(500, 42);
+    validate(v);
+    for (auto x : v) {
+      EXPECT_EQ(x, uint32_t(42));
+    }
+  }
+  {
+    std::vector<int64_t> v(300, -1);
+    validate(v);
+    for (auto x : v) {
+      EXPECT_EQ(x, int64_t(-1));
+    }
+  }
+  {
+    std::vector<double> v(200, 3.14);
+    validate(v);
+    for (auto x : v) {
+      EXPECT_EQ(x, 3.14);
+    }
+  }
+}
+
+// ============================================================================
+// Early exit when input is already sorted
+// ============================================================================
+
+TEST(RadixSortTest, EarlyExitSorted) {
+  {
+    std::vector<uint64_t> v(10000);
+    std::iota(v.begin(), v.end(), uint64_t(0));
+    validate(v);
+  }
+  {
+    std::vector<int64_t> v(10000);
+    std::iota(v.begin(), v.end(), int64_t(-5000));
+    validate(v);
+  }
+  {
+    std::vector<double> v(10000);
+    for (size_t i = 0; i < 10000; ++i) {
+      v[i] = static_cast<double>(i);
+    }
+    validate(v);
+  }
+  { // descending already sorted
+    std::vector<uint64_t> v(10000);
+    for (size_t i = 0; i < 10000; ++i) {
+      v[i] = 9999 - i;
+    }
+    validateDescending(v);
+  }
+}
+
+// ============================================================================
+// Custom projection
+// ============================================================================
+
+TEST(RadixSortTest, CustomProjection) {
+  // Sort by modulo
+  {
+    std::vector<int32_t> v(200);
+    for (auto& x : v) {
+      x = static_cast<int32_t>(rng() % 1000);
+    }
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), [](int32_t a, int32_t b) {
+          return (a % 10) < (b % 10);
+        });
+    stable_radix_sort(v.begin(), v.end(), [](int32_t x) { return x % 10; });
+    EXPECT_EQ(v, expected);
+  }
+  // Sort by negation (signed int key)
+  {
+    std::vector<int32_t> v(200);
+    for (auto& x : v) {
+      x = static_cast<int32_t>(rng() % 1000 - 500);
+    }
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), [](int32_t a, int32_t b) {
+          return (-a) < (-b);
+        });
+    stable_radix_sort(v.begin(), v.end(), [](int32_t x) { return -x; });
+    EXPECT_EQ(v, expected);
+  }
+  // Sort by fractional part (uint64_t key via bit_cast)
+  {
+    auto v = generateRandom<double>(200);
+    stable_radix_sort(v.begin(), v.end(), [](double x) -> uint64_t {
+      return std::bit_cast<uint64_t>(x - std::floor(x));
+    });
+    EXPECT_TRUE(std::is_sorted(v.begin(), v.end(), [](double a, double b) {
+      return std::bit_cast<uint64_t>(a - std::floor(a)) <
+          std::bit_cast<uint64_t>(b - std::floor(b));
+    }));
+  }
+  // Struct with int projection
+  {
+    struct Person {
+      int age;
+      int id;
+      bool operator==(const Person&) const = default;
+    };
+    std::vector<Person> people(100);
+    for (int i = 0; i < 100; ++i) {
+      people[i] = Person{static_cast<int>(rng() % 80), i};
+    }
+    auto expected = people;
+    std::stable_sort(
+        expected.begin(), expected.end(), [](const Person& a, const Person& b) {
+          return a.age < b.age;
+        });
+    stable_radix_sort(people.begin(), people.end(), [](const Person& p) {
+      return p.age;
+    });
+    EXPECT_EQ(people, expected);
+  }
+  // Struct with double projection
+  {
+    struct Employee {
+      double salary;
+      int id;
+      bool operator==(const Employee&) const = default;
+    };
+    std::vector<Employee> emps(100);
+    for (int i = 0; i < 100; ++i) {
+      emps[i] = Employee{static_cast<double>(rng() % 100000) / 100.0, i};
+    }
+    stable_radix_sort(emps.begin(), emps.end(), [](const Employee& e) {
+      return e.salary;
+    });
+    EXPECT_TRUE(
+        std::is_sorted(
+            emps.begin(), emps.end(), [](const Employee& a, const Employee& b) {
+              return a.salary < b.salary;
+            }));
+  }
+}
+
+// ============================================================================
+// Reverse iterator
+// ============================================================================
+
+TEST(RadixSortTest, ReverseIterator) {
+  // reverse + ascending = forward descending
+  {
+    auto v = generateRandom<uint64_t>(200);
+    stable_radix_sort(v.rbegin(), v.rend());
+    for (size_t i = 1; i < v.size(); ++i) {
+      EXPECT_GE(v[i - 1], v[i]) << std::format("index={}", i);
+    }
+  }
+  // reverse + descending = forward ascending
+  {
+    auto v = generateRandom<uint64_t>(200);
+    stable_radix_sort<kDescOpts>(v.rbegin(), v.rend());
+    for (size_t i = 1; i < v.size(); ++i) {
+      EXPECT_LE(v[i - 1], v[i]) << std::format("index={}", i);
+    }
+  }
+  // double + reverse iterator
+  {
+    auto v = generateRandom<double>(200);
+    auto expected = v;
+    std::stable_sort(expected.rbegin(), expected.rend(), augmentedLess<double>);
+    stable_radix_sort(v.rbegin(), v.rend());
+    EXPECT_EQ(v, expected);
+  }
+}
+
+// ============================================================================
+// Descending + UInt64 counter
+// ============================================================================
+
+TEST(RadixSortTest, DescendingCounter64) {
+  constexpr auto kDescC64 = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortOrder = RadixSortOrder::Descending;
+    opts.HistogramStorageType = RadixHistogramStorageType::UInt64;
+    return opts;
+  }();
+
+  auto v = generateRandom<uint64_t>(10000);
+  auto expected = v;
+  std::stable_sort(expected.begin(), expected.end(), std::greater<uint64_t>{});
+  stable_radix_sort<kDescC64>(v.begin(), v.end());
+  EXPECT_EQ(v, expected);
+}
+
+// ============================================================================
+// Descending + 16-bit chunks
+// ============================================================================
+
+TEST(RadixSortTest, DescendingChunk16) {
+  constexpr auto kDescC16 = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortOrder = RadixSortOrder::Descending;
+    opts.BitsPerPass = RadixBitsPerPass::Bits16;
+    return opts;
+  }();
+
+  {
+    auto v = generateRandom<uint32_t>(1000);
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), std::greater<uint32_t>{});
+    stable_radix_sort<kDescC16>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+  {
+    auto v = generateRandom<double>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end(), std::greater<double>{});
+    stable_radix_sort<kDescC16>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+}
+
+// ============================================================================
+// Single-byte types (counting sort path)
+// ============================================================================
+
+TEST(RadixSortTest, SingleByte) {
+  // uint8_t: all 256 values shuffled
+  {
+    std::vector<uint8_t> v(256);
+    std::iota(v.begin(), v.end(), uint8_t(0));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
 
-  validate(std::move(items), [](const Item& item) { return item.score; });
-}
-
-TEST_F(StableRadixSortTest, KeyExtractorDescending) {
-  std::vector<Item> items(100);
-  std::uniform_real_distribution<double> dist(-100.0, 100.0);
-  for (int i = 0; i < 100; ++i) {
-    items[i].score = dist(rng);
-    items[i].originalIndex = i;
+  // int8_t: all 256 values shuffled
+  {
+    std::vector<int8_t> v(256);
+    std::iota(v.begin(), v.end(), int8_t(-128));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end(), augmentedLess<int8_t>);
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
 
-  validateDescending(std::move(items), [](const Item& item) {
-    return item.score;
-  });
-}
-
-TEST_F(StableRadixSortTest, KeyExtractorInteger) {
-  struct Record {
-    uint64_t id{};
-    std::string name;
-
-    bool operator==(const Record&) const = default;
-  };
-
-  std::vector<Record> records = {
-      {5, "five"},
-      {2, "two"},
-      {8, "eight"},
-      {1, "one"},
-      {3, "three"},
-  };
-
-  validate(std::move(records), [](const Record& r) { return r.id; });
-}
-
-// ============================================================================
-// Stability tests
-// ============================================================================
-
-TEST_F(StableRadixSortTest, StabilityPreserved) {
-  // Create items with duplicate scores
-  std::vector<Item> items;
-  items.reserve(100);
-  for (int i = 0; i < 100; ++i) {
-    items.push_back({static_cast<double>(i / 10), i}); // 10 items per score
+  // uint8_t: descending by augmented ordering
+  {
+    std::vector<uint8_t> v(50);
+    std::iota(v.begin(), v.end(), uint8_t(0));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), augmentedGreater<uint8_t>);
+    stable_radix_sort<kDescOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
 
-  // Shuffle to randomize order
-  std::shuffle(items.begin(), items.end(), rng);
-
-  validate(std::move(items), [](const Item& item) { return item.score; });
-}
-
-TEST_F(StableRadixSortTest, StabilityWithMultipleGroups) {
-  // Create items with 3 distinct score values
-  std::vector<Item> items;
-  for (int i = 0; i < 30; ++i) {
-    double score = static_cast<double>(i % 3); // 0.0, 1.0, or 2.0
-    items.push_back({score, i});
+  // uint8_t key extractor
+  {
+    std::vector<uint8_t> keys(256);
+    std::iota(keys.begin(), keys.end(), uint8_t(0));
+    std::shuffle(keys.begin(), keys.end(), rng);
+    struct Tagged {
+      uint8_t key;
+      int idx;
+      bool operator==(const Tagged&) const = default;
+    };
+    std::vector<Tagged> items;
+    for (int i = 0; i < 256; ++i) {
+      items.push_back({keys[i], i});
+    }
+    auto expected = items;
+    std::stable_sort(
+        expected.begin(), expected.end(), [](const Tagged& a, const Tagged& b) {
+          return a.key < b.key;
+        });
+    stable_radix_sort(items.begin(), items.end(), [](const Tagged& x) {
+      return x.key;
+    });
+    ASSERT_EQ(items.size(), expected.size());
+    for (size_t i = 0; i < items.size(); ++i) {
+      SCOPED_TRACE(std::format("index={}", i));
+      EXPECT_EQ(items[i], expected[i]);
+    }
   }
 
-  validate(std::move(items), [](const Item& item) { return item.score; });
-}
-
-// ============================================================================
-// Comparison with std::stable_sort
-// ============================================================================
-
-TEST_F(StableRadixSortTest, MatchesStableSort) {
-  std::vector<double> v(500);
-  std::uniform_real_distribution<double> dist(-1000.0, 1000.0);
-  for (auto& x : v) {
-    x = dist(rng);
+  // int8_t with mixed positive and negative clusters
+  {
+    std::vector<int8_t> v = {-128, -64, -1, 0, 1, 63, 127, -127, -2, 2};
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end(), augmentedLess<int8_t>);
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
-  validate(std::move(v));
 }
 
-TEST_F(StableRadixSortTest, MatchesStableSortDescending) {
-  std::vector<double> v(500);
-  std::uniform_real_distribution<double> dist(-1000.0, 1000.0);
-  for (auto& x : v) {
-    x = dist(rng);
+// ============================================================================
+// char / signed char / unsigned char (standalone 1-byte types)
+// ============================================================================
+
+TEST(RadixSortTest, CharTypes) {
+  // unsigned char full range 0..255
+  {
+    std::vector<unsigned char> v(256);
+    std::iota(v.begin(), v.end(), static_cast<unsigned char>(0));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
-  validateDescending(std::move(v));
-}
 
-// ============================================================================
-// Large input tests
-// ============================================================================
-
-TEST_F(StableRadixSortTest, LargeInput) {
-  constexpr size_t kSize = 100000;
-  std::vector<uint64_t> v(kSize);
-  std::uniform_int_distribution<uint64_t> dist;
-  for (auto& x : v) {
-    x = dist(rng);
+  // signed char full range -128..127
+  {
+    std::vector<signed char> v(256);
+    std::iota(v.begin(), v.end(), static_cast<signed char>(-128));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
-  validate(std::move(v));
-}
 
-TEST_F(StableRadixSortTest, LargeInputDouble) {
-  constexpr size_t kSize = 100000;
-  std::vector<double> v(kSize);
-  std::uniform_real_distribution<double> dist(-1e9, 1e9);
-  for (auto& x : v) {
-    x = dist(rng);
+  // char all equal
+  {
+    std::vector<char> v(100, static_cast<char>(42));
+    auto expected = v;
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
   }
-  validate(std::move(v));
+
+  // char threshold boundary: 63, 64, 65
+  for (auto n : {63, 64, 65}) {
+    std::vector<char> v(n);
+    std::iota(v.begin(), v.end(), static_cast<char>(0));
+    std::shuffle(v.begin(), v.end(), rng);
+    SCOPED_TRACE(std::format("char threshold n={}", n));
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_TRUE(std::is_sorted(v.begin(), v.end()));
+  }
+
+  // char already sorted
+  {
+    std::vector<char> v(100);
+    std::iota(v.begin(), v.end(), static_cast<char>(0));
+    auto expected = v;
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // char descending
+  {
+    std::vector<char> v(100);
+    std::iota(v.begin(), v.end(), static_cast<char>(0));
+    std::reverse(v.begin(), v.end());
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end(), std::greater<char>{});
+    stable_radix_sort<kDescOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // unsigned char with only high values (128..255)
+  {
+    std::vector<unsigned char> v(128);
+    std::iota(v.begin(), v.end(), static_cast<unsigned char>(128));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // signed char all negative (-128..-1)
+  {
+    std::vector<signed char> v(128);
+    std::iota(v.begin(), v.end(), static_cast<signed char>(-128));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // char custom projection via unsigned return type
+  {
+    std::vector<char> v(200);
+    std::iota(v.begin(), v.end(), static_cast<char>(0));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto keyed = v;
+    std::stable_sort(keyed.begin(), keyed.end(), [](char a, char b) {
+      return static_cast<unsigned char>(a % 50) <
+          static_cast<unsigned char>(b % 50);
+    });
+    stable_radix_sort(v.begin(), v.end(), [](char x) {
+      return static_cast<unsigned char>(x % 50);
+    });
+    EXPECT_EQ(v, keyed);
+  }
 }
 
 // ============================================================================
-// Small input (fallback to std::stable_sort)
+// wchar_t / char16_t / char32_t
 // ============================================================================
 
-TEST_F(StableRadixSortTest, SmallInputFallback) {
-  validate(std::vector<uint64_t>{9, 7, 5, 3, 1, 8, 6, 4, 2, 0});
+TEST(RadixSortTest, WideCharTypes) {
+  // char16_t random
+  {
+    std::vector<char16_t> v(1000);
+    std::uniform_int_distribution<int> dist(0, 65535);
+    for (auto& x : v) {
+      x = static_cast<char16_t>(dist(rng));
+    }
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // char32_t random
+  {
+    std::vector<char32_t> v(1000);
+    std::uniform_int_distribution<uint32_t> dist;
+    for (auto& x : v) {
+      x = static_cast<char32_t>(dist(rng));
+    }
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // char32_t large values concentrated in high byte
+  {
+    std::vector<char32_t> v(500);
+    std::uniform_int_distribution<uint32_t> dist(0xFF000000, 0xFFFFFFFF);
+    for (auto& x : v) {
+      x = static_cast<char32_t>(dist(rng));
+    }
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // char32_t small values (only in low 2 bytes)
+  {
+    std::vector<char32_t> v(500);
+    std::uniform_int_distribution<uint32_t> dist(0, 0xFFFF);
+    for (auto& x : v) {
+      x = static_cast<char32_t>(dist(rng));
+    }
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // wchar_t (equivalent to char16_t on MSVC) all equal
+  {
+    std::vector<wchar_t> v(200, static_cast<wchar_t>(0x42));
+    stable_radix_sort(v.begin(), v.end());
+    for (auto x : v) {
+      EXPECT_EQ(x, static_cast<wchar_t>(0x42));
+    }
+  }
+
+  // char16_t threshold boundary 63/64/65
+  for (auto n : {63, 64, 65}) {
+    std::vector<char16_t> v(n);
+    std::iota(v.begin(), v.end(), static_cast<char16_t>(0));
+    std::shuffle(v.begin(), v.end(), rng);
+    SCOPED_TRACE(std::format("char16_t threshold n={}", n));
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_TRUE(std::is_sorted(v.begin(), v.end()));
+  }
+
+  // char32_t descending
+  {
+    auto v = generateRandom<char32_t>(500);
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), std::greater<char32_t>{});
+    constexpr auto kDescChar32 = [] {
+      auto opts = RadixSortOptions{};
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    stable_radix_sort<kDescChar32>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
 }
 
 // ============================================================================
-// Key transformation helpers
+// long double
 // ============================================================================
 
-TEST_F(StableRadixSortTest, FloatKeyCorrectness) {
-  using namespace stable_radix_sort_keys;
+TEST(RadixSortTest, LongDouble) {
+  // long double random (on MSVC, long double == double)
+  {
+    std::vector<long double> v(500);
+    std::uniform_real_distribution<long double> dist(-1000.0, 1000.0);
+    for (auto& x : v) {
+      x = dist(rng);
+    }
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), augmentedLess<long double>);
+    stable_radix_sort(v.begin(), v.end());
+    ASSERT_EQ(v.size(), expected.size());
+    for (size_t i = 0; i < v.size(); ++i) {
+      SCOPED_TRACE(std::format("index={}", i));
+      EXPECT_EQ(v[i], expected[i]);
+    }
+  }
 
-  FloatKey<double, false> asc;
-  FloatKey<double, true> desc;
+  // long double special values
+  {
+    std::vector<long double> v = {
+        std::numeric_limits<long double>::infinity(),
+        -std::numeric_limits<long double>::infinity(),
+        0.0L,
+        -0.0L,
+        1.0L,
+        -1.0L,
+        std::numeric_limits<long double>::max(),
+        std::numeric_limits<long double>::lowest(),
+        std::numeric_limits<long double>::denorm_min(),
+    };
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), augmentedLess<long double>);
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
 
-  // Verify ordering is preserved
-  EXPECT_LT(asc(-1.0), asc(0.0));
-  EXPECT_LT(asc(0.0), asc(1.0));
-  EXPECT_LT(asc(-std::numeric_limits<double>::infinity()), asc(-1e308));
-  EXPECT_LT(asc(1e308), asc(std::numeric_limits<double>::infinity()));
+  // long double NaNsFirst
+  {
+    constexpr auto kNaNsFirstLD = [] {
+      auto opts = RadixSortOptions{};
+      opts.NaNsPosHandling = RadixNaNsPosHandling::AtFirst;
+      opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+      return opts;
+    }();
+    std::vector<long double> v = {
+        static_cast<long double>(NAN),
+        3.0L,
+        static_cast<long double>(NAN),
+        1.0L,
+        static_cast<long double>(NAN),
+        2.0L,
+        std::numeric_limits<long double>::infinity(),
+        -std::numeric_limits<long double>::infinity(),
+    };
+    stable_radix_sort<kNaNsFirstLD>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(static_cast<double>(v[0])));
+    EXPECT_TRUE(std::isnan(static_cast<double>(v[1])));
+    EXPECT_TRUE(std::isnan(static_cast<double>(v[2])));
+  }
 
-  // Descending should invert
-  EXPECT_GT(desc(-1.0), desc(0.0));
-  EXPECT_GT(desc(0.0), desc(1.0));
+  // long double descending
+  {
+    std::vector<long double> v(200);
+    std::uniform_real_distribution<long double> dist(-500.0, 500.0);
+    for (auto& x : v) {
+      x = dist(rng);
+    }
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), augmentedGreater<long double>);
+    constexpr auto kDescLD = [] {
+      auto opts = RadixSortOptions{};
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    stable_radix_sort<kDescLD>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // long double tiny input
+  {
+    std::vector<long double> v = {3.14L, -2.71L, 1.41L, -1.73L};
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), augmentedLess<long double>);
+    stable_radix_sort(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
 }
 
-TEST_F(StableRadixSortTest, IntegralKeyCorrectness) {
-  using namespace stable_radix_sort_keys;
+// ============================================================================
+// bool (native type)
+// ============================================================================
 
-  IntegralKey<int64_t, false> asc;
-  IntegralKey<int64_t, true> desc;
+TEST(RadixSortTest, BoolNative) {
+  // bool array shuffled
+  {
+    bool arr[100];
+    for (int i = 0; i < 100; ++i) {
+      arr[i] = static_cast<bool>(rng() % 2);
+    }
+    bool expected[100];
+    std::copy(std::begin(arr), std::end(arr), std::begin(expected));
+    std::stable_sort(std::begin(expected), std::end(expected));
+    stable_radix_sort(std::begin(arr), std::end(arr));
+    for (int i = 0; i < 100; ++i) {
+      SCOPED_TRACE(std::format("index={}", i));
+      EXPECT_EQ(arr[i], expected[i]);
+    }
+  }
 
-  // Verify ordering is preserved
-  EXPECT_LT(asc(std::numeric_limits<int64_t>::min()), asc(-1));
-  EXPECT_LT(asc(-1), asc(0));
-  EXPECT_LT(asc(0), asc(1));
-  EXPECT_LT(asc(1), asc(std::numeric_limits<int64_t>::max()));
+  // bool all false
+  {
+    bool arr[50]{};
+    bool expected[50]{};
+    stable_radix_sort(std::begin(arr), std::end(arr));
+    for (int i = 0; i < 50; ++i) {
+      EXPECT_FALSE(arr[i]);
+    }
+  }
 
-  // Descending should invert
-  EXPECT_GT(desc(-1), desc(0));
-  EXPECT_GT(desc(0), desc(1));
+  // bool all true
+  {
+    bool arr[50];
+    std::fill(std::begin(arr), std::end(arr), true);
+    stable_radix_sort(std::begin(arr), std::end(arr));
+    for (int i = 0; i < 50; ++i) {
+      EXPECT_TRUE(arr[i]);
+    }
+  }
+
+  // bool single element
+  {
+    bool arr1[] = {true};
+    stable_radix_sort(std::begin(arr1), std::end(arr1));
+    EXPECT_TRUE(arr1[0]);
+    bool arr2[] = {false};
+    stable_radix_sort(std::begin(arr2), std::end(arr2));
+    EXPECT_FALSE(arr2[0]);
+  }
+
+  // bool descending
+  {
+    bool arr[100];
+    for (int i = 0; i < 100; ++i) {
+      arr[i] = static_cast<bool>(rng() % 2);
+    }
+    bool expected[100];
+    std::copy(std::begin(arr), std::end(arr), std::begin(expected));
+    std::stable_sort(
+        std::begin(expected), std::end(expected), std::greater<bool>{});
+    constexpr auto kDescBool = [] {
+      auto opts = RadixSortOptions{};
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    stable_radix_sort<kDescBool>(std::begin(arr), std::end(arr));
+    for (int i = 0; i < 100; ++i) {
+      SCOPED_TRACE(std::format("index={}", i));
+      EXPECT_EQ(arr[i], expected[i]);
+    }
+  }
+
+  // bool already sorted
+  {
+    bool arr[] = {false, false, false, true, true, true};
+    bool expected[]{false, false, false, true, true, true};
+    stable_radix_sort(std::begin(arr), std::end(arr));
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_EQ(arr[i], expected[i]);
+    }
+  }
+
+  // bool alternating (pattern stability)
+  {
+    bool arr[60];
+    for (int i = 0; i < 60; ++i) {
+      arr[i] = (i % 2 == 0);
+    }
+    std::shuffle(std::begin(arr), std::end(arr), rng);
+    bool expected[60];
+    std::copy(std::begin(arr), std::end(arr), std::begin(expected));
+    std::stable_sort(std::begin(expected), std::end(expected));
+    stable_radix_sort(std::begin(arr), std::end(arr));
+    for (int i = 0; i < 60; ++i) {
+      EXPECT_EQ(arr[i], expected[i]);
+    }
+  }
 }
 
-} // namespace
-} // namespace folly
+// ============================================================================
+// RadixExecutionPolicy::Par (OpenMP parallel LSD)
+// ============================================================================
+
+#ifdef _OPENMP
+TEST(RadixSortTest, ParLsd) {
+  constexpr auto kParOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.ExecutionPolicy = RadixExecutionPolicy::Par;
+    return opts;
+  }();
+
+  // uint64_t random parallel
+  {
+    auto v = generateRandom<uint64_t>(10000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // int64 random parallel (with negatives)
+  {
+    auto v = generateRandom<int64_t>(10000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // double random parallel
+  {
+    auto v = generateRandom<double>(10000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // all equal (nonEmptyCount <= 1 for all passes)
+  {
+    auto v = std::vector<uint64_t>(10000, 42);
+    stable_radix_sort<kParOpts>(v.begin(), v.end());
+    for (auto x : v) {
+      EXPECT_EQ(x, uint64_t(42));
+    }
+  }
+
+  // already sorted (early exit in parallel)
+  {
+    auto v = std::vector<uint64_t>(10000);
+    std::iota(v.begin(), v.end(), uint64_t(0));
+    auto expected = v;
+    stable_radix_sort<kParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // non-power-of-2 size (isChunksSorted default path)
+  {
+    auto v = generateRandom<uint64_t>(10001);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // small input (below insertion threshold)
+  {
+    auto v = generateRandom<uint64_t>(50);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Par descending
+  {
+    constexpr auto kParDescOpts = [] {
+      auto opts = RadixSortOptions{};
+      opts.ExecutionPolicy = RadixExecutionPolicy::Par;
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    auto v = generateRandom<uint64_t>(5000);
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), std::greater<uint64_t>{});
+    stable_radix_sort<kParDescOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Par with float + NaN
+  {
+    constexpr auto kParNaNsFirst = [] {
+      auto opts = RadixSortOptions{};
+      opts.ExecutionPolicy = RadixExecutionPolicy::Par;
+      opts.NaNsPosHandling = RadixNaNsPosHandling::AtFirst;
+      opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+      return opts;
+    }();
+    std::vector<double> v = {
+        NAN,
+        3.0,
+        NAN,
+        1.0,
+        NAN,
+        2.0,
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(),
+    };
+    stable_radix_sort<kParNaNsFirst>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(v[0]));
+    EXPECT_TRUE(std::isnan(v[1]));
+    EXPECT_TRUE(std::isnan(v[2]));
+  }
+
+  // Par stability (duplicate keys)
+  {
+    struct ItemParallel {
+      int key;
+      int idx;
+      bool operator==(const ItemParallel&) const = default;
+    };
+    std::vector<ItemParallel> items(200);
+    for (int i = 0; i < 200; ++i) {
+      items[i] = {i % 10, i};
+    }
+    std::shuffle(items.begin(), items.end(), rng);
+    auto expected = items;
+    std::stable_sort(
+        expected.begin(),
+        expected.end(),
+        [](const ItemParallel& a, const ItemParallel& b) {
+          return a.key < b.key;
+        });
+    stable_radix_sort<kParOpts>(
+        items.begin(),
+        items.end(),
+        std::allocator<ItemParallel>{},
+        [](const ItemParallel& x) { return x.key; });
+    EXPECT_EQ(items, expected);
+  }
+}
+#endif // _OPENMP
+
+// ============================================================================
+// RadixSortStrategy::Msd (Most Significant Digit first)
+// ============================================================================
+
+TEST(RadixSortTest, MsdSeq) {
+  constexpr auto kMsdOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortStrategy = RadixSortStrategy::Msd;
+    opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+    return opts;
+  }();
+
+  // uint64 random
+  {
+    auto v = generateRandom<uint64_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // all zero (maxVal=0 → passes=1)
+  {
+    auto v = std::vector<uint64_t>(500, 0);
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    for (auto x : v) {
+      EXPECT_EQ(x, uint64_t(0));
+    }
+  }
+
+  // small values 0..255 (only lowest byte varies)
+  {
+    std::vector<uint64_t> v(500);
+    std::iota(v.begin(), v.end(), uint64_t(0));
+    std::shuffle(v.begin(), v.end(), rng);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // uint64 large values with scattered MSB
+  {
+    std::vector<uint64_t> v(500);
+    std::uniform_int_distribution<uint64_t> dist(
+        uint64_t(1) << 63, std::numeric_limits<uint64_t>::max());
+    for (auto& x : v) {
+      x = dist(rng);
+    }
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // int64 with negatives
+  {
+    auto v = generateRandom<int64_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // double random
+  {
+    auto v = generateRandom<double>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // already sorted (early exit)
+  {
+    auto v = std::vector<uint64_t>(1000);
+    std::iota(v.begin(), v.end(), uint64_t(0));
+    auto expected = v;
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // all equal (nonEmpty=1 at each pass, recursion without partitioning)
+  {
+    auto v = std::vector<uint64_t>(500, 42);
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    for (auto x : v) {
+      EXPECT_EQ(x, uint64_t(42));
+    }
+  }
+
+  // MSD fallback to LSD threshold boundary
+  {
+    constexpr auto kMsdLowThreshold = [] {
+      auto opts = RadixSortOptions{};
+      opts.SortStrategy = RadixSortStrategy::Msd;
+      opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+      opts.MsdFallbackToLsdThreshold = 10;
+      return opts;
+    }();
+    auto v = generateRandom<uint64_t>(100);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdLowThreshold>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Msd descending
+  {
+    constexpr auto kMsdDesc = [] {
+      auto opts = RadixSortOptions{};
+      opts.SortStrategy = RadixSortStrategy::Msd;
+      opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    auto v = generateRandom<uint64_t>(500);
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), std::greater<uint64_t>{});
+    stable_radix_sort<kMsdDesc>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Msd with Bits16
+  {
+    constexpr auto kMsdBits16 = [] {
+      auto opts = RadixSortOptions{};
+      opts.SortStrategy = RadixSortStrategy::Msd;
+      opts.ExecutionPolicy = RadixExecutionPolicy::Seq;
+      opts.BitsPerPass = RadixBitsPerPass::Bits16;
+      return opts;
+    }();
+    auto v = generateRandom<uint64_t>(500);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdBits16>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Msd with uint32 (fewer passes)
+  {
+    auto v = generateRandom<uint32_t>(500);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Msd with small data (< 64 → insertion sort)
+  {
+    auto v = generateRandom<uint64_t>(50);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Msd with only one distinct bucket
+  {
+    std::vector<uint64_t> v(100);
+    for (auto& x : v) {
+      x = uint64_t(0xFF) << 56;
+    }
+    v[0] = uint64_t(0xFE) << 56;
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+}
+
+// ============================================================================
+// RadixSortStrategy::Msd + RadixExecutionPolicy::Par
+// ============================================================================
+
+#ifdef _OPENMP
+TEST(RadixSortTest, MsdPar) {
+  constexpr auto kMsdParOpts = [] {
+    auto opts = RadixSortOptions{};
+    opts.SortStrategy = RadixSortStrategy::Msd;
+    opts.ExecutionPolicy = RadixExecutionPolicy::Par;
+    return opts;
+  }();
+
+  // uint64 random
+  {
+    auto v = generateRandom<uint64_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // all zero (maxVal=0 → passes=1)
+  {
+    auto v = std::vector<uint64_t>(500, 0);
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    for (auto x : v) {
+      EXPECT_EQ(x, uint64_t(0));
+    }
+  }
+
+  // int64 with negatives
+  {
+    auto v = generateRandom<int64_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // double random
+  {
+    auto v = generateRandom<double>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // already sorted (early exit)
+  {
+    auto v = std::vector<uint64_t>(1000);
+    std::iota(v.begin(), v.end(), uint64_t(0));
+    auto expected = v;
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // all equal (nonEmpty=1 at each pass)
+  {
+    auto v = std::vector<uint64_t>(500, 42);
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    for (auto x : v) {
+      EXPECT_EQ(x, uint64_t(42));
+    }
+  }
+
+  // MsdPar descending
+  {
+    constexpr auto kMsdParDesc = [] {
+      auto opts = RadixSortOptions{};
+      opts.SortStrategy = RadixSortStrategy::Msd;
+      opts.ExecutionPolicy = RadixExecutionPolicy::Par;
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    auto v = generateRandom<uint64_t>(500);
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), std::greater<uint64_t>{});
+    stable_radix_sort<kMsdParDesc>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // non-power-of-2 size (isChunksSorted default path)
+  {
+    auto v = generateRandom<uint64_t>(1001);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // small data (< 64 → insertion sort)
+  {
+    auto v = generateRandom<uint64_t>(50);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // MsdPar with one distinct bucket
+  {
+    std::vector<uint64_t> v(100);
+    for (auto& x : v) {
+      x = uint64_t(0xFF) << 56;
+    }
+    v[0] = uint64_t(0xFE) << 56;
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // MsdPar fallback to LSD threshold
+  {
+    constexpr auto kMsdParLowThreshold = [] {
+      auto opts = RadixSortOptions{};
+      opts.SortStrategy = RadixSortStrategy::Msd;
+      opts.ExecutionPolicy = RadixExecutionPolicy::Par;
+      opts.MsdFallbackToLsdThreshold = 10;
+      return opts;
+    }();
+    auto v = generateRandom<uint64_t>(100);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdParLowThreshold>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // MsdPar stability (duplicate keys)
+  {
+    auto v = generateRandom<uint64_t>(500);
+    for (auto& x : v) {
+      x &= 0x1F;
+    }
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kMsdParOpts>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+}
+#endif // _OPENMP
+
+// ============================================================================
+// RadixSortOptions combination matrix
+// ============================================================================
+
+TEST(RadixSortTest, OptionsMatrix) {
+  // Bits16 + Ascending
+  {
+    constexpr auto kM1 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits16;
+      opts.SortOrder = RadixSortOrder::Ascending;
+      return opts;
+    }();
+    auto v = generateRandom<uint32_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kM1>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Bits16 + Descending
+  {
+    constexpr auto kM2 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits16;
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    auto v = generateRandom<uint32_t>(1000);
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), std::greater<uint32_t>{});
+    stable_radix_sort<kM2>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Bits16 + Counter64 + Asc
+  {
+    constexpr auto kM3 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits16;
+      opts.HistogramStorageType = RadixHistogramStorageType::UInt64;
+      opts.SortOrder = RadixSortOrder::Ascending;
+      return opts;
+    }();
+    auto v = generateRandom<uint64_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end());
+    stable_radix_sort<kM3>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Bits8 + Counter64 + Desc
+  {
+    constexpr auto kM4 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits8;
+      opts.HistogramStorageType = RadixHistogramStorageType::UInt64;
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    auto v = generateRandom<uint64_t>(1000);
+    auto expected = v;
+    std::stable_sort(
+        expected.begin(), expected.end(), std::greater<uint64_t>{});
+    stable_radix_sort<kM4>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Bits16 + Counter64 + Desc + double
+  {
+    constexpr auto kM5 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits16;
+      opts.HistogramStorageType = RadixHistogramStorageType::UInt64;
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    auto v = generateRandom<double>(500);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end(), std::greater<double>{});
+    stable_radix_sort<kM5>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+
+  // Bits16 + AtFirst + double
+  {
+    constexpr auto kM6 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits16;
+      opts.NaNsPosHandling = RadixNaNsPosHandling::AtFirst;
+      opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+      return opts;
+    }();
+    std::vector<double> v = {
+        NAN,
+        1.0,
+        NAN,
+        2.0,
+        3.0,
+        -1.0,
+        -2.0,
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(),
+    };
+    stable_radix_sort<kM6>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(v[0]));
+    EXPECT_TRUE(std::isnan(v[1]));
+  }
+
+  // Bits8 + Counter64 + AtFirst + Desc + float
+  {
+    constexpr auto kM7 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits8;
+      opts.HistogramStorageType = RadixHistogramStorageType::UInt64;
+      opts.SortOrder = RadixSortOrder::Descending;
+      opts.NaNsPosHandling = RadixNaNsPosHandling::AtFirst;
+      opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+      return opts;
+    }();
+    std::vector<float> v = {
+        NAN,
+        1.0f,
+        NAN,
+        2.0f,
+        3.0f,
+        -1.0f,
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+    };
+    stable_radix_sort<kM7>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(v[6]));
+    EXPECT_TRUE(std::isnan(v[7]));
+  }
+
+  // Bits16 + Counter64 + AtLast + Desc + double
+  {
+    constexpr auto kM8 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits16;
+      opts.HistogramStorageType = RadixHistogramStorageType::UInt64;
+      opts.SortOrder = RadixSortOrder::Descending;
+      opts.NaNsPosHandling = RadixNaNsPosHandling::AtLast;
+      opts.NaNsAssumption = RadixNaNsAssumption::Existence;
+      return opts;
+    }();
+    std::vector<double> v = {
+        1.0,
+        NAN,
+        2.0,
+        NAN,
+        3.0,
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(),
+    };
+    stable_radix_sort<kM8>(v.begin(), v.end());
+    EXPECT_TRUE(std::isnan(v[0]));
+    EXPECT_TRUE(std::isnan(v[1]));
+  }
+
+  // int32 + Bits16 + Counter64 + Desc
+  {
+    constexpr auto kM9 = [] {
+      auto opts = RadixSortOptions{};
+      opts.BitsPerPass = RadixBitsPerPass::Bits16;
+      opts.HistogramStorageType = RadixHistogramStorageType::UInt64;
+      opts.SortOrder = RadixSortOrder::Descending;
+      return opts;
+    }();
+    auto v = generateRandom<int32_t>(1000);
+    auto expected = v;
+    std::stable_sort(expected.begin(), expected.end(), std::greater<int32_t>{});
+    stable_radix_sort<kM9>(v.begin(), v.end());
+    EXPECT_EQ(v, expected);
+  }
+}
+
+// ============================================================================
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/folly/container/Iterator.h
+++ b/folly/container/Iterator.h
@@ -133,6 +133,17 @@ template <typename Iter>
 using iterator_mapped_type_t =
     typename iterator_value_type_t<Iter>::second_type;
 
+//  is_reverse_iterator
+//
+//  Whether an iterator type is a std::reverse_iterator specialization.
+template <typename T>
+struct is_reverse_iterator : std::false_type {};
+template <typename Iter>
+struct is_reverse_iterator<std::reverse_iterator<Iter>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_reverse_iterator_v = is_reverse_iterator<T>::value;
+
 /**
  * Argument tuple for variadic emplace/constructor calls. Stores arguments by
  * (decayed) value. Restores original argument types with reference qualifiers

--- a/folly/memory/BUCK
+++ b/folly/memory/BUCK
@@ -153,6 +153,18 @@ fb_dirsync_cpp_library(
 )
 
 fb_dirsync_cpp_library(
+    name = "hybrid_alloc",
+    headers = ["HybridAlloc.h"],
+    use_raw_headers = True,
+    exported_deps = [
+        ":malloc",
+        "//folly:memory",
+        "//folly:portability",
+        "//folly/lang:safe_assert",
+    ],
+)
+
+fb_dirsync_cpp_library(
     name = "allocator",
     headers = ["Allocator.h"],
     use_raw_headers = True,

--- a/folly/memory/CMakeLists.txt
+++ b/folly/memory/CMakeLists.txt
@@ -129,6 +129,17 @@ folly_add_library(
 )
 
 folly_add_library(
+  NAME hybrid_alloc
+  HEADERS
+    HybridAlloc.h
+  EXPORTED_DEPS
+    folly_lang_safe_assert
+    folly_memory
+    folly_memory_malloc
+    folly_portability
+)
+
+folly_add_library(
   NAME memory_resource
   HEADERS
     MemoryResource.h

--- a/folly/memory/HybridAlloc.h
+++ b/folly/memory/HybridAlloc.h
@@ -1,0 +1,393 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+
+#include <folly/Memory.h>
+#include <folly/Portability.h>
+#include <folly/lang/SafeAssert.h>
+#include <folly/memory/Malloc.h>
+
+#if defined(_MSC_VER)
+#include <malloc.h>
+#define FOLLY_ALLOCA(size) _alloca(size)
+#elif defined(__GNUC__) || defined(__clang__)
+#define FOLLY_ALLOCA(size) __builtin_alloca(size)
+#else
+#error "FOLLY_ALLOCA is not available for this compiler"
+#endif
+
+#ifndef FOLLY_HYBRID_ALLOC_DEFAULT_THRESHOLD
+#define FOLLY_HYBRID_ALLOC_DEFAULT_THRESHOLD 1024
+#endif
+
+#ifndef FOLLY_HYBRID_ALLOC_MAX_STACK_ALIGNMENT
+#define FOLLY_HYBRID_ALLOC_MAX_STACK_ALIGNMENT 4096
+#endif
+
+#define FOLLY_HYBRID_ALLOC_DOUBLE_FREE_CHECK 1
+
+namespace folly {
+
+/// Header stored immediately before each hybrid allocation.
+///
+/// The user pointer is placed after this header, rounded up to the requested
+/// alignment. `raw_ptr` is the address that must be passed back to the
+/// allocator when the storage came from the heap.
+struct alignas(max_align_v) HybridAllocHeader {
+  uint32_t marker; // origin and state of this allocation
+  void* raw_ptr; // base pointer used for free (may differ from user ptr)
+  size_t alloc_size; // total allocated size
+  size_t alignment; // alignment used for this allocation
+};
+
+inline constexpr size_t kHybridAllocHeaderSize = sizeof(HybridAllocHeader);
+
+static_assert(
+    kHybridAllocHeaderSize % max_align_v == 0,
+    "HybridAllocHeader size must be multiple of max_align_t");
+
+/// Marker values distinguish stack vs heap origin and detect double-frees.
+inline constexpr uint32_t kHybridAllocStackMarker = 0xCCCC;
+inline constexpr uint32_t kHybridAllocHeapMarker = 0xDDDD;
+inline constexpr uint32_t kHybridAlignedAllocStackMarker = 0xEEEE;
+inline constexpr uint32_t kHybridAlignedAllocHeapMarker = 0xFFFF;
+inline constexpr uint32_t kHybridAllocFreedHeapMarker = 0xDEAD;
+inline constexpr uint32_t kHybridAllocFreedStackMarker = 0xBEEF;
+
+namespace detail {
+
+inline constexpr bool isHybridAllocStackMarker(uint32_t marker) noexcept {
+  return marker == kHybridAllocStackMarker ||
+      marker == kHybridAlignedAllocStackMarker;
+}
+
+inline constexpr bool isHybridAllocHeapMarker(uint32_t marker) noexcept {
+  return marker == kHybridAllocHeapMarker ||
+      marker == kHybridAlignedAllocHeapMarker;
+}
+
+inline constexpr bool isHybridAllocFreedMarker(uint32_t marker) noexcept {
+  return marker == kHybridAllocFreedHeapMarker ||
+      marker == kHybridAllocFreedStackMarker;
+}
+
+// Raises sub-max_align_t alignments up to max_align_v so that the header
+// placement logic stays uniform.
+inline constexpr size_t normalizeHybridAllocAlignment(
+    size_t alignment) noexcept {
+  return alignment < max_align_v ? max_align_v : alignment;
+}
+
+inline constexpr bool validHybridAllocAlignment(size_t alignment) noexcept {
+  return valid_align_value(alignment);
+}
+
+/// Computes the total bytes needed for a hybrid allocation.
+///
+/// Includes the user payload, header, and enough padding to satisfy alignment.
+/// Returns false for invalid alignment or overflow.
+inline constexpr bool hybridAllocTotalSize(
+    size_t size, size_t alignment, size_t* total) noexcept {
+  if (!validHybridAllocAlignment(alignment)) {
+    return false;
+  }
+
+  alignment = normalizeHybridAllocAlignment(alignment);
+  constexpr auto kMax = std::numeric_limits<size_t>::max();
+  const size_t padding = alignment - 1;
+  if (size > kMax - kHybridAllocHeaderSize - padding) {
+    return false;
+  }
+
+  *total = size + kHybridAllocHeaderSize + padding;
+  return true;
+}
+
+// Like hybridAllocTotalSize but returns 0 on overflow.
+inline constexpr size_t hybridAllocTotalSizeOrZero(
+    size_t size, size_t alignment) noexcept {
+  size_t total = 0;
+  hybridAllocTotalSize(size, alignment, &total);
+  return total;
+}
+
+// Whether the request fits the stack threshold after accounting for overhead.
+inline bool hybridAllocUseStack(
+    size_t size, size_t threshold, size_t alignment) noexcept {
+  size_t total;
+  return size <= threshold && hybridAllocTotalSize(size, alignment, &total);
+}
+
+// Debug assertion that the requested alignment is within the stack limit.
+inline void checkHybridStackAlignment(size_t alignment) noexcept {
+  FOLLY_SAFE_DCHECK(
+      normalizeHybridAllocAlignment(alignment) <=
+          FOLLY_HYBRID_ALLOC_MAX_STACK_ALIGNMENT,
+      "hybrid allocation stack alignment is too large",
+      uint64_t{alignment});
+}
+
+/// Initializes a raw allocation and returns the aligned user pointer.
+///
+/// Writes the header immediately before the returned pointer. `freePtr` is
+/// null for stack storage and the heap base pointer otherwise.
+inline void* initHybridAlloc(
+    void* raw,
+    size_t alignment,
+    uint32_t marker,
+    void* freePtr,
+    size_t allocSize) noexcept {
+  if (raw == nullptr) {
+    return nullptr;
+  }
+
+  const size_t normalizedAlignment = normalizeHybridAllocAlignment(alignment);
+  assert(validHybridAllocAlignment(alignment));
+
+  auto* user = align_ceil(
+      static_cast<unsigned char*>(raw) + kHybridAllocHeaderSize,
+      normalizedAlignment);
+  auto* header =
+      reinterpret_cast<HybridAllocHeader*>(user - kHybridAllocHeaderSize);
+  header->marker = marker;
+  header->raw_ptr = freePtr;
+  header->alloc_size = allocSize;
+  header->alignment = normalizedAlignment;
+  return user;
+}
+
+// Wrapper for the common stack-allocation path; raw_ptr is set to nullptr.
+inline void* initHybridStackAlloc(
+    void* raw, size_t alignment, uint32_t marker, size_t allocSize) noexcept {
+  return initHybridAlloc(raw, alignment, marker, nullptr, allocSize);
+}
+
+// Allocates total bytes via malloc and initialises the header.
+inline void* hybridHeapAllocWithTotal(
+    size_t total, size_t alignment, uint32_t marker) noexcept {
+  void* raw = std::malloc(total);
+  return initHybridAlloc(raw, alignment, marker, raw, total);
+}
+
+// Computes total size, then allocates on the heap.
+inline void* hybridHeapAlloc(
+    size_t size, size_t alignment, uint32_t marker) noexcept {
+  size_t total;
+  if (!hybridAllocTotalSize(size, alignment, &total)) {
+    return nullptr;
+  }
+
+  return hybridHeapAllocWithTotal(total, alignment, marker);
+}
+
+// Retrieve the header preceding a user pointer.
+inline HybridAllocHeader* hybridAllocHeader(void* ptr) noexcept {
+  return reinterpret_cast<HybridAllocHeader*>(
+      static_cast<unsigned char*>(ptr) - kHybridAllocHeaderSize);
+}
+
+inline const HybridAllocHeader* hybridAllocHeader(const void* ptr) noexcept {
+  return reinterpret_cast<const HybridAllocHeader*>(
+      static_cast<const unsigned char*>(ptr) - kHybridAllocHeaderSize);
+}
+
+} // namespace detail
+
+/// Frees memory allocated by the FOLLY_HYBRID_ALLOC* macros.
+///
+/// Stack allocations are a no-op; heap allocations are released with
+/// sizedFree(). Double-free checking is enabled in debug builds.
+inline void hybridFree(void* ptr) noexcept {
+  if (ptr == nullptr) {
+    return;
+  }
+
+  auto* header = detail::hybridAllocHeader(ptr);
+  const auto marker = header->marker;
+#if FOLLY_HYBRID_ALLOC_DOUBLE_FREE_CHECK
+  FOLLY_SAFE_CHECK(
+      !detail::isHybridAllocFreedMarker(marker),
+      "hybrid allocation was already freed",
+      uint64_t{marker});
+#endif
+
+  if (detail::isHybridAllocHeapMarker(marker)) {
+#if FOLLY_HYBRID_ALLOC_DOUBLE_FREE_CHECK
+    header->marker = kHybridAllocFreedHeapMarker;
+#endif
+    sizedFree(header->raw_ptr, header->alloc_size);
+    return;
+  }
+
+  FOLLY_SAFE_CHECK(
+      detail::isHybridAllocStackMarker(marker),
+      "invalid hybrid allocation marker",
+      uint64_t{marker});
+#if FOLLY_HYBRID_ALLOC_DOUBLE_FREE_CHECK
+  header->marker = kHybridAllocFreedStackMarker;
+#endif
+}
+
+/// Returns the recorded allocation size, including header and padding.
+inline size_t hybridGetTotalSize(const void* ptr) noexcept {
+  if (ptr == nullptr) {
+    return 0;
+  }
+  return detail::hybridAllocHeader(ptr)->alloc_size;
+}
+
+/// Returns a heap-backed copy of a hybrid allocation.
+///
+/// Heap allocations are returned unchanged. Stack allocations are copied to a
+/// new heap buffer; the original stack storage is left in place.
+inline void* hybridMarkPersistent(void* ptr, size_t size) noexcept {
+  if (ptr == nullptr) {
+    return nullptr;
+  }
+
+  auto* header = detail::hybridAllocHeader(ptr);
+  const auto marker = header->marker;
+#if FOLLY_HYBRID_ALLOC_DOUBLE_FREE_CHECK
+  FOLLY_SAFE_CHECK(
+      !detail::isHybridAllocFreedMarker(marker),
+      "hybrid allocation was already freed",
+      uint64_t{marker});
+#endif
+
+  if (detail::isHybridAllocHeapMarker(marker)) {
+    return ptr;
+  }
+
+  FOLLY_SAFE_CHECK(
+      detail::isHybridAllocStackMarker(marker),
+      "invalid hybrid allocation marker",
+      uint64_t{marker});
+
+  const auto heapMarker = marker == kHybridAlignedAllocStackMarker
+      ? kHybridAlignedAllocHeapMarker
+      : kHybridAllocHeapMarker;
+  void* persistent =
+      detail::hybridHeapAlloc(size, header->alignment, heapMarker);
+  if (persistent == nullptr) {
+    return nullptr;
+  }
+  std::memcpy(persistent, ptr, size);
+  return persistent;
+}
+
+} // namespace folly
+
+/// @def FOLLY_HYBRID_ALLOC_THRESHOLD(size, threshold)
+/// Allocates bytes on the stack when `size <= threshold`, otherwise on heap.
+///
+/// The returned pointer is compatible with hybridFree(). On MSVC, avoid
+/// passing expressions with side effects.
+#if defined(__GNUC__) || defined(__clang__)
+#define FOLLY_HYBRID_ALLOC_THRESHOLD(size, threshold)                         \
+  __extension__({                                                             \
+    size_t const __folly_hybrid_size = (size);                                \
+    size_t const __folly_hybrid_threshold = (threshold);                      \
+    size_t const __folly_hybrid_alignment = ::folly::max_align_v;             \
+    size_t __folly_hybrid_total = 0;                                          \
+    void* __folly_hybrid_result = nullptr;                                    \
+    if (::folly::detail::hybridAllocTotalSize(                                \
+            __folly_hybrid_size,                                              \
+            __folly_hybrid_alignment,                                         \
+            &__folly_hybrid_total)) {                                         \
+      if (__folly_hybrid_size <= __folly_hybrid_threshold) {                  \
+        ::folly::detail::checkHybridStackAlignment(__folly_hybrid_alignment); \
+        __folly_hybrid_result = ::folly::detail::initHybridStackAlloc(        \
+            FOLLY_ALLOCA(__folly_hybrid_total),                               \
+            __folly_hybrid_alignment,                                         \
+            ::folly::kHybridAllocStackMarker,                                 \
+            __folly_hybrid_total);                                            \
+      } else {                                                                \
+        __folly_hybrid_result = ::folly::detail::hybridHeapAllocWithTotal(    \
+            __folly_hybrid_total,                                             \
+            __folly_hybrid_alignment,                                         \
+            ::folly::kHybridAllocHeapMarker);                                 \
+      }                                                                       \
+    }                                                                         \
+    __folly_hybrid_result;                                                    \
+  })
+#elif defined(_MSC_VER)
+// MSVC has no statement-expression equivalent. Keep FOLLY_ALLOCA at the call
+// site, and avoid passing expressions with side effects to these macros.
+#define FOLLY_HYBRID_ALLOC_THRESHOLD(size, threshold)                       \
+  (::folly::detail::hybridAllocUseStack(                                    \
+       (size), (threshold), ::folly::max_align_v)                           \
+       ? (::folly::detail::checkHybridStackAlignment(::folly::max_align_v), \
+          ::folly::detail::initHybridStackAlloc(                            \
+              FOLLY_ALLOCA(                                                 \
+                  ::folly::detail::hybridAllocTotalSizeOrZero(              \
+                      (size), ::folly::max_align_v)),                       \
+              ::folly::max_align_v,                                         \
+              ::folly::kHybridAllocStackMarker,                             \
+              ::folly::detail::hybridAllocTotalSizeOrZero(                  \
+                  (size), ::folly::max_align_v)))                           \
+       : ::folly::detail::hybridHeapAlloc(                                  \
+             (size), ::folly::max_align_v, ::folly::kHybridAllocHeapMarker))
+#endif
+
+/// Convenience wrapper using the default hybrid allocation threshold.
+#define FOLLY_HYBRID_ALLOC(size) \
+  FOLLY_HYBRID_ALLOC_THRESHOLD(size, FOLLY_HYBRID_ALLOC_DEFAULT_THRESHOLD)
+
+/// @def FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(size, alignment, threshold)
+/// Like FOLLY_HYBRID_ALLOC_THRESHOLD, with an explicit alignment.
+///
+/// Stack alignment is capped at FOLLY_HYBRID_ALLOC_MAX_STACK_ALIGNMENT.
+#if defined(__GNUC__) || defined(__clang__)
+#define FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(size, alignment, threshold)      \
+  __extension__({                                                             \
+    size_t const __folly_hybrid_size = (size);                                \
+    size_t const __folly_hybrid_threshold = (threshold);                      \
+    size_t const __folly_hybrid_alignment = (alignment);                      \
+    size_t __folly_hybrid_total = 0;                                          \
+    void* __folly_hybrid_result = nullptr;                                    \
+    if (::folly::detail::hybridAllocTotalSize(                                \
+            __folly_hybrid_size,                                              \
+            __folly_hybrid_alignment,                                         \
+            &__folly_hybrid_total)) {                                         \
+      if (__folly_hybrid_size <= __folly_hybrid_threshold) {                  \
+        ::folly::detail::checkHybridStackAlignment(__folly_hybrid_alignment); \
+        __folly_hybrid_result = ::folly::detail::initHybridStackAlloc(        \
+            FOLLY_ALLOCA(__folly_hybrid_total),                               \
+            __folly_hybrid_alignment,                                         \
+            ::folly::kHybridAlignedAllocStackMarker,                          \
+            __folly_hybrid_total);                                            \
+      } else {                                                                \
+        __folly_hybrid_result = ::folly::detail::hybridHeapAllocWithTotal(    \
+            __folly_hybrid_total,                                             \
+            __folly_hybrid_alignment,                                         \
+            ::folly::kHybridAlignedAllocHeapMarker);                          \
+      }                                                                       \
+    }                                                                         \
+    __folly_hybrid_result;                                                    \
+  })
+#elif defined(_MSC_VER)
+// MSVC has no statement-expression equivalent. Keep FOLLY_ALLOCA at the call
+// site, and avoid passing expressions with side effects to these macros.
+#define FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(size, alignment, threshold)       \
+  (::folly::detail::hybridAllocUseStack((size), (threshold), (alignment))      \
+       ? ::folly::detail::initHybridStackAlloc(                                \
+             (::folly::detail::checkHybridStackAlignment((alignment)),         \
+              FOLLY_ALLOCA(                                                    \
+                  ::folly::detail::hybridAllocTotalSizeOrZero(                 \
+                      (size), (alignment)))),                                  \
+             (alignment),                                                      \
+             ::folly::kHybridAlignedAllocStackMarker,                          \
+             ::folly::detail::hybridAllocTotalSizeOrZero((size), (alignment))) \
+       : ::folly::detail::hybridHeapAlloc(                                     \
+             (size), (alignment), ::folly::kHybridAlignedAllocHeapMarker))
+#endif
+
+/// Convenience wrapper for aligned allocation with the default threshold.
+#define FOLLY_HYBRID_ALIGNED_ALLOC(size, alignment) \
+  FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD(             \
+      size, alignment, FOLLY_HYBRID_ALLOC_DEFAULT_THRESHOLD)


### PR DESCRIPTION
# PR Summary: StableRadixSort + HybridAlloc

This PR extends `StableRadixSort` with MSD traversal and OpenMP parallel execution, and introduces `HybridAlloc` — a lightweight stack-or-heap allocation utility — to support runtime-sized per-thread bucket storage in the parallel path.

---

## StableRadixSort

The existing LSD-only implementation is preserved as the default strategy. This PR adds:

- **Four execution modes** — `LSD+Seq`, `LSD+Par`, `MSD+Seq`, `MSD+Par` — selectable at compile time via `RadixSortOptions`
- **Sortedness fast-path** — the single-pass histogram build also detects if input is already sorted, skipping the sort entirely
- **Adaptive MSD** — MSD recursion falls back to LSD (or insertion sort) for small sub-problems
- **Per‑thread 2D histograms** in the OpenMP path to avoid atomic contention (`#pragma omp parallel for` histogram/scatter, `#pragma omp parallel for` for bucket recursion)
- **Configurable digit width** — 8‑bit (256 buckets) or 16‑bit (65536 buckets) per pass
- **NaN positioning** — configurable AtFirst / AtLast / Unhandled, with a compile-time assumption toggle (Existence / NonExistence) to skip NaN logic when none are present


All existing entry points (`stable_radix_sort`, `stable_radix_sort_descending`) remain available and unchanged — no breaking changes to callers.

---

## HybridAlloc (`folly/memory/HybridAlloc.h`)

A pair of preprocessor macros (`FOLLY_HYBRID_ALLOC_THRESHOLD`, `FOLLY_HYBRID_ALIGNED_ALLOC_THRESHOLD`) that allocate on the stack via `alloca` when the request fits a configurable threshold, falling back to `malloc` otherwise. A `HybridAllocHolder<T>` RAII wrapper handles cleanup.

**Motivation:**  
the OpenMP parallel path needs per‑thread bucket arrays whose size depends on the runtime thread count. For 8‑bit radix (256 buckets × threads), stack allocation works. For 16‑bit radix (65536 buckets × threads), heap is required. `HybridAlloc` selects the right backing at the call site with zero abstraction overhead.

---

## Tests and Benchmarks

### Correctness

Covers all 4 execution modes across:

- Unsigned / signed integers
- `float` / `double` / `long double` (NaN positioning: first/last/descending)
- `char` / `wchar_t` / `char16_t` / `char32_t`
- `bool`
- Custom type sorting
- Edge cases: empty, single‑element, already‑sorted, all‑equal, reverse
- Insertion‑sort threshold boundary (63/64/65)
- 16‑bit chunks, 64‑bit counters, reverse iterators
- MSD→LSD fallback
- Stability with duplicate keys

### Benchmarks

- **Sequential** comparison against `std::sort`, `std::stable_sort`, `boost::spreadsort`, `boost::pdqsort`, `folly::detail::double_radix_sort` at sizes 100 – 1M
- **Parallel** comparison against `std::sort(par)`, `std::stable_sort(par)`, and MSVC `parallel_radixsort` (when available)