### PR TITLE
Fix fmt::format include in AtomicBatchDispatcher.cpp

### DIFF
--- a/folly/algorithm/simd/test/FindFixedTest.cpp
+++ b/folly/algorithm/simd/test/FindFixedTest.cpp
@@ -35,7 +35,14 @@ namespace {
 template <typename T, std::size_t N>
 void allTestsForN(std::span<T, N> buf) {
   auto errorMsg = [&] {
-    return fmt::format("looking in: {}, sizeof(T): {}", buf, sizeof(T));
+    // std::byte (and similar) is not directly formattable by fmt, so widen
+    // each element to an integer for the diagnostic message.
+    std::vector<std::uint64_t> values;
+    values.reserve(buf.size());
+    for (const auto& x : buf) {
+      values.push_back(static_cast<std::uint64_t>(x));
+    }
+    return fmt::format("looking in: {}, sizeof(T): {}", values, sizeof(T));
   };
 
   T foundX = static_cast<T>(0);

--- a/folly/fibers/detail/AtomicBatchDispatcher.cpp
+++ b/folly/fibers/detail/AtomicBatchDispatcher.cpp
@@ -18,7 +18,7 @@
 
 #include <cassert>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace folly {
 namespace fibers {


### PR DESCRIPTION
fmt::format is declared in <fmt/format.h>, not <fmt/core.h> on newer fmt (11/12). This file does not pull in format.h transitively, so it fails to build against newer fmt (e.g. homebrew on macOS CI).