### PR TITLE
Return to the EventBase loop after an internal event fires

### DIFF
--- a/folly/io/async/AsyncTimeout.cpp
+++ b/folly/io/async/AsyncTimeout.cpp
@@ -138,9 +138,23 @@ void AsyncTimeout::libeventCallback(libevent_fd_t fd, short events, void* arg) {
   // this can't possibly fire if timeout->eventBase_ is nullptr
   timeout->timeoutManager_->bumpHandlingTime();
 
-  RequestContextScopeGuard rctx(timeout->context_);
+  // Read these before running the callback, which is allowed to destroy the
+  // timeout. Folds away entirely when !kInternalEventsCanStallLoop.
+  auto* timeoutManager = timeout->timeoutManager_;
+  const bool internal =
+      kInternalEventsCanStallLoop &&
+      static_cast<bool>(
+          event_ref_flags(timeout->event_.getEvent()) & EVLIST_INTERNAL);
 
-  timeout->timeoutExpired();
+  {
+    RequestContextScopeGuard rctx(timeout->context_);
+
+    timeout->timeoutExpired();
+  }
+
+  if (internal) {
+    timeoutManager->yieldAfterInternalEvent();
+  }
 }
 
 } // namespace folly

--- a/folly/io/async/EventBase.cpp
+++ b/folly/io/async/EventBase.cpp
@@ -72,6 +72,7 @@ class EventBaseBackend : public folly::EventBaseBackendBase {
 
   int eb_event_base_loop(int flags) override;
   int eb_event_base_loopbreak() override;
+  void eb_yield_after_internal_event() override;
 
   int eb_event_add(Event& event, const struct timeval* timeout) override;
   int eb_event_del(EventBaseBackendBase::Event& event) override;
@@ -81,11 +82,19 @@ class EventBaseBackend : public folly::EventBaseBackendBase {
   bool setEdgeTriggered(Event& event) override;
 
  private:
+  void initYieldEvent();
+
+  static void yieldCallback(folly::libevent_fd_t, short, void*) {}
+
   event_base* evb_;
+  // See eb_yield_after_internal_event(). Assigned but deliberately never
+  // added, so it costs nothing until it is activated.
+  struct event yieldEvent_;
 };
 
 EventBaseBackend::EventBaseBackend() {
   evb_ = event_base_new();
+  initYieldEvent();
 }
 
 EventBaseBackend::EventBaseBackend(event_base* evb) : evb_(evb) {
@@ -93,6 +102,12 @@ EventBaseBackend::EventBaseBackend(event_base* evb) : evb_(evb) {
     LOG(ERROR) << "EventBase(): Pass nullptr as event base.";
     throw std::invalid_argument("EventBase(): event base cannot be nullptr");
   }
+  initYieldEvent();
+}
+
+void EventBaseBackend::initYieldEvent() {
+  event_set(&yieldEvent_, -1, 0, &EventBaseBackend::yieldCallback, nullptr);
+  event_base_set(evb_, &yieldEvent_);
 }
 
 int EventBaseBackend::eb_event_base_loop(int flags) {
@@ -101,6 +116,24 @@ int EventBaseBackend::eb_event_base_loop(int flags) {
 
 int EventBaseBackend::eb_event_base_loopbreak() {
   return event_base_loopbreak(evb_);
+}
+
+void EventBaseBackend::eb_yield_after_internal_event() {
+  // Callers gate on kInternalEventsCanStallLoop, so this is only reached on
+  // the libevent versions that need it.
+  //
+  // Activating a non-internal event is what makes the dispatch count as work,
+  // so event_base_loop() exits EVLOOP_ONCE after finishing the events it has
+  // already made active. That matches what libevent 1.4 does, and what the
+  // EventBase loop expects. Activating an assigned but never added event is
+  // libevent's own idiom for scheduling an immediate callback, used by
+  // event_base_once(); because it is never added it does not count towards
+  // event_haveevents(), so it cannot keep loop() alive.
+  //
+  // loopbreak() would be marginally cheaper but returns without running the
+  // rest of this dispatch, and loopexit() allocates, going through
+  // event_base_once().
+  event_active(&yieldEvent_, EV_TIMEOUT, 1);
 }
 
 int EventBaseBackend::eb_event_add(
@@ -856,6 +889,19 @@ void EventBase::bumpHandlingTime() {
 
     VLOG(11) << "EventBase " << this << " " << __PRETTY_FUNCTION__
              << " (loop) startWork_ " << startWork_.time_since_epoch().count();
+  }
+}
+
+void EventBase::yieldAfterInternalEvent() {
+  // Reached only from an event callback, so the loop thread. Both the
+  // loopCallbacks_ read and what the backend does with this are unsynchronized
+  // and rely on that.
+  dcheckIsInEventBaseThread();
+  // Nothing to return to the loop for if the callback did not leave any work
+  // behind, and the backends that need this are the ones where returning is
+  // not free.
+  if (!loopCallbacks_.empty()) {
+    evb_->eb_yield_after_internal_event();
   }
 }
 

--- a/folly/io/async/EventBase.h
+++ b/folly/io/async/EventBase.h
@@ -835,6 +835,18 @@ class EventBase
    */
   void bumpHandlingTime() final;
 
+  /**
+   * Give the loop a chance to return from the backend after an internal
+   * event's callback was dispatched, so that any loop callback it scheduled
+   * runs before the loop blocks again.
+   *
+   * Called from the internal event dispatch paths (EventHandler and
+   * AsyncTimeout); there is no reason for user code to call this.
+   *
+   * See EventBaseBackendBase::eb_yield_after_internal_event().
+   */
+  void yieldAfterInternalEvent() final;
+
   class SmoothLoopTime {
    public:
     explicit SmoothLoopTime(std::chrono::microseconds timeInterval)

--- a/folly/io/async/EventBaseBackendBase.h
+++ b/folly/io/async/EventBaseBackendBase.h
@@ -29,6 +29,25 @@ namespace folly {
 class EventBase;
 class EventBaseBackendBase;
 
+// Whether dispatching a callback for an internal event can leave the backend
+// loop blocked instead of returning to the EventBase loop.
+//
+// libevent 0617a818 "Make EVLOOP_ONCE ignore internal events", first released
+// in 2.0.9-rc, made event_base_loop() exit EVLOOP_ONCE only if it ran a
+// callback on a non-internal event; before it, and in 1.4, the loop exits once
+// the active queue drains, whichever events ran. LIBEVENT_VERSION_NUMBER is
+// itself the 2.0 boundary: 1.4 does not define it, only
+// _EVENT_NUMERIC_VERSION.
+//
+// This is the only place the version is tested. Where it is false the checks
+// guarding eb_yield_after_internal_event() fold away entirely.
+inline constexpr bool kInternalEventsCanStallLoop =
+#if defined(LIBEVENT_VERSION_NUMBER) && LIBEVENT_VERSION_NUMBER >= 0x02000900
+    true;
+#else
+    false;
+#endif
+
 class EventBaseEvent {
  public:
   EventBaseEvent() = default;
@@ -153,6 +172,16 @@ class EventBaseBackendBase {
   virtual event_base* getEventBase() = 0;
   virtual int eb_event_base_loop(int flags) = 0;
   virtual int eb_event_base_loopbreak() = 0;
+
+  // Called after dispatching the callback of an internal event, when the
+  // EventBase needs the loop to return so it can run the loop callbacks that
+  // callback scheduled. Only called when kInternalEventsCanStallLoop.
+  //
+  // EventBase's loop assumes eb_event_base_loop(EVLOOP_ONCE) returns after
+  // dispatching anything, which is why only the libevent backend overrides
+  // this: the default is a no-op, correct for any backend that returns after
+  // dispatching, internal or not.
+  virtual void eb_yield_after_internal_event() {}
 
   virtual int eb_event_add(Event& event, const struct timeval* timeout) = 0;
   virtual int eb_event_del(Event& event) = 0;

--- a/folly/io/async/EventHandler.cpp
+++ b/folly/io/async/EventHandler.cpp
@@ -151,13 +151,27 @@ void EventHandler::libeventCallback(libevent_fd_t fd, short events, void* arg) {
   // this can't possibly fire if handler->eventBase_ is nullptr
   handler->eventBase_->bumpHandlingTime();
 
-  RequestContextSaverScopeGuard rctxGuard;
-  ExecutionObserverScopeGuard guard(
-      &handler->eventBase_->getExecutionObserverList(),
-      &handler->eventBase_,
-      folly::ExecutionObserver::CallbackType::Event);
+  // Read these before running the callback, which is allowed to destroy the
+  // handler. Folds away entirely when !kInternalEventsCanStallLoop.
+  auto* eventBase = handler->eventBase_;
+  const bool internal =
+      kInternalEventsCanStallLoop &&
+      static_cast<bool>(
+          folly::event_ref_flags(handler->event_.getEvent()) & EVLIST_INTERNAL);
 
-  handler->handlerReady(uint16_t(events));
+  {
+    RequestContextSaverScopeGuard rctxGuard;
+    ExecutionObserverScopeGuard guard(
+        &handler->eventBase_->getExecutionObserverList(),
+        &handler->eventBase_,
+        folly::ExecutionObserver::CallbackType::Event);
+
+    handler->handlerReady(uint16_t(events));
+  }
+
+  if (internal) {
+    eventBase->yieldAfterInternalEvent();
+  }
 }
 
 void EventHandler::setEventBase(EventBase* eventBase) {

--- a/folly/io/async/TimeoutManager.h
+++ b/folly/io/async/TimeoutManager.h
@@ -80,6 +80,15 @@ class TimeoutManager {
   virtual bool isInTimeoutManagerThread() = 0;
 
   /**
+   * Called after dispatching the callback of an event registered as internal,
+   * to give the manager a chance to regain control of its loop. Managers that
+   * always regain it need not do anything.
+   *
+   * See EventBaseBackendBase::eb_yield_after_internal_event().
+   */
+  virtual void yieldAfterInternalEvent() {}
+
+  /**
    * Runs the given Cob at some time after the specified number of
    * milliseconds.  (No guarantees exactly when.)
    *

--- a/folly/io/async/test/EventBaseTestLib.h
+++ b/folly/io/async/test/EventBaseTestLib.h
@@ -2787,6 +2787,56 @@ TYPED_TEST_P(EventBaseTest, LoopRearmsNotificationQueue) {
   EXPECT_EQ(evbPtr->getNumLoopCallbacks(), 0);
 }
 
+TYPED_TEST_P(EventBaseTest, LoopRearmsNotificationQueueWhileBlocked) {
+  auto evbPtr = this->makeEventBase();
+  auto& evb = *evbPtr;
+
+  // A registered non-internal event that never fires, so that the loop blocks
+  // in the backend instead of exiting for lack of events, which would drain
+  // the notification queue on the way out and hide the problem.
+  SocketPair sp;
+  struct IdleHandler : public EventHandler {
+    IdleHandler(EventBase* eb, int fd)
+        : EventHandler(eb, NetworkSocket::fromFd(fd)) {}
+    void handlerReady(uint16_t) noexcept override {}
+  };
+  IdleHandler idle(&evb, sp[0]);
+  ASSERT_TRUE(idle.registerHandler(EventHandler::READ | EventHandler::PERSIST));
+
+  // Keep the first iterations non-blocking, so that the wakeup that
+  // startConsuming() writes to the queue fd is consumed and the queue is
+  // rearmed before the loop settles. Without this the loop can wedge during
+  // startup and never reach the state under test here.
+  Baton<> up;
+  evb.runInLoop([&] { up.post(); });
+
+  // loop(), with no keepalive held, registers the notification queue as an
+  // internal event.
+  std::thread t([&] { evb.loop(); });
+  up.wait();
+  // Let the loop settle into a blocking dispatch.
+  /* sleep override */ std::this_thread::sleep_for(
+      std::chrono::milliseconds(100));
+
+  // Delivering the first task disarms the queue and defers the rearm to a loop
+  // callback. If the loop does not regain control to run that callback, the
+  // queue stays disarmed and no later producer writes the wakeup fd, so the
+  // second task is lost forever.
+  for (size_t i = 0; i < 2; ++i) {
+    Baton<> done;
+    evb.runInEventBaseThread([&] { done.post(); });
+    EXPECT_TRUE(done.try_wait_for(std::chrono::seconds(30)))
+        << "task " << i << " was never delivered";
+  }
+
+  evb.terminateLoopSoon();
+  // Wake the loop through the non-internal event too, so that it observes the
+  // stop request even if the notification queue is stuck, that is, when this
+  // test is failing.
+  writeToFD(sp[1], 1);
+  t.join();
+}
+
 TYPED_TEST_P(EventBaseTest, GetThreadIdCollector) {
   auto evbPtr = this->makeEventBase();
   auto* collector = evbPtr->getThreadIdCollector();
@@ -3132,6 +3182,7 @@ REGISTER_TYPED_TEST_SUITE_P(
     LastLoopKeepAliveTriggeringDestruction,
     EventBaseObserver,
     LoopRearmsNotificationQueue,
+    LoopRearmsNotificationQueueWhileBlocked,
     GetThreadIdCollector,
     Suspension,
     DrivableExecutorTest,


### PR DESCRIPTION
Summary:
Since libevent 2.0.9, `event_base_loop` in `EVLOOP_ONCE` mode only returns once
it has run a callback for an event that is not marked internal. EventBase
registers its notification queue as an internal event whenever nothing is
holding a keepalive. Delivering a task disarms that queue and leaves the rearm
to a loop callback, so if the loop stays parked inside the backend the rearm
never runs, and every task queued after that is silently dropped.

The internal event dispatch paths now ask the backend to hand control back
whenever the callback left loop callbacks behind, and the libevent backend does
that by activating a dummy event. Anything older exits `EVLOOP_ONCE` as soon as
the active queue drains, whichever events ran, so it never had the problem. The
gate is a compile-time constant off the libevent version, which makes this a
no-op before 2.0.9 — including the 1.4 that fbcode pins, where the new code
folds away entirely.

Reviewed By: yfeldblum

Differential Revision: D116567667


