### PR TITLE
Modify LocalLifetime destructor to clear local cache

### DIFF
--- a/folly/SingletonThreadLocal.h
+++ b/folly/SingletonThreadLocal.h
@@ -126,7 +126,7 @@ class SingletonThreadLocal {
   using WrapperTL = ThreadLocal<Wrapper, TLTag>;
 
   struct LocalLifetime : State::LocalLifetime {
-    ~LocalLifetime() { destroy(getWrapper()); }
+    ~LocalLifetime() { getLocalCache().object = nullptr; }
   };
 
   SingletonThreadLocal() = delete;


### PR DESCRIPTION
`destroy(getWrapper())` re-enters `ThreadLocalPtr::get()` while TLS destructors are already running. This crashes sometimes, see e.g. #2002. Instead avoid re-entering `ThreadLocal` in the TLS destructor and only clears the local fast-path cache `getLocalCache().object = nullptr`, which is sufficient to prevent stale reuse.

fixes #1252 , fixes #2002 