### PR TITLE
Relax MeteredExecutor state update ordering

### DIFF
--- a/folly/executors/MeteredExecutor-inl.h
+++ b/folly/executors/MeteredExecutor-inl.h
@@ -65,7 +65,7 @@ void MeteredExecutorImpl<Atom>::modifyState(F f) {
   } while (!state_.compare_exchange_strong(
       oldState,
       newState,
-      std::memory_order_seq_cst,
+      std::memory_order_relaxed,
       std::memory_order_relaxed));
 }
 


### PR DESCRIPTION
## Summary

Relax the successful `MeteredExecutorImpl::modifyState()` compare-exchange from `memory_order_seq_cst` to `memory_order_relaxed`.

`state_` is a packed bookkeeping word containing the pending-task count, pause state, and number of workers in the wrapped executor queue. Its updates require atomicity and per-object modification ordering, but do not publish task contents or synchronize unrelated memory.

Task publication is handled separately by `UMPMCQueue`, which provides its own synchronization between enqueue and dequeue.

`pause()` already updates the same `state_` word with a relaxed atomic RMW.

## Details

`modifyState()` has three callers:

- `add()`: enqueues the task first, then updates pending/worker counts
- `resume()`: clears the paused bit and reserves workers to schedule
- `worker()`: decrements pending/worker counts before dequeuing the task

None of these uses the `state_` CAS as a cross-object publication mechanism.

The initial load and failed CAS in `modifyState()` are already relaxed, so this removes the remaining unnecessary sequentially-consistent operation from the state-update path.

Related to #2656.
