### PR TITLE
MemsetBenchmark: use .balign instead of .align for macOS x86_64 compatibility

### DIFF
--- a/folly/test/MemsetBenchmark.cpp
+++ b/folly/test/MemsetBenchmark.cpp
@@ -41,7 +41,7 @@ size_t getPow2(size_t v) {
 template <void* memset_impl(void*, int, size_t)>
 void bmMemset(void* buf, size_t length, size_t iters) {
 #if !defined(__aarch64__)
-  __asm__ volatile(".align 64\n");
+  __asm__ volatile(".balign 64\n");
 #endif
   FOLLY_PRAGMA_UNROLL_N(1)
   for (size_t i = 0; i < iters; ++i) {


### PR DESCRIPTION
## Summary

Replace `.align 64` with `.balign 64` in `folly/test/MemsetBenchmark.cpp` to fix a build failure on macOS x86_64 (Intel Macs).

## Problem

The `.align` directive is interpreted differently by the Apple assembler versus GNU `as`:

| Assembler | `.align 64` means | Result |
|-----------|-------------------|--------|
| GNU `as` (Linux) | align to 64 bytes | Works |
| Apple `as` (macOS) | align to 2^64 bytes | Invalid |

On macOS x86_64, `.align 64` attempts to align to 2^64 bytes, which fails with:

```
folly/test/MemsetBenchmark.cpp:44:20: error: invalid alignment value
   44 |   __asm__ volatile(".align 64\n");
      |                    ^
<inline asm>:1:9: note: instantiated into assembly here
    1 |         .align 64
      |                ^
error: cannot encode offset of relocations; object file too large
```

This caused build failures on macOS x86_64 when folly's test targets were compiled, affecting downstream consumers like Nixpkgs' `watchman` derivation (which builds folly with tests enabled).

Apple Silicon (aarch64) was already excluded by the `#if !defined(__aarch64__)` guard, so this only affects x86_64 macOS.

## Fix

Replace `.align` with `.balign`, which unambiguously means "align to N bytes" on both GNU `as` and the Apple assembler. This is a drop-in replacement that preserves the original 64-byte cache-line alignment intent on every platform with no behavioral change on Linux.

```diff
-  __asm__ volatile(".align 64\n");
+  __asm__ volatile(".balign 64\n");
```

## Verification

### macOS x86_64 (Intel Mac, local)

```bash
# .balign 64 — succeeds
$ echo 'void test(void) { __asm__ volatile(".balign 64\n"); }' | clang -c -x c - -o /dev/null
# (no output, exit 0)

# .align 64 — fails with the exact build error
$ echo 'void test(void) { __asm__ volatile(".align 64\n"); }' | clang -c -x c - -o /dev/null
<stdin>:1:20: error: invalid alignment value
    1 | void test(void) { __asm__ volatile(".align 64\n"); }
      |                    ^
<inline asm>:1:9: note: instantiated into assembly here
    1 |         .align 64
      |                ^
```

### Linux x86_64 (Ubuntu 24.04, Docker)

Verified that `.balign 64` and `.align 64` produce identical object code on GNU GAS, confirming no behavioral change on Linux:

```bash
$ echo ".balign 64
nop" | as -o /tmp/balign.o && objdump -d /tmp/balign.o
0000000000000000 <.text>:
   0:	90                   	nop

$ echo ".align 64
nop" | as -o /tmp/align.o && objdump -d /tmp/align.o
0000000000000000 <.text>:
   0:	90                   	nop
```

Both directives produce the same `nop` at offset 0 (aligned to 64-byte boundary). `.balign` and `.align` are equivalent on GNU GAS.

### macOS aarch64 (Apple Silicon)

Unchanged — the modified line is excluded by `#if !defined(__aarch64__)`.

## Test plan

- [x] `.balign 64` compiles on macOS x86_64 (Intel Mac)
- [x] `.align 64` fails on macOS x86_64 with the exact build error
- [x] `.balign 64` and `.align 64` produce identical object code on Linux x86_64 (Ubuntu 24.04, GNU GAS)
- [ ] Full folly build + test on Linux x86_64 via CI (`getdeps_linux.yml`)
- [ ] Full folly build on macOS aarch64 via CI (`getdeps_mac.yml`) — line excluded by `#if !defined(__aarch64__)`

Resolves #2690
