### PR TITLE
Guard IOBuf coalesce capacity against integer overflow (re-land e59a396b + 51b3a7f1)

### DIFF
--- a/folly/io/IOBuf.cpp
+++ b/folly/io/IOBuf.cpp
@@ -860,7 +860,11 @@ IOBuf IOBuf::cloneCoalescedAsValueWithHeadroomTailroom(
 
   // Coalesce into newBuf
   const std::size_t newLength = computeChainDataLength();
-  const std::size_t newCapacity = newLength + newHeadroom + newTailroom;
+  std::size_t newCapacity = 0;
+  if (!checked_add(&newCapacity, newLength, newHeadroom, newTailroom) ||
+      newCapacity > kMaxIOBufSize) {
+    throw_exception<std::bad_alloc>();
+  }
   IOBuf newBuf{CREATE, newCapacity};
   newBuf.advance(newHeadroom);
 
@@ -1040,7 +1044,11 @@ void IOBuf::coalesceSlow(size_t maxLength) {
 
 void IOBuf::coalesceAndReallocate(
     size_t newHeadroom, size_t newLength, IOBuf* end, size_t newTailroom) {
-  std::size_t newCapacity = newLength + newHeadroom + newTailroom;
+  std::size_t newCapacity = 0;
+  if (!checked_add(&newCapacity, newLength, newHeadroom, newTailroom) ||
+      newCapacity > kMaxIOBufSize) {
+    throw_exception<std::bad_alloc>();
+  }
 
   // Allocate space for the coalesced buffer.
   // We always convert to an external buffer, even if we happened to be an

--- a/folly/io/test/IOBufTest.cpp
+++ b/folly/io/test/IOBufTest.cpp
@@ -1576,6 +1576,35 @@ TEST(IOBuf, CoalesceEmptyBuffers) {
   EXPECT_TRUE(ByteRange(StringPiece("hello")) == br);
 }
 
+// A chain whose coalesced capacity (length + newHeadroom + newTailroom)
+// overflows size_t must throw std::bad_alloc rather than wrapping around to a
+// small capacity, allocating an undersized buffer, and overflowing it while
+// copying the data.
+TEST(IOBuf, CoalesceCapacityOverflow) {
+  auto head = fromStr("hello");
+  head->insertAfterThisOne(fromStr("world"));
+  ASSERT_TRUE(head->isChained());
+
+  constexpr auto kMax = std::numeric_limits<std::size_t>::max();
+  EXPECT_THROW(head->coalesceWithHeadroomTailroom(kMax, kMax), std::bad_alloc);
+}
+
+// cloneCoalescedAsValueWithHeadroomTailroom (and the unique_ptr wrapper that
+// forwards to it) must throw std::bad_alloc when the coalesced capacity
+// overflows size_t rather than wrapping around to an undersized buffer.
+TEST(IOBuf, CloneCoalescedCapacityOverflow) {
+  auto head = fromStr("hello");
+  head->insertAfterThisOne(fromStr("world"));
+  ASSERT_TRUE(head->isChained());
+
+  constexpr auto kMax = std::numeric_limits<std::size_t>::max();
+  EXPECT_THROW(
+      head->cloneCoalescedWithHeadroomTailroom(kMax, kMax), std::bad_alloc);
+  EXPECT_THROW(
+      head->cloneCoalescedAsValueWithHeadroomTailroom(kMax, kMax),
+      std::bad_alloc);
+}
+
 TEST(IOBuf, CloneCoalescedChain) {
   auto b = IOBuf::createChain(1000, 100);
   b->advance(10);


### PR DESCRIPTION
Re-lands the checked_add + kMaxIOBufSize guards from e59a396b (D116335797) and 51b3a7f1 (D116669664) — reverted on 2026-08-21 (78ea997c, cebec52, task S698837) — and restores the two regression tests removed with them (`TEST(IOBuf, CoalesceCapacityOverflow)`, `TEST(IOBuf, CloneCoalescedCapacityOverflow)`).

**Why:** on current main, `newLength + newHeadroom + newTailroom` is an unchecked `size_t` sum in both `coalesceAndReallocate` (folly/io/IOBuf.cpp:1043) and `cloneCoalescedAsValueWithHeadroomTailroom` (:863). When the sum wraps through the public wrappers (`coalesceWithHeadroomTailroom` / `cloneCoalesced*WithHeadroomTailroom`), `newCapacity` lands on a small value that passes the `kMaxIOBufSize` check; the buffer is under-allocated and the subsequent copy overflows it. This restores parity with the copy constructor, `reserveSlow`, `create`, and `takeOwnership`, which already use checked_add + kMaxIOBufSize.

**Verification** (standalone harness building the patched TUs against a fresh main checkout — full cmake suite left to CI):
- macOS (arm64, clang -O1 -DNDEBUG): all checks pass — both restored tests throw `std::bad_alloc` as asserted; wrap-to-8 (SIZE_MAX pair) and wrap-to-1 (64 KiB chain, `newTailroom = SIZE_MAX - len + 2`) geometries both now throw; normal coalescing preserved (size/headroom/tailroom honored); oversize-but-not-wrapping rejected.
- Linux (ubuntu-latest, clang -O1): same 7/7 pass — https://github.com/shaggyinsomniac/meta-bounty-poc/actions/runs/33181002285 (workflow applies this exact patch to a fresh clone and runs the checks).
- Pre-patch behavior for contrast (ASAN on unpatched main): heap-buffer-overflow WRITE of size 1024 in `coalesceAndReallocate` (IOBuf.cpp:1063) — logs linked in #2686.

If the reverts were intentional under S698837, feel free to close this — a comment on the unchecked line referencing the task would prevent future confusion either way. Happy to adjust (guard placement, error type, test placement) however maintainers prefer.

Fixes #2686