### PR TITLE
Fix duplicated words and typos in comments and docs

### DIFF
--- a/folly/ConstructorCallbackList.h
+++ b/folly/ConstructorCallbackList.h
@@ -55,7 +55,7 @@ namespace folly {
 // places with low overhead.
 //
 // NOTE: The callback is triggered with a *partially* constructed object.
-// This implies that that callback code can only access members that are
+// This implies that callback code can only access members that are
 // constructed *before* the ConstructorCallbackList object.  Also, at the time
 // of the callback, none of the Foo() constructor code will have run.
 // Per the example above,

--- a/folly/Function.h
+++ b/folly/Function.h
@@ -844,7 +844,7 @@ class Function final : private detail::function::FunctionTraits<FunctionType> {
   Function& operator=(Fun fun) noexcept(Nx) {
     // Doing this in place is more efficient when we can do so safely.
     if (Nx) {
-      // Q: Why is is safe to destroy and reconstruct this object in place?
+      // Q: Why is it safe to destroy and reconstruct this object in place?
       // A: See the explanation in the move assignment operator.
       this->~Function();
       ::new (this) Function(static_cast<Fun&&>(fun));

--- a/folly/Synchronized.h
+++ b/folly/Synchronized.h
@@ -669,7 +669,7 @@ struct Synchronized
    * copy-construction of the destination data from the source data. No lock is
    * taken on the destination mutex.
    *
-   * May throw even when the data type is is nothrow-copy-constructible because
+   * May throw even when the data type is nothrow-copy-constructible because
    * acquiring a lock may throw.
    *
    * deprecated
@@ -1583,7 +1583,7 @@ class LockedPtr {
  *    // needed by the underlying deadlock avoiding algorithm
  *    synchronized([](auto, auto) { ... }, rlock(one), wlock(two, 1s));
  *
- * Note that the arguments passed to to *lock() calls will be passed by
+ * Note that the arguments passed to *lock() calls will be passed by
  * const-ref to the function invocation, as the implementation might use them
  * many times
  */

--- a/folly/ThreadCachedInt.h
+++ b/folly/ThreadCachedInt.h
@@ -145,7 +145,7 @@ class ThreadCachedInt {
 
     void increment(IntT inc) {
       if (FOLLY_LIKELY(!reset_.load(std::memory_order_acquire))) {
-        // This thread is the only writer to val_, so it's fine do do
+        // This thread is the only writer to val_, so it's fine to do
         // a relaxed load and do the addition non-atomically.
         val_.store(
             val_.load(std::memory_order_relaxed) + inc,

--- a/folly/Utility.h
+++ b/folly/Utility.h
@@ -96,7 +96,7 @@ using detail::decay_t;
  *      }
  *
  *  Note: If passed an rvalue, invokes the move-ctor, not the copy-ctor. This
- *  can be used to to force a move, where just using std::move would not:
+ *  can be used to force a move, where just using std::move would not:
  *
  *      folly::copy(std::move(data)); // force-move, not just a cast to &&
  *

--- a/folly/channels/MultiplexChannel-inl.h
+++ b/folly/channels/MultiplexChannel-inl.h
@@ -179,7 +179,7 @@ class MultiplexChannelProcessor : public IChannelCallback {
         pendingAsyncCalls_(0) {}
 
   /**
-   * Starts multiplexing values from the input receiver to to one or more keyed
+   * Starts multiplexing values from the input receiver to one or more keyed
    * subscriptions.
    */
   void start(Receiver<InputValueType> inputReceiver) {

--- a/folly/concurrency/container/RelaxedConcurrentPriorityQueue.h
+++ b/folly/concurrency/container/RelaxedConcurrentPriorityQueue.h
@@ -95,7 +95,7 @@
 // 1. PopBatch could be 0 or a positive integer.
 // If it is 0, only pop one node at a time.
 // This is the strict implementation. It guarantees the return
-// priority is alway the highest.  If it is > 0, we keep
+// priority is always the highest.  If it is > 0, we keep
 // up to that number of nodes in a shared buffer to be consumed by
 // subsequent pop operations.
 //
@@ -1046,7 +1046,7 @@ class RelaxedConcurrentPriorityQueue {
     }
   }
 
-  // This could guarentee the Mound is empty
+  // This could guarantee the Mound is empty
   FOLLY_ALWAYS_INLINE bool isMoundEmpty() {
     Position pos;
     pos.level = pos.index = 0;

--- a/folly/container/FBVector.h
+++ b/folly/container/FBVector.h
@@ -638,7 +638,7 @@ class fbvector {
   //  deficiency. In lieu of a strong exception guarantee, relocate_undo does
   //  the next best thing: it provides a weak exception guarantee by
   //  destroying the new data, but leaving the old data in an indeterminate
-  //  state. Note that that indeterminate state will be valid, since the
+  //  state. Note that indeterminate state will be valid, since the
   //  old data has not been destroyed; it has merely been the source of a
   //  move, which is required to leave the source in a valid state.
 

--- a/folly/coro/Collect.h
+++ b/folly/coro/Collect.h
@@ -579,7 +579,7 @@ auto collectAnyRange(InputRange awaitables) -> folly::coro::Task<std::pair<
 // aware of the coroutine starting behavior described in collectAll()
 // documentation.
 //
-// The result of the first successful SemiAwaitable, or the the exception from
+// The result of the first successful SemiAwaitable, or the exception from
 // the last SemiAwaitable is returned if none are successful. Any result of the
 // remaining SemiAwaitables will be discarded, independently of whether it's a
 // value or an exception.

--- a/folly/coro/Coroutine.h
+++ b/folly/coro/Coroutine.h
@@ -372,7 +372,7 @@ class ExtendedCoroutineHandle {
 
     // A manual vtable with 1 function. Benefits over virtual inheritance:
     //   - `TaskWrapperPromise` can implement `getErrorHandle` without bloating
-    //     itself with with a vtable it does not need.
+    //     itself with a vtable it does not need.
     //   - A tiny binary size win.
     //   - Derived classes like `TaskPromise` don't have to be `final` in order
     //     for the compiler to treat them as non-polymorphic.

--- a/folly/detail/ThreadLocalDetail.h
+++ b/folly/detail/ThreadLocalDetail.h
@@ -613,7 +613,7 @@ struct FOLLY_EXPORT StaticMeta final : StaticMetaBase {
 
     ThreadEntry* te = getThreadEntry(ent);
     uint32_t id = ent->getOrInvalid();
-    // Only valid index into the the elements array
+    // Only valid index into the elements array
     DCHECK_NE(id, kEntryIDInvalid);
     DCHECK(te->cachedInSetMatchesElementsArray(id));
     return te->elements[id];

--- a/folly/detail/test/ThreadLocalDetailTest.cpp
+++ b/folly/detail/test/ThreadLocalDetailTest.cpp
@@ -266,7 +266,7 @@ TEST_F(ThreadLocalDetailTest, accessAllAndRealloc) {
 
   spawnMoreThreads = std::thread([&]() {
     spawnHelperBarrier.wait();
-    // create a bunch of threads. let them assign some value to the elemnts
+    // create a bunch of threads. let them assign some value to the elements
     // other than one at index 0. This will cause elements array to be
     // reallocated a few times. They should not get blocked by presence of the
     // accessAllThreads accessor.

--- a/folly/docs/Hazptr.md
+++ b/folly/docs/Hazptr.md
@@ -216,7 +216,7 @@ read-modify-write operations in the observation path and which scales very well
 with core count.
 
 Folly offers some exotic solutions here. `folly::ReadMostlySharedPtr`is a
-version of of shared-ptr accelerated with thread-local caches and thread-local
+version of shared-ptr accelerated with thread-local caches and thread-local
 refcount operations. `folly::CoreCachedSharedPtr` is a version of shared-ptr
 accelerated with a fixed-size slab of copies to ensure that refcount operations
 be relatively uncontended, but can be subject to exotic race conditions. And

--- a/folly/docs/Switch.md
+++ b/folly/docs/Switch.md
@@ -22,7 +22,7 @@ flags.
   - `switch-default`: error
   - `covered-switch-default`: ignored
 
-User code can explicitely opt-in to exhaustive switch behavior with
+User code can explicitly opt-in to exhaustive switch behavior with
 `FOLLY_EXHAUSTIVE_SWITCH()`.
 
 **Non-exhaustive**:
@@ -30,7 +30,7 @@ User code can explicitely opt-in to exhaustive switch behavior with
   - `switch-default`: error
   - `covered-switch-default`: error
 
-User code can explicitely opt-in to non-exhaustive switch behavior with
+User code can explicitly opt-in to non-exhaustive switch behavior with
 `FOLLY_NON_EXHAUSTIVE_SWITCH()`.
 
 Examples:
@@ -266,7 +266,7 @@ NOTE: having the `switch` diagnostics configured for exhaustive switches OUGHT
 to be the default for all C++ codebases. However, due to the copious usage
 `switch` statements in our codebase without these improved diagnostics, it will
 take time to get there. In the meantime, we can use the
-`FOLLY_EXHAUSTIVE_SWITCH()` macro to explicitely opt-in to the exhaustive switch
+`FOLLY_EXHAUSTIVE_SWITCH()` macro to explicitly opt-in to the exhaustive switch
 behavior.
 
 ## Non-exhaustive switches

--- a/folly/fibers/async/Async.h
+++ b/folly/fibers/async/Async.h
@@ -77,7 +77,7 @@ static constexpr auto& await = await_async;
  *
  * Runtime Consideration:
  * - The wrapper is currently 0 cost (in optimized builds), and this will
- *   remain a guarentee
+ *   remain a guarantee
  * - It provides protection (in debug builds) against running Async-annotated
  *   code on main context.
  * - It does NOT provide protection against doing I/O in non Async-annotated

--- a/folly/functional/Invoke.h
+++ b/folly/functional/Invoke.h
@@ -871,7 +871,7 @@ struct empty {};
 FOLLY_DEFINE_CPO(detail_tag_invoke_fn::tag_invoke_fn, tag_invoke)
 
 // Query if the 'folly::tag_invoke()' CPO can be invoked with a tag and
-// arguments of the the specified types.
+// arguments of the specified types.
 //
 // This checks whether an overload of the free-function tag_invoke() found
 // by ADL can be invoked with the specified types.

--- a/folly/hash/detail/ChecksumDetail.cpp
+++ b/folly/hash/detail/ChecksumDetail.cpp
@@ -99,7 +99,7 @@
  * When <= 512 bits remain in the message, we finish up by folding
  * across smaller distances.  This works similarly; the distance D is
  * just different, so different constant multipliers must be used.
- * Finally, once the remaining message is just 64 bits, it is is
+ * Finally, once the remaining message is just 64 bits, it is
  * reduced to the CRC-32 using Barrett reduction (explained later).
  *
  * For more information see the original paper from Intel: "Fast CRC

--- a/folly/io/IOBuf.h
+++ b/folly/io/IOBuf.h
@@ -1114,7 +1114,7 @@ class IOBuf {
    * function checks if the chain is non-trivial, i.e. the chain has more than
    * just one IOBuf in it.
    *
-   * @returns  true iff the the IOBuf's chain has more than 1 IOBuf in it
+   * @returns  true iff the IOBuf's chain has more than 1 IOBuf in it
    *
    * @methodset Chaining
    */

--- a/folly/io/async/AsyncSSLSocket.h
+++ b/folly/io/async/AsyncSSLSocket.h
@@ -89,7 +89,7 @@ class AsyncSSLSocket : public AsyncSocket {
      * Note that OpenSSL performs only rudimentary internal
      * consistency verification checks by itself. Any other validation
      * like whether or not the certificate was issued by a trusted CA.
-     * The default implementation of this callback mimics what what
+     * The default implementation of this callback mimics what
      * OpenSSL does internally if SSL_VERIFY_PEER is set with no
      * verification callback.
      *

--- a/folly/io/async/AsyncTransport.h
+++ b/folly/io/async/AsyncTransport.h
@@ -325,7 +325,7 @@ class AsyncWriter {
     /**
      * writeError() will be invoked if an error occurs writing the data.
      *
-     * @param bytesWritten      The number of bytes that were successfull
+     * @param bytesWritten      The number of bytes that were successful
      * @param ex                An exception describing the error that occurred.
      */
     virtual void writeErr(

--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -786,7 +786,7 @@ class EventBase
    * - In strict mode (strictLoopThread = true), isInEventBaseThread() always
    *   returns false. This is to support use cases in which the loop is run by a
    *   dedicated executor, possibly not continuously, so it is safe to rely on
-   *   isInEventBaseThread() from any thread with with no risk of races. In this
+   *   isInEventBaseThread() from any thread with no risk of races. In this
    *   mode, the behavior is equivalent to inRunningEventBaseThread().
    */
   bool isInEventBaseThread() const;

--- a/folly/io/async/IoUring.h
+++ b/folly/io/async/IoUring.h
@@ -117,7 +117,7 @@ class IoUringOp : public AsyncBaseOp {
   // we have to use a union here because of -Wgnu-variable-sized-type-not-at-end
   //__u64 big_cqe[];
   union {
-    __u64 user_data; // first member from from io_uring_cqe
+    __u64 user_data; // first member from io_uring_cqe
     uint8_t data[32];
   } cqe_ = {};
 

--- a/folly/io/async/NotificationQueue.h
+++ b/folly/io/async/NotificationQueue.h
@@ -251,7 +251,7 @@ class NotificationQueue {
    * The fdType parameter determines the type of file descriptor used
    * internally to signal message availability.  The default (eventfd) is
    * preferable for performance and because it won't fail when the queue gets
-   * too long.  It is not available on on older and non-linux kernels, however.
+   * too long.  It is not available on older and non-linux kernels, however.
    * In this case the code will fall back to using a pipe, the parameter is
    * mostly for testing purposes.
    */

--- a/folly/io/async/Request.h
+++ b/folly/io/async/Request.h
@@ -560,7 +560,7 @@ static_assert(sizeof(RequestContext) <= 64, "unexpected size");
  * RequestContextScopeGuard which replaces the current context in construction.
  *
  * This enables taking advantage of the optimization in setContext() which skips
- * invoking the RequestData callbacks if the new context is the the same as the
+ * invoking the RequestData callbacks if the new context is the same as the
  * current one. The use case is processing tasks in a loop which are likely to
  * share the same context.
  */

--- a/folly/io/async/SSLContext.h
+++ b/folly/io/async/SSLContext.h
@@ -555,7 +555,7 @@ class SSLContext {
    * zero causes ALPN to be disabled.
    *
    * @param items  List of NextProtocolsItems, Each item contains a list of
-   *               protocol names and weight. After the call of this fucntion
+   *               protocol names and weight. After the call of this function
    *               each non-empty list of protocols will be advertised with
    *               probability weight/sum_of_weights. This method makes a copy,
    *               so the caller needn't keep the list in scope after the call

--- a/folly/io/async/test/EventHandlerTest.cpp
+++ b/folly/io/async/test/EventHandlerTest.cpp
@@ -186,7 +186,7 @@ TEST_F(EventHandlerTest, many_concurrent_consumers) {
 
 #ifdef EV_PRI
 //
-// See rfc6093 for extensive discussion on TCP URG semantics. Specificaly,
+// See rfc6093 for extensive discussion on TCP URG semantics. Specifically,
 // it points out that URG mechanism was never intended to be used
 // for out-of-band information delivery. However, pretty much every
 // implementation interprets the LAST octect or urgent data as the

--- a/folly/lang/bind/AsArgument.h
+++ b/folly/lang/bind/AsArgument.h
@@ -21,7 +21,7 @@
 
 ///
 /// Implements the bindings semantics of `safe_closure()`.  In this example, it
-/// is responsible for for the "pass by" portion of the logic -- by the time we
+/// is responsible for the "pass by" portion of the logic -- by the time we
 /// invoke `bind_as_argument`, the input ref was already stored as a value
 /// inside the `safe_closure`.
 ///

--- a/folly/lang/bind/Bind.h
+++ b/folly/lang/bind/Bind.h
@@ -440,7 +440,7 @@ constexpr auto in_place_with(
 // meant to be passed only by-value, as a prvalue.  They can all take unary,
 // or plural `like_args` as inputs.  Their only difference from
 // `bind::args{values...}` is that these modifiers override some aspect of
-// `bind_info_t`s on on all the bindings they contain.
+// `bind_info_t`s on all the bindings they contain.
 //
 // Unlike standard C++, the "constant" and "ref" modifiers commute, avoiding
 // that common footgun.

--- a/folly/logging/LogLevel.h
+++ b/folly/logging/LogLevel.h
@@ -45,7 +45,7 @@ enum class LogLevel : uint32_t {
   // This level is intended to be primarily used in log category settings.
   // In your code it is usually better to use one of the finer-grained DBGn
   // levels.  In your log category settings you can then set the log category
-  // level to a specific DBGn level, or to to main DBG level to enable all DBGn
+  // level to a specific DBGn level, or to main DBG level to enable all DBGn
   // messages.
   //
   // This is named "DBG" rather than "DEBUG" since some open source projects

--- a/folly/logging/xlog.h
+++ b/folly/logging/xlog.h
@@ -523,7 +523,7 @@ FOLLY_EXPORT FOLLY_ALWAYS_INLINE bool xlogFirstNExactImpl(std::size_t n) {
  *   - a pointer to the LogCategory
  *
  *   If the __INCLUDE_LEVEL__ macro is available (both gcc and clang support
- *   this), then we we can detect when we are inside a .cpp file versus a
+ *   this), then we can detect when we are inside a .cpp file versus a
  *   header file.  If we are inside a .cpp file, we can avoid declaring these
  *   variables once per XLOG() statement, and instead we only declare one copy
  *   of these variables for the entire file.

--- a/folly/memory/Allocator.h
+++ b/folly/memory/Allocator.h
@@ -139,7 +139,7 @@ class AlignedSysAllocator : private Align {
 
   using Align::Align;
 
-  // TODO: remove this ctor, which is is no longer required as of under gcc7
+  // TODO: remove this ctor, which is no longer required as of under gcc7
   template <
       typename S = Align,
       std::enable_if_t<std::is_default_constructible<S>::value, int> = 0>

--- a/folly/observer/test/ObserverTest.cpp
+++ b/folly/observer/test/ObserverTest.cpp
@@ -809,7 +809,7 @@ TEST(Observer, HazptrObserverRecursiveReclamation) {
   // in this scenario:
   // * in scope is a domain instance with no executor
   // * the hazptr-observer is itself owned by a hazptr-obj
-  // * tha hazptr-obj is retired with deferred reclamation enforced
+  // * the hazptr-obj is retired with deferred reclamation enforced
   // * the hazptr-obj and the hazptr-observer states are owned by the domain
   // * many objects are retired, bringing the domain close to the threshold
   // * one observable update cycle states within the callback

--- a/folly/result/rich_exception_ptr.h
+++ b/folly/result/rich_exception_ptr.h
@@ -524,7 +524,7 @@ class rich_exception_ptr_impl : protected B {
           "rich_exception_ptr::operator== invalid for 2 small value uintptrs",
           false);
       // The fallback could trivally compare `get_uintptr()`, to return `true`
-      // correctly sometimes, but the the right comparison semantics must
+      // correctly sometimes, but the right comparison semantics must
       // actually be determined by `result<T>` that knows the small-value type.
       return false;
     }

--- a/folly/synchronization/DistributedMutex-inl.h
+++ b/folly/synchronization/DistributedMutex-inl.h
@@ -980,7 +980,7 @@ bool doFutexWait(Waiter* waiter, Waiter*& next) {
     return true;
   }
 
-  // if we reach here then were were not given an early delivery, and any
+  // if we reach here then we were not given an early delivery, and any
   // thread that goes to wake us up will see a consistent view of the rest of
   // the contention chain (since the next_ variable is set before the
   // kSleeping exchange above)

--- a/folly/synchronization/Rcu.h
+++ b/folly/synchronization/Rcu.h
@@ -333,7 +333,7 @@ class rcu_domain {
   rcu_domain& operator=(const rcu_domain&) = delete;
   rcu_domain& operator=(rcu_domain&&) = delete;
 
-  // Reader locks: Prevent any calls from occuring, retired memory
+  // Reader locks: Prevent any calls from occurring, retired memory
   // from being freed, and synchronize() calls from completing until
   // all preceding lock() sections are finished.
 

--- a/folly/test/SocketAddressTest.cpp
+++ b/folly/test/SocketAddressTest.cpp
@@ -511,7 +511,7 @@ TEST(SocketAddress, CheckComparatorBehavior) {
   second.setFromIpPort("128.0.0.100", 10);
   CheckFirstLessThanSecond(first, second);
 
-  // Comparision between IPV4 and IPV6
+  // Comparison between IPV4 and IPV6
   first.setFromIpPort("128.0.0.0", 0);
   second.setFromIpPort("::ffff:127.0.0.1", 0);
   CheckFirstLessThanSecond(first, second);

--- a/folly/test/StringToFloatBenchmark.cpp
+++ b/folly/test/StringToFloatBenchmark.cpp
@@ -251,7 +251,7 @@ int main(int argc, char** argv) {
   std::random_device rd; // a seed source for the random number engine
   std::mt19937 gen(rd()); // mersenne_twister_engine seeded with rd()
   constexpr int kNumValues =
-      10'000'000; // enough values for the the benchmark iterations
+      10'000'000; // enough values for the benchmark iterations
 
   {
     // this block generates random values by separately sampling values

--- a/folly/testing/TestUtil.h
+++ b/folly/testing/TestUtil.h
@@ -221,7 +221,7 @@ class CaptureFD {
   using ChunkCob = std::function<void(folly::StringPiece)>;
 
   /**
-   * chunk_cob is is guaranteed to consume all the captured output. It is
+   * chunk_cob is guaranteed to consume all the captured output. It is
    * invoked on each readIncremental(), and also on FD release to capture
    * as-yet unread lines.  Chunks can be empty.
    */


### PR DESCRIPTION
## Summary

Fixes high-confidence text errors found by sweeping comments and Markdown docs across the repo: duplicated words and common misspellings. **Comments and documentation only — no code or behavior changes.**

Legitimate C++ tokens were deliberately left untouched (e.g. `convertible to To`, `cast from From to To`, `folly::to to check`, `in in-situ-only`), since `To`/`From` are type names, `folly::to` is a function, and `in-situ` is a hyphenated term.

## Changes

### Duplicated words

| File | Before | After |
|------|--------|-------|
| `folly/ConstructorCallbackList.h` | `that that callback code` | `that callback code` |
| `folly/Synchronized.h` | `is is nothrow-copy-constructible` | `is nothrow-copy-constructible` |
| `folly/Synchronized.h` | `passed to to *lock()` | `passed to *lock()` |
| `folly/Utility.h` | `used to to force a move` | `used to force a move` |
| `folly/Function.h` | `Why is is safe` | `Why is it safe` |
| `folly/result/rich_exception_ptr.h` | `but the the right` | `but the right` |
| `folly/memory/Allocator.h` | `which is is no longer` | `which is no longer` |
| `folly/test/StringToFloatBenchmark.cpp` | `for the the benchmark` | `for the benchmark` |
| `folly/hash/detail/ChecksumDetail.cpp` | `it is is reduced` | `it is reduced` |
| `folly/io/IOBuf.h` | `the the IOBuf's chain` | `the IOBuf's chain` |
| `folly/io/async/NotificationQueue.h` | `available on on older` | `available on older` |
| `folly/io/async/EventBase.h` | `with with no risk` | `with no risk` |
| `folly/io/async/Request.h` | `is the the same` | `is the same` |
| `folly/io/async/IoUring.h` | `member from from io_uring_cqe` | `member from io_uring_cqe` |
| `folly/io/async/AsyncSSLSocket.h` | `mimics what what` | `mimics what` |
| `folly/lang/bind/Bind.h` | `on on all the bindings` | `on all the bindings` |
| `folly/lang/bind/AsArgument.h` | `responsible for for the` | `responsible for the` |
| `folly/testing/TestUtil.h` | `is is guaranteed` | `is guaranteed` |
| `folly/container/FBVector.h` | `Note that that indeterminate` | `Note that indeterminate` |
| `folly/detail/ThreadLocalDetail.h` | `into the the elements array` | `into the elements array` |
| `folly/coro/Coroutine.h` | `with with a vtable` | `with a vtable` |
| `folly/coro/Collect.h` | `or the the exception` | `or the exception` |
| `folly/logging/xlog.h` | `then we we can detect` | `then we can detect` |
| `folly/logging/LogLevel.h` | `or to to main DBG level` | `or to main DBG level` |
| `folly/functional/Invoke.h` | `of the the specified types` | `of the specified types` |
| `folly/channels/MultiplexChannel-inl.h` | `receiver to to one or more` | `receiver to one or more` |
| `folly/ThreadCachedInt.h` | `it's fine do do a relaxed load` | `it's fine to do a relaxed load` |
| `folly/synchronization/DistributedMutex-inl.h` | `then were were not given` | `then we were not given` |
| `folly/docs/Hazptr.md` | `version of of shared-ptr` | `version of shared-ptr` |

### Misspellings

| File | Before | After |
|------|--------|-------|
| `folly/test/SocketAddressTest.cpp` | `Comparision` | `Comparison` |
| `folly/fibers/async/Async.h` | `guarentee` | `guarantee` |
| `folly/concurrency/container/RelaxedConcurrentPriorityQueue.h` | `guarentee` | `guarantee` |
| `folly/concurrency/container/RelaxedConcurrentPriorityQueue.h` | `alway` | `always` |
| `folly/io/async/AsyncTransport.h` | `successfull` | `successful` |
| `folly/io/async/SSLContext.h` | `fucntion` | `function` |
| `folly/io/async/test/EventHandlerTest.cpp` | `Specificaly` | `Specifically` |
| `folly/docs/Switch.md` | `explicitely` (3x) | `explicitly` |
| `folly/synchronization/Rcu.h` | `occuring` | `occurring` |
| `folly/observer/test/ObserverTest.cpp` | `tha hazptr-obj` | `the hazptr-obj` |
| `folly/detail/test/ThreadLocalDetailTest.cpp` | `elemnts` | `elements` |

## Verification

Inspection-only (C++ not built here). Each change was checked in context to confirm it is a genuine comment/doc typo and not a code identifier or technical term. Re-grepped after editing to confirm no remaining instances and that no code logic was modified.