### PR TITLE
container: fix heap_vector GrowthPolicy allocate_at_least override in C++20 build

### DIFF
--- a/folly/container/test/heap_vector_types_test.cpp
+++ b/folly/container/test/heap_vector_types_test.cpp
@@ -69,15 +69,19 @@ struct CountingAllocator : std::allocator<T> {
     nAllocations += 1;
     return std::allocator<T>::allocate(n);
   }
-#ifdef __cpp_lib_allocate_at_least
-  // Since C++23, std::vector allocates via allocator_traits::allocate_at_least,
-  // which std::allocator provides; without this override that inherited method
-  // would bypass the counting allocate() above and leave nAllocations at 0.
+  // std::vector may allocate via allocator_traits::allocate_at_least, which
+  // std::allocator provides; without this override that inherited method would
+  // bypass the counting allocate() above and leave nAllocations at 0. libc++
+  // (e.g. Homebrew LLVM 22) routes vector growth through allocate_at_least even
+  // in C++20 mode, so detect the base member directly rather than gating on the
+  // C++23 __cpp_lib_allocate_at_least macro, which folly's default C++20 build
+  // does not define.
+  template <typename Base = std::allocator<T>>
+    requires requires(Base& b, std::size_t n) { b.allocate_at_least(n); }
   auto allocate_at_least(std::size_t n) {
     nAllocations += 1;
     return std::allocator<T>::allocate_at_least(n);
   }
-#endif
   int nAllocations{0};
 
   template <typename U>


### PR DESCRIPTION
The previous fix (f2dfdc4a) guarded the CountingAllocator::allocate_at_least override behind #ifdef __cpp_lib_allocate_at_least, a C++23 feature-test macro. But folly's CMake build defaults to C++20 (CMakeLists.txt), so that macro is undefined and the override was compiled out entirely -- it never took effect.

Homebrew LLVM 22's libc++ provides std::allocator::allocate_at_least and routes std::vector growth through it even in C++20 mode, bypassing the counting allocate() and leaving nAllocations at 0. This is exactly the Mac CI failure at heap_vector_types_test.cpp:863/871 ("Which is: 0").

Detect the base member directly with a requires-clause instead of the C++23 macro, so the override compiles whenever std::allocator actually provides allocate_at_least, regardless of language mode. Verified counting works in both C++20 and C++23.