### PR TITLE
] F14VectorMap::iterator should be random access (Do not merge SAFE_CHECK) (#2689)

### DIFF
--- a/folly/container/BUCK
+++ b/folly/container/BUCK
@@ -207,6 +207,12 @@ fb_dirsync_cpp_library(
 )
 
 fb_dirsync_cpp_library(
+    name = "reverse_iterator",
+    headers = ["reverse_iterator.h"],
+    use_raw_headers = True,
+)
+
+fb_dirsync_cpp_library(
     name = "bit_iterator",
     headers = ["BitIterator.h"],
     use_raw_headers = True,

--- a/folly/container/CMakeLists.txt
+++ b/folly/container/CMakeLists.txt
@@ -295,6 +295,12 @@ folly_add_library(
 )
 
 folly_add_library(
+  NAME reverse_iterator
+  HEADERS
+    reverse_iterator.h
+)
+
+folly_add_library(
   NAME small_vector
   HEADERS
     small_vector.h

--- a/folly/container/F14Map.h
+++ b/folly/container/F14Map.h
@@ -1569,6 +1569,7 @@ class F14VectorMapImpl
   template <typename BeforeDestroy>
   FOLLY_ALWAYS_INLINE iterator
   eraseInto(const_iterator pos, BeforeDestroy&& beforeDestroy) {
+    FOLLY_SAFE_CHECK(pos != cend(), "erase() of a past-the-end iterator");
     auto index = this->table_.iterToIndex(pos);
     auto underlying = this->table_.find(VectorContainerIndexSearch{index});
     eraseUnderlying(underlying, beforeDestroy);
@@ -1724,14 +1725,22 @@ class F14VectorMap
 
   /// Explicit conversions between iterator and reverse_iterator
   /// @methodset Iterators
-  iterator iter(reverse_iterator riter) { return this->table_.iter(riter); }
+  iterator iter(reverse_iterator riter) {
+    FOLLY_SAFE_CHECK(riter != rend(), "iter() of rend()");
+    return this->table_.iter(riter);
+  }
   const_iterator iter(const_reverse_iterator riter) const {
+    FOLLY_SAFE_CHECK(riter != crend(), "iter() of rend()");
     return this->table_.iter(riter);
   }
 
   /// @copydoc iter
-  reverse_iterator riter(iterator it) { return this->table_.riter(it); }
+  reverse_iterator riter(iterator it) {
+    FOLLY_SAFE_CHECK(it != this->end(), "riter() of end()");
+    return this->table_.riter(it);
+  }
   const_reverse_iterator riter(const_iterator it) const {
+    FOLLY_SAFE_CHECK(it != this->cend(), "riter() of end()");
     return this->table_.riter(it);
   }
 

--- a/folly/container/F14Map.h
+++ b/folly/container/F14Map.h
@@ -1569,11 +1569,12 @@ class F14VectorMapImpl
   template <typename BeforeDestroy>
   FOLLY_ALWAYS_INLINE iterator
   eraseInto(const_iterator pos, BeforeDestroy&& beforeDestroy) {
-    FOLLY_SAFE_CHECK(pos != cend(), "erase() of a past-the-end iterator");
+    FOLLY_SAFE_DCHECK(
+        cbegin() <= pos && pos < cend(), "erase() of an invalid iterator");
     auto index = this->table_.iterToIndex(pos);
     auto underlying = this->table_.find(VectorContainerIndexSearch{index});
     eraseUnderlying(underlying, beforeDestroy);
-    return index == 0 ? end() : this->table_.indexToIter(index - 1);
+    return this->table_.indexToIter(index - 1);
   }
 
   // This form avoids ambiguity when key_type has a templated constructor
@@ -1594,8 +1595,7 @@ class F14VectorMapImpl
     while (first != last) {
       first = eraseInto(first, beforeDestroy);
     }
-    auto index = this->table_.iterToIndex(first);
-    return index == 0 ? end() : this->table_.indexToIter(index - 1);
+    return begin() + (first - cbegin());
   }
 
   /// Callback-erase a specific key.
@@ -1726,22 +1726,30 @@ class F14VectorMap
   /// Explicit conversions between iterator and reverse_iterator
   /// @methodset Iterators
   iterator iter(reverse_iterator riter) {
-    FOLLY_SAFE_CHECK(riter != rend(), "iter() of rend()");
-    return this->table_.iter(riter);
+    FOLLY_SAFE_DCHECK(
+        rbegin() <= riter && riter < rend(),
+        "iter() of an invalid reverse_iterator");
+    return iterator{riter + 1};
   }
   const_iterator iter(const_reverse_iterator riter) const {
-    FOLLY_SAFE_CHECK(riter != crend(), "iter() of rend()");
-    return this->table_.iter(riter);
+    FOLLY_SAFE_DCHECK(
+        crbegin() <= riter && riter < crend(),
+        "iter() of an invalid reverse_iterator");
+    return const_iterator{riter + 1};
   }
 
   /// @copydoc iter
   reverse_iterator riter(iterator it) {
-    FOLLY_SAFE_CHECK(it != this->end(), "riter() of end()");
-    return this->table_.riter(it);
+    FOLLY_SAFE_DCHECK(
+        this->begin() <= it && it < this->end(),
+        "riter() of an invalid iterator");
+    return it.base() - 1;
   }
   const_reverse_iterator riter(const_iterator it) const {
-    FOLLY_SAFE_CHECK(it != this->cend(), "riter() of end()");
-    return this->table_.riter(it);
+    FOLLY_SAFE_DCHECK(
+        this->cbegin() <= it && it < this->cend(),
+        "riter() of an invalid iterator");
+    return it.base() - 1;
   }
 
   friend Range<const_reverse_iterator> tag_invoke(

--- a/folly/container/F14Set.h
+++ b/folly/container/F14Set.h
@@ -1185,7 +1185,8 @@ class F14VectorSetImpl
   template <typename BeforeDestroy>
   FOLLY_ALWAYS_INLINE iterator
   eraseInto(const_iterator pos, BeforeDestroy&& beforeDestroy) {
-    FOLLY_SAFE_CHECK(pos != cend(), "erase() of a past-the-end iterator");
+    FOLLY_SAFE_DCHECK(
+        cbegin() <= pos && pos < cend(), "erase() of an invalid iterator");
     auto underlying = this->table_.find(
         VectorContainerIndexSearch{this->table_.iterToIndex(pos)});
     eraseUnderlying(underlying, beforeDestroy);
@@ -1291,21 +1292,29 @@ class F14VectorSet
 
   // explicit conversions between iterator and reverse_iterator
   iterator iter(reverse_iterator riter) {
-    FOLLY_SAFE_CHECK(riter != rend(), "iter() of rend()");
-    return this->table_.iter(riter);
+    FOLLY_SAFE_DCHECK(
+        rbegin() <= riter && riter < rend(),
+        "iter() of an invalid reverse_iterator");
+    return iterator{riter + 1};
   }
   const_iterator iter(const_reverse_iterator riter) const {
-    FOLLY_SAFE_CHECK(riter != crend(), "iter() of rend()");
-    return this->table_.iter(riter);
+    FOLLY_SAFE_DCHECK(
+        crbegin() <= riter && riter < crend(),
+        "iter() of an invalid reverse_iterator");
+    return const_iterator{riter + 1};
   }
 
   reverse_iterator riter(iterator it) {
-    FOLLY_SAFE_CHECK(it != this->end(), "riter() of end()");
-    return this->table_.riter(it);
+    FOLLY_SAFE_DCHECK(
+        this->begin() <= it && it < this->end(),
+        "riter() of an invalid iterator");
+    return it.base() - 1;
   }
   const_reverse_iterator riter(const_iterator it) const {
-    FOLLY_SAFE_CHECK(it != this->cend(), "riter() of end()");
-    return this->table_.riter(it);
+    FOLLY_SAFE_DCHECK(
+        this->cbegin() <= it && it < this->cend(),
+        "riter() of an invalid iterator");
+    return it.base() - 1;
   }
 
   friend Range<const_reverse_iterator> tag_invoke(

--- a/folly/container/F14Set.h
+++ b/folly/container/F14Set.h
@@ -1185,6 +1185,7 @@ class F14VectorSetImpl
   template <typename BeforeDestroy>
   FOLLY_ALWAYS_INLINE iterator
   eraseInto(const_iterator pos, BeforeDestroy&& beforeDestroy) {
+    FOLLY_SAFE_CHECK(pos != cend(), "erase() of a past-the-end iterator");
     auto underlying = this->table_.find(
         VectorContainerIndexSearch{this->table_.iterToIndex(pos)});
     eraseUnderlying(underlying, beforeDestroy);
@@ -1289,13 +1290,21 @@ class F14VectorSet
   }
 
   // explicit conversions between iterator and reverse_iterator
-  iterator iter(reverse_iterator riter) { return this->table_.iter(riter); }
+  iterator iter(reverse_iterator riter) {
+    FOLLY_SAFE_CHECK(riter != rend(), "iter() of rend()");
+    return this->table_.iter(riter);
+  }
   const_iterator iter(const_reverse_iterator riter) const {
+    FOLLY_SAFE_CHECK(riter != crend(), "iter() of rend()");
     return this->table_.iter(riter);
   }
 
-  reverse_iterator riter(iterator it) { return this->table_.riter(it); }
+  reverse_iterator riter(iterator it) {
+    FOLLY_SAFE_CHECK(it != this->end(), "riter() of end()");
+    return this->table_.riter(it);
+  }
   const_reverse_iterator riter(const_iterator it) const {
+    FOLLY_SAFE_CHECK(it != this->cend(), "riter() of end()");
     return this->table_.riter(it);
   }
 

--- a/folly/container/detail/BUCK
+++ b/folly/container/detail/BUCK
@@ -60,6 +60,7 @@ fb_dirsync_cpp_library(
         "//folly:traits",
         "//folly:unit",
         "//folly/container:heterogeneous_access",
+        "//folly/container:reverse_iterator",
         "//folly/functional:invoke",
         "//folly/hash:hash",
         "//folly/lang:align",

--- a/folly/container/detail/CMakeLists.txt
+++ b/folly/container/detail/CMakeLists.txt
@@ -54,6 +54,7 @@ folly_add_library(
     folly_container_detail_f14_mask
     folly_container_detail_util
     folly_container_heterogeneous_access
+    folly_container_reverse_iterator
     folly_functional_invoke
     folly_hash_hash
     folly_lang_align

--- a/folly/container/detail/F14Policy.h
+++ b/folly/container/detail/F14Policy.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <memory>
 #include <new>
 #include <type_traits>
@@ -27,6 +28,7 @@
 #include <folly/Unit.h>
 #include <folly/container/HeterogeneousAccess.h>
 #include <folly/container/detail/F14Table.h>
+#include <folly/container/reverse_iterator.h>
 #include <folly/hash/Hash.h>
 #include <folly/lang/Align.h>
 #include <folly/lang/Exception.h>
@@ -923,76 +925,9 @@ template <
     typename EligibleForPerturbedInsertionOrder>
 class VectorContainerPolicy;
 
+// Iteration is LIFO: the last value in values_ is the first one visited.
 template <typename ValuePtr>
-class VectorContainerIterator : public BaseIter<ValuePtr, uint32_t> {
-  using Super = BaseIter<ValuePtr, uint32_t>;
-  using ValueConstPtr = typename Super::ValueConstPtr;
-
- public:
-  using pointer = typename Super::pointer;
-  using reference = typename Super::reference;
-  using value_type = typename Super::value_type;
-
-  VectorContainerIterator() = default;
-  VectorContainerIterator(VectorContainerIterator const&) = default;
-  VectorContainerIterator(VectorContainerIterator&&) = default;
-  VectorContainerIterator& operator=(VectorContainerIterator const&) = default;
-  VectorContainerIterator& operator=(VectorContainerIterator&&) = default;
-  ~VectorContainerIterator() = default;
-
-  /*implicit*/ operator VectorContainerIterator<ValueConstPtr>() const {
-    return VectorContainerIterator<ValueConstPtr>{current_, lowest_};
-  }
-
-  reference operator*() const { return *current_; }
-
-  pointer operator->() const { return current_; }
-
-  VectorContainerIterator& operator++() {
-    if (FOLLY_UNLIKELY(current_ == lowest_)) {
-      current_ = nullptr;
-    } else {
-      --current_;
-    }
-    return *this;
-  }
-
-  VectorContainerIterator operator++(int) {
-    auto cur = *this;
-    ++*this;
-    return cur;
-  }
-
-  friend bool operator==(
-      VectorContainerIterator const& lhs, VectorContainerIterator const& rhs) {
-    return lhs.current_ == rhs.current_;
-  }
-  friend bool operator!=(
-      VectorContainerIterator const& lhs, VectorContainerIterator const& rhs) {
-    return !(lhs == rhs);
-  }
-
- private:
-  ValuePtr current_;
-  ValuePtr lowest_;
-
-  explicit VectorContainerIterator(ValuePtr current, ValuePtr lowest)
-      : current_(current), lowest_(lowest) {}
-
-  std::size_t index() const { return current_ - lowest_; }
-
-  template <
-      typename K,
-      typename M,
-      typename H,
-      typename E,
-      typename A,
-      typename P>
-  friend class VectorContainerPolicy;
-
-  template <typename P>
-  friend class VectorContainerIterator;
-};
+using VectorContainerIterator = folly::reverse_iterator<ValuePtr>;
 
 struct VectorContainerIndexSearch {
   uint32_t index_;
@@ -1455,13 +1390,10 @@ class VectorContainerPolicy
 
   // Iterator stuff
 
-  Iter linearBegin(std::size_t size) const {
-    return size > 0
-        ? Iter{values_ + size - 1, values_}
-        : Iter{nullptr, nullptr};
-  }
+  // Iter is a reverse_iterator.
+  Iter linearBegin(std::size_t size) const { return Iter{values_ + size}; }
 
-  Iter linearEnd() const { return Iter{nullptr, nullptr}; }
+  Iter linearEnd() const { return Iter{values_}; }
 
   //////// F14BasicMap/Set policy
 
@@ -1469,9 +1401,8 @@ class VectorContainerPolicy
     if (underlying.atEnd()) {
       return linearEnd();
     } else {
-      assume(values_ + underlying.item() != nullptr);
       assume(values_ != nullptr);
-      return Iter{values_ + underlying.item(), values_};
+      return indexToIter(underlying.item());
     }
   }
 
@@ -1479,21 +1410,17 @@ class VectorContainerPolicy
     return makeIter(underlying);
   }
 
+  // Conversions between Iter (a reverse_iterator) and an index into values_.
+  // Item is used directly as values_[index] and base() is one past the
+  // element, hence the -1. So end() maps to Item(-1) == max(), never a live
+  // subscript, and indexToIter wraps it back to end().
   Item iterToIndex(ConstIter const& iter) const {
-    auto n = iter.index();
-    assume(n <= std::numeric_limits<Item>::max());
-    return static_cast<Item>(n);
+    return static_cast<Item>(iter.base() - values_ - 1);
   }
 
-  Iter indexToIter(Item index) const { return Iter{values_ + index, values_}; }
-
-  Iter iter(ReverseIter it) { return Iter{it, values_}; }
-
-  ConstIter iter(ConstReverseIter it) const { return ConstIter{it, values_}; }
-
-  ReverseIter riter(Iter it) { return it.current_; }
-
-  ConstReverseIter riter(ConstIter it) const { return it.current_; }
+  Iter indexToIter(Item index) const {
+    return Iter{values_ + static_cast<Item>(index + 1)};
+  }
 
   ValuePtr values_{nullptr};
 };

--- a/folly/container/reverse_iterator.h
+++ b/folly/container/reverse_iterator.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <concepts>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace folly {
+
+/**
+ * folly::reverse_iterator
+ *
+ * Same semantics as std::reverse_iterator, but it reports triviality
+ * correctly. Both libstdc++ and libc++ user-provide the copy constructor of
+ * std::reverse_iterator, so std::is_trivially_copyable_v is false even when
+ * the underlying iterator is a raw pointer. Here every special member is
+ * implicitly defaulted, so triviality follows the underlying iterator.
+ */
+template <typename Iter>
+class reverse_iterator {
+  using traits = std::iterator_traits<Iter>;
+
+  template <typename>
+  friend class reverse_iterator;
+
+ public:
+  using iterator_type = Iter;
+  using value_type = typename traits::value_type;
+  using difference_type = typename traits::difference_type;
+  using pointer = typename traits::pointer;
+  using reference = typename traits::reference;
+  // Reversing never yields more than random access, even over a contiguous
+  // iterator.
+  using iterator_category = std::conditional_t<
+      std::is_convertible_v<
+          typename traits::iterator_category,
+          std::random_access_iterator_tag>,
+      std::random_access_iterator_tag,
+      typename traits::iterator_category>;
+  using iterator_concept = std::conditional_t<
+      std::random_access_iterator<Iter>,
+      std::random_access_iterator_tag,
+      std::bidirectional_iterator_tag>;
+
+  constexpr reverse_iterator() = default;
+
+  explicit constexpr reverse_iterator(Iter it) noexcept(
+      std::is_nothrow_move_constructible_v<Iter>)
+      : current_{std::move(it)} {}
+
+  template <typename OtherIter>
+    requires(
+        !std::is_same_v<OtherIter, Iter> &&
+        std::convertible_to<const OtherIter&, Iter>)
+  /* implicit */ constexpr reverse_iterator(
+      const reverse_iterator<OtherIter>& other)
+      : current_{other.current_} {}
+
+  template <typename OtherIter>
+    requires(
+        !std::is_same_v<OtherIter, Iter> &&
+        std::convertible_to<const OtherIter&, Iter> &&
+        std::assignable_from<Iter&, const OtherIter&>)
+  constexpr reverse_iterator& operator=(
+      const reverse_iterator<OtherIter>& other) {
+    current_ = other.current_;
+    return *this;
+  }
+
+  constexpr Iter base() const { return current_; }
+
+  constexpr reference operator*() const {
+    Iter tmp = current_;
+    return *--tmp;
+  }
+
+  constexpr pointer operator->() const
+    requires(
+        std::is_pointer_v<Iter> || requires(const Iter i) { i.operator->(); })
+  {
+    Iter tmp = current_;
+    --tmp;
+    if constexpr (std::is_pointer_v<Iter>) {
+      return tmp;
+    } else {
+      return tmp.operator->();
+    }
+  }
+
+  constexpr reference operator[](difference_type n) const {
+    return *(*this + n);
+  }
+
+  constexpr reverse_iterator& operator++() {
+    --current_;
+    return *this;
+  }
+
+  constexpr reverse_iterator operator++(int) {
+    reverse_iterator tmp = *this;
+    --current_;
+    return tmp;
+  }
+
+  constexpr reverse_iterator& operator--() {
+    ++current_;
+    return *this;
+  }
+
+  constexpr reverse_iterator operator--(int) {
+    reverse_iterator tmp = *this;
+    ++current_;
+    return tmp;
+  }
+
+  constexpr reverse_iterator& operator+=(difference_type n) {
+    current_ -= n;
+    return *this;
+  }
+
+  constexpr reverse_iterator& operator-=(difference_type n) {
+    current_ += n;
+    return *this;
+  }
+
+  constexpr reverse_iterator operator+(difference_type n) const {
+    return reverse_iterator{current_ - n};
+  }
+
+  constexpr reverse_iterator operator-(difference_type n) const {
+    return reverse_iterator{current_ + n};
+  }
+
+  friend constexpr reverse_iterator operator+(
+      difference_type n, const reverse_iterator& it) {
+    return it + n;
+  }
+
+ private:
+  Iter current_{};
+};
+
+template <typename Iter>
+reverse_iterator(Iter) -> reverse_iterator<Iter>;
+
+template <typename Iter1, typename Iter2>
+constexpr bool operator==(
+    const reverse_iterator<Iter1>& a, const reverse_iterator<Iter2>& b) {
+  return a.base() == b.base();
+}
+
+template <typename Iter1, typename Iter2>
+constexpr bool operator<(
+    const reverse_iterator<Iter1>& a, const reverse_iterator<Iter2>& b) {
+  return b.base() < a.base();
+}
+
+template <typename Iter1, typename Iter2>
+constexpr bool operator>(
+    const reverse_iterator<Iter1>& a, const reverse_iterator<Iter2>& b) {
+  return b.base() > a.base();
+}
+
+template <typename Iter1, typename Iter2>
+constexpr bool operator<=(
+    const reverse_iterator<Iter1>& a, const reverse_iterator<Iter2>& b) {
+  return b.base() <= a.base();
+}
+
+template <typename Iter1, typename Iter2>
+constexpr bool operator>=(
+    const reverse_iterator<Iter1>& a, const reverse_iterator<Iter2>& b) {
+  return b.base() >= a.base();
+}
+
+template <typename Iter1, typename Iter2>
+constexpr auto operator-(
+    const reverse_iterator<Iter1>& a, const reverse_iterator<Iter2>& b)
+    -> decltype(b.base() - a.base()) {
+  return b.base() - a.base();
+}
+
+template <typename Iter>
+constexpr reverse_iterator<Iter> make_reverse_iterator(Iter it) {
+  return reverse_iterator<Iter>{std::move(it)};
+}
+
+} // namespace folly

--- a/folly/container/test/BUCK
+++ b/folly/container/test/BUCK
@@ -422,6 +422,15 @@ fb_dirsync_cpp_unittest(
 )
 
 fb_dirsync_cpp_unittest(
+    name = "reverse_iterator_test",
+    srcs = ["reverse_iterator_test.cpp"],
+    deps = [
+        "//folly/container:reverse_iterator",
+        "//folly/portability:gtest",
+    ],
+)
+
+fb_dirsync_cpp_unittest(
     name = "range_traits_test",
     srcs = ["range_traits_test.cpp"],
     headers = [],

--- a/folly/container/test/F14MapTest.cpp
+++ b/folly/container/test/F14MapTest.cpp
@@ -799,6 +799,7 @@ TEST(F14VectorMap, reverseIterator) {
   auto verify = [](TMap const& h, uint64_t lo, uint64_t hi) {
     auto loIt = h.find(lo);
     EXPECT_NE(h.end(), loIt);
+    EXPECT_EQ(lo, loIt->first);
     uint64_t val = lo;
     for (auto rit = h.riter(loIt); rit != h.rend(); ++rit) {
       EXPECT_EQ(val, rit->first);

--- a/folly/container/test/F14SetTest.cpp
+++ b/folly/container/test/F14SetTest.cpp
@@ -780,6 +780,7 @@ TEST(F14VectorMap, reverseIterator) {
   auto verify = [](TSet const& h, uint64_t lo, uint64_t hi) {
     auto loIt = h.find(lo);
     EXPECT_NE(h.end(), loIt);
+    EXPECT_EQ(lo, *loIt);
     uint64_t val = lo;
     for (auto rit = h.riter(loIt); rit != h.rend(); ++rit) {
       EXPECT_EQ(val, *rit);

--- a/folly/container/test/reverse_iterator_test.cpp
+++ b/folly/container/test/reverse_iterator_test.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/container/reverse_iterator.h>
+
+#include <iterator>
+#include <list>
+#include <numeric>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <folly/portability/GTest.h>
+
+namespace {
+
+using IntIter = folly::reverse_iterator<int*>;
+using ConstIntIter = folly::reverse_iterator<const int*>;
+
+// The whole point of this type: std::reverse_iterator is not trivially
+// copyable on either libstdc++ or libc++.
+static_assert(std::is_trivially_copyable_v<IntIter>);
+static_assert(std::is_trivially_destructible_v<IntIter>);
+static_assert(sizeof(IntIter) == sizeof(int*));
+
+static_assert(std::random_access_iterator<IntIter>);
+static_assert(!std::contiguous_iterator<IntIter>);
+static_assert(std::same_as<std::iter_value_t<IntIter>, int>);
+static_assert(std::same_as<std::iter_reference_t<IntIter>, int&>);
+static_assert(std::same_as<
+              std::iterator_traits<IntIter>::iterator_category,
+              std::random_access_iterator_tag>);
+
+static_assert(std::convertible_to<IntIter, ConstIntIter>);
+static_assert(!std::convertible_to<ConstIntIter, IntIter>);
+
+using ListIter = folly::reverse_iterator<std::list<int>::iterator>;
+static_assert(std::bidirectional_iterator<ListIter>);
+static_assert(!std::random_access_iterator<ListIter>);
+
+TEST(ReverseIterator, BaseIsOnePastTheElement) {
+  int a[] = {0, 1, 2};
+  IntIter it{a + 3};
+  EXPECT_EQ(a + 3, it.base());
+  EXPECT_EQ(2, *it);
+  EXPECT_EQ(a + 2, &*it);
+}
+
+TEST(ReverseIterator, Traversal) {
+  std::vector<int> v(5);
+  std::iota(v.begin(), v.end(), 0);
+
+  std::vector<int> seen;
+  for (IntIter it{v.data() + v.size()}; it != IntIter{v.data()}; ++it) {
+    seen.push_back(*it);
+  }
+  EXPECT_EQ(std::vector<int>({4, 3, 2, 1, 0}), seen);
+}
+
+TEST(ReverseIterator, Arithmetic) {
+  int a[] = {0, 1, 2, 3, 4};
+  IntIter first{a + 5};
+  IntIter last{a};
+
+  EXPECT_EQ(5, last - first);
+  EXPECT_EQ(4, first[0]);
+  EXPECT_EQ(0, first[4]);
+  EXPECT_EQ(2, *(first + 2));
+  EXPECT_EQ(2, *(2 + first));
+  EXPECT_EQ(0, *(last - 1));
+
+  IntIter it = first;
+  it += 3;
+  EXPECT_EQ(1, *it);
+  it -= 2;
+  EXPECT_EQ(3, *it);
+  EXPECT_EQ(3, *it++);
+  EXPECT_EQ(2, *it);
+  EXPECT_EQ(2, *it--);
+  EXPECT_EQ(3, *it);
+}
+
+TEST(ReverseIterator, Comparison) {
+  int a[] = {0, 1, 2};
+  IntIter first{a + 3};
+  IntIter last{a};
+
+  EXPECT_TRUE(first < last);
+  EXPECT_TRUE(first <= last);
+  EXPECT_TRUE(last > first);
+  EXPECT_TRUE(last >= first);
+  EXPECT_TRUE(first != last);
+  EXPECT_TRUE(first == IntIter{a + 3});
+
+  // Heterogeneous, as with iterator vs const_iterator.
+  ConstIntIter cfirst = first;
+  EXPECT_TRUE(cfirst == first);
+  EXPECT_TRUE(cfirst < last);
+  EXPECT_EQ(3, last - cfirst);
+}
+
+TEST(ReverseIterator, Arrow) {
+  std::pair<int, int> a[] = {{0, 1}, {2, 3}};
+  folly::reverse_iterator<std::pair<int, int>*> it{a + 2};
+  EXPECT_EQ(2, it->first);
+  EXPECT_EQ(3, it->second);
+}
+
+TEST(ReverseIterator, MakeAndDeduce) {
+  int a[] = {0, 1, 2};
+  auto it = folly::make_reverse_iterator(a + 3);
+  static_assert(std::same_as<decltype(it), IntIter>);
+  EXPECT_EQ(2, *it);
+
+  folly::reverse_iterator deduced{a + 3};
+  static_assert(std::same_as<decltype(deduced), IntIter>);
+  EXPECT_EQ(2, *deduced);
+}
+
+TEST(ReverseIterator, MatchesStd) {
+  std::vector<int> v(6);
+  std::iota(v.begin(), v.end(), 0);
+
+  auto ours = folly::reverse_iterator{v.data() + v.size()};
+  auto theirs = std::reverse_iterator{v.data() + v.size()};
+  for (std::size_t i = 0; i < v.size(); ++i, ++ours, ++theirs) {
+    EXPECT_EQ(*theirs, *ours) << "at " << i;
+    EXPECT_EQ(theirs.base(), ours.base()) << "at " << i;
+  }
+}
+
+TEST(ReverseIterator, DefaultConstructed) {
+  IntIter it;
+  EXPECT_EQ(nullptr, it.base());
+  EXPECT_EQ(it, IntIter{});
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

F14VectorMap::reverse_iterator is just a pointer.
But the regular iterator is some weird custom thingy.

Not obvious why that'd be good. 
Trying to do reverse_iterator<T*> but we'll see if someone relied on some extra weird behaviour.


Sudden implicit behaviours discovered:

* iter/riter will return an invalid element for end. Erasing it would cause a UB. Just introduced a DCHECK
* erase(end()) will remove the last element. You need to specifically spell it like m.erase(m.end()), an iterator equal to end() won't work.
  That definitely might have happened if someone didn't know what they were doing. 
  Also again - unlikely to delete an end() from an unordered set.
  I feel very weird supporting that. For now will just put a SAFE_CHECK - and will see if that trips the CI.

Differential Revision: D119091588


