### PR TITLE
Strip folly's own root from XLOG categories, not the outer project's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ set_property(
   APPEND
   PROPERTY
   COMPILE_DEFINITIONS
-  "FOLLY_XLOG_STRIP_PREFIXES=\"${CMAKE_SOURCE_DIR}:${CMAKE_BINARY_DIR}\""
+  "FOLLY_XLOG_STRIP_PREFIXES=\"${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_CURRENT_BINARY_DIR}\""
 )
 
 # Collect headers for installation (still needed for install step)


### PR DESCRIPTION
## Problem

The comment above this property states the intent:

> using only the relative portion of the source file name inside the folly repository

but the value is built from `CMAKE_SOURCE_DIR` / `CMAKE_BINARY_DIR`, which point at the **top-level** project. Those equal folly's own roots only when folly is the top-level build.

When folly is embedded — FetchContent, `add_subdirectory`, or any superproject — `CMAKE_SOURCE_DIR` is the consumer's root and is not a prefix of folly's source paths. `xlogStripFilename()` then strips nothing, and every folly category falls back to the full absolute `__FILE__`. Two consequences for embedded consumers:

- `--logging=folly=DBG2` and every `folly.*` selector match nothing; only the root level works.
- category names leak absolute build paths, e.g. `home.runner.work.myproject._deps.folly-src.folly.io.async.AsyncSocket`.

## Fix

Use `CMAKE_CURRENT_SOURCE_DIR` / `CMAKE_CURRENT_BINARY_DIR`. Evaluated in folly's own top-level `CMakeLists.txt`, these always resolve to folly's source and build roots regardless of how folly is embedded — and it's the same variable the surrounding `set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} …)` call already uses to scope the property.

**No behavior change when folly is the top-level project**, since `CMAKE_SOURCE_DIR == CMAKE_CURRENT_SOURCE_DIR` in that case. The change only affects builds where the current behavior is already broken.

## Test plan

- Embedded build (folly via FetchContent in a superproject): before, folly categories were the absolute `__FILE__` and `--logging=folly=DBG2` selected nothing; after, categories derive as `folly.*` and the selector scopes correctly.
- Top-level folly build: `FOLLY_XLOG_STRIP_PREFIXES` expands identically before and after.

Same class of fix as facebookexperimental/moxygen#207, which corrected the identical `CMAKE_SOURCE_DIR` assumption in moxygen's own use of this define.
