### PR TITLE
symbolizer: fix DW_AT_specification offset for DW_FORM_ref_addr

### DIFF
--- a/folly/debugging/symbolizer/DwarfUtil.cpp
+++ b/folly/debugging/symbolizer/DwarfUtil.cpp
@@ -820,12 +820,29 @@ folly::StringPiece getFunctionName(
 Die findDefinitionDie(const CompilationUnit& cu, const Die& die) {
   // Find the real definition instead of declaration.
   // DW_AT_specification: Incomplete, non-defining, or separate declaration
-  // corresponding to a declaration
-  auto offset = getAttribute<uint64_t>(cu, die, DW_AT_specification);
-  if (!offset) {
+  // corresponding to a declaration.
+  //
+  // The attribute is a reference. Most reference forms (DW_FORM_ref1,
+  // DW_FORM_ref2, DW_FORM_ref4, DW_FORM_ref8, DW_FORM_ref_udata) are
+  // offsets from the first byte of the compilation unit header.
+  // DW_FORM_ref_addr is an offset from the first byte of the .debug_info
+  // section, so it must not be offset by cu.offset.
+  uint64_t offset = 0;
+  bool isRefAddr = false;
+  bool found = false;
+  forEachAttribute(cu, die, [&](const Attribute& attr) {
+    if (attr.spec.name == DW_AT_specification) {
+      offset = std::get<uint64_t>(attr.attrValue);
+      isRefAddr = attr.spec.form == DW_FORM_ref_addr;
+      found = true;
+      return false;
+    }
+    return true;
+  });
+  if (!found) {
     return die;
   }
-  return getDieAtOffset(cu, cu.offset + offset.value());
+  return getDieAtOffset(cu, isRefAddr ? offset : cu.offset + offset);
 }
 
 } // namespace symbolizer


### PR DESCRIPTION
## Summary

Fixes #2445.

`findDefinitionDie()` in `folly/debugging/symbolizer/DwarfUtil.cpp` added `cu.offset` to the `DW_AT_specification` reference value unconditionally:

```cpp
auto offset = getAttribute<uint64_t>(cu, die, DW_AT_specification);
...
return getDieAtOffset(cu, cu.offset + offset.value());
```

This is only correct for the CU-relative reference forms (`DW_FORM_ref1/2/4/8`, `DW_FORM_ref_udata`), whose values are offsets from the first byte of the compilation unit header. `DW_FORM_ref_addr` is an absolute offset from the first byte of the `.debug_info` section, so adding `cu.offset` double-counts. With a large enough `cu.offset` the resulting lookup lands past the end of `.debug_info`, triggering a `FOLLY_SAFE_CHECK(sp.size() >= sizeof(T), "underflow")` in `read()` while symbolizing — exactly what the issue reports for GCC 14 binaries.

## Fix

The existing `DW_AT_abstract_origin` handling in `DwarfImpl.cpp` already special-cases `DW_FORM_ref_addr` (lines 722-725), so this change brings `findDefinitionDie` in line with it. Since `getAttribute<uint64_t>` discards the form, the function now iterates attributes directly to keep both the value and the form:

```cpp
uint64_t offset = 0;
bool isRefAddr = false;
bool found = false;
forEachAttribute(cu, die, [&](const Attribute& attr) {
  if (attr.spec.name == DW_AT_specification) {
    offset = std::get<uint64_t>(attr.attrValue);
    isRefAddr = attr.spec.form == DW_FORM_ref_addr;
    found = true;
    return false;
  }
  return true;
});
if (!found) {
  return die;
}
return getDieAtOffset(cu, isRefAddr ? offset : cu.offset + offset);
```

CU-relative references keep the existing `cu.offset + value` behavior; `DW_FORM_ref_addr` uses the absolute offset directly.

I considered the patch suggested in the issue (subtracting `cu.offset` inside `readAttribute`), but that makes the generic attribute reader attribute-name-aware and underflows to a huge `uint64_t` when `cu.offset > rawval`. The form check in the consumer is both safer and matches how the codebase already treats `DW_AT_abstract_origin`.

## Verification

- Bug confirmed against current `main`: `findDefinitionDie` still unconditionally adds `cu.offset` (issue reporter's `readAttribute` workaround no longer matches the refactored code).
- Cross-checked the DWARF spec reference semantics against the existing correct handling of `DW_FORM_ref_addr` for `DW_AT_abstract_origin` in `DwarfImpl.cpp`.
- The common path (CU-relative forms) is byte-for-byte the same behavior as before.