### PR TITLE
ci: use default Xcode for Mac getdeps instead of pinned Xcode 16.2

### DIFF
--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macOS-latest
     timeout-minutes: 60
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
       CC: /opt/homebrew/opt/llvm/bin/clang
       CXX: /opt/homebrew/opt/llvm/bin/clang++
       SCCACHE_GHA_ENABLED: "on"

--- a/build/fbcode_builder/getdeps/test/fixtures/expected/xxhash_plain/getdeps_mac.yml
+++ b/build/fbcode_builder/getdeps/test/fixtures/expected/xxhash_plain/getdeps_mac.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macOS-latest
     timeout-minutes: 60
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
       CC: /opt/homebrew/opt/llvm/bin/clang
       CXX: /opt/homebrew/opt/llvm/bin/clang++
       SCCACHE_GHA_ENABLED: "on"

--- a/build/fbcode_builder/getdeps/workflow_generator.py
+++ b/build/fbcode_builder/getdeps/workflow_generator.py
@@ -168,7 +168,7 @@ class GenerateGitHubActionsCmd(ProjectCmdBase):
         env_lines = []
         if build_opts.is_darwin():
             env_lines.append(
-                "DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer"
+                "DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer"
             )
         if use_homebrew_llvm:
             env_lines.append("CC: /opt/homebrew/opt/llvm/bin/clang")


### PR DESCRIPTION
The Mac workflow pinned DEVELOPER_DIR to /Applications/Xcode_16.2.app, which GitHub has since rotated off the macOS runner image, so xcrun fails ("missing DEVELOPER_DIR path") before any build starts. The job also uses Homebrew LLVM, which always pulls the newest clang, so pinning an old SDK against an ever-newer compiler is the fragile combination that caused the earlier libc++ header mismatches; a newer default SDK pairs better.

Point DEVELOPER_DIR at /Applications/Xcode.app/Contents/Developer (the runner's default-selected Xcode symlink), which survives image rotations. Updated in the generated workflow, the getdeps workflow_generator that emits it, and the golden-file test fixture so they stay consistent.