### PR TITLE
coro: fix eager-conversion detection for clang >= 22

### DIFF
--- a/folly/algorithm/simd/test/FindFixedTest.cpp
+++ b/folly/algorithm/simd/test/FindFixedTest.cpp
@@ -35,7 +35,14 @@ namespace {
 template <typename T, std::size_t N>
 void allTestsForN(std::span<T, N> buf) {
   auto errorMsg = [&] {
-    return fmt::format("looking in: {}, sizeof(T): {}", buf, sizeof(T));
+    // std::byte (and similar) is not directly formattable by fmt, so widen
+    // each element to an integer for the diagnostic message.
+    std::vector<std::uint64_t> values;
+    values.reserve(buf.size());
+    for (const auto& x : buf) {
+      values.push_back(static_cast<std::uint64_t>(x));
+    }
+    return fmt::format("looking in: {}, sizeof(T): {}", values, sizeof(T));
   };
 
   T foundX = static_cast<T>(0);

--- a/folly/coro/Coroutine.h
+++ b/folly/coro/Coroutine.h
@@ -195,6 +195,7 @@ struct detect_promise_return_object_eager_conversion_ {
       }
 
       promise_type* promise;
+      bool body_ran = false;
     };
 
     ~promise_type() {
@@ -208,14 +209,26 @@ struct detect_promise_return_object_eager_conversion_ {
     void unhandled_exception() {}
 
     return_object get_return_object() noexcept { return {*this}; }
-    void return_void() {}
+    //  Record that the coroutine body has run. Guarded on `object` so that, in
+    //  the eager case where the return-object temporary is already destroyed
+    //  (it nulls `object` in its destructor), this is a safe no-op.
+    void return_void() {
+      if (object) {
+        object->body_ran = true;
+      }
+    }
 
     return_object* object = nullptr;
   };
 
+  //  Conversion is eager iff it happens before the coroutine body runs. This is
+  //  measured directly via `body_ran` rather than via promise liveness: some
+  //  compilers (clang >= 22) destroy the promise after the return-object
+  //  conversion rather than before, so the promise may still be alive at
+  //  conversion time even when conversion is deferred.
   /* implicit */ detect_promise_return_object_eager_conversion_(
       promise_type::return_object const& o) noexcept
-      : eager{!!o.promise} {}
+      : eager{!o.body_ran} {}
   //  letting the coroutine type be trivially-copyable makes the coroutine crash
   //  under clang; to work around, provide an empty but not trivial destructor
   ~detect_promise_return_object_eager_conversion_() {}

--- a/folly/fibers/detail/AtomicBatchDispatcher.cpp
+++ b/folly/fibers/detail/AtomicBatchDispatcher.cpp
@@ -18,7 +18,7 @@
 
 #include <cassert>
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 namespace folly {
 namespace fibers {


### PR DESCRIPTION
detect_promise_return_object_eager_conversion() inferred "eager" from
whether the promise was still alive at return-object conversion time
(!!o.promise). clang >= 22 reordered the conversion to run before the
promise destructor instead of after, so the promise is still alive at
conversion even when conversion is deferred. The detector then wrongly
reported eager, causing Expected/Optional coroutines to yield empty
results (bad expected access / empty Optional unwrapped) on Mac CI,
which builds with Homebrew LLVM.

Detect the actual signal instead: whether the coroutine body already ran
before the conversion, via a body_ran flag set in return_void. This is
robust to the promise-dtor/conversion ordering and stays correct for
genuinely-eager compilers (in eager mode the conversion precedes the
body, and the return-object destructor nulls `object` so the later
return_void is a safe no-op).

Verified on clang 22 and AppleClang 17 at -O0..-O3 with the real
eager/deferred branches. Fixes the shared detector used by Expected.h,
Optional.h, and result/detail/result_promise.h, and satisfies the
existing CoroutineTest contract (clang >= 17 => eager == false).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>