### PR TITLE
ci: add macos-26-intel (x86_64) to macOS CI matrix

### DIFF
--- a/.github/workflows/getdeps_mac.yml
+++ b/.github/workflows/getdeps_mac.yml
@@ -21,12 +21,14 @@ permissions:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, macos-26-intel]
     env:
       DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
-      CC: /opt/homebrew/opt/llvm/bin/clang
-      CXX: /opt/homebrew/opt/llvm/bin/clang++
       SCCACHE_GHA_ENABLED: "on"
     steps:
 
@@ -45,6 +47,11 @@ jobs:
 
     - name: Install Homebrew LLVM
       run: brew install llvm
+
+    - name: Set up compiler paths
+      run: |
+        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
 
     - name: Show disk space at start
       run: df -h
@@ -129,7 +136,7 @@ jobs:
       run: python3 build/fbcode_builder/getdeps.py --allow-system-packages fixup-dyn-deps --src-dir=. folly _artifacts/mac --project-install-prefix folly:/usr/local --final-install-prefix /usr/local
     - uses: actions/upload-artifact@v6
       with:
-        name: folly
+        name: folly-${{ matrix.os }}
         path: _artifacts
 
     - name: Test folly


### PR DESCRIPTION
## Summary

Add `macos-26-intel` (x86_64) as a second matrix dimension to the macOS CI workflow (`getdeps_mac.yml`) to catch x86_64 macOS-specific regressions that aarch64 CI cannot detect.

## Problem

Folly's macOS CI only runs on `macOS-latest` (aarch64 / Apple Silicon). Code paths guarded by `#if !defined(__aarch64__)` are never compiled on aarch64 runners, making x86_64 macOS-specific issues invisible to CI.

This gap allowed an invalid `.align 64` assembly directive to ship undetected — it only fails on the Apple x86_64 assembler (see #2690, #2691). The existing CI matrix:

| Runner | Architecture | In CI? | Catches x86_64 macOS bugs? |
|--------|-------------|--------|-----------------------------|
| `ubuntu-24.04` | x86_64 Linux | Yes | No (GAS accepts `.align 64`) |
| `macOS-latest` | aarch64 macOS | Yes | No (code excluded by `#if !defined(__aarch64__)`) |
| `macos-26-intel` | x86_64 macOS | **No** | **Yes** |

## Changes

- Add `strategy.matrix` with `os: [macOS-latest, macos-26-intel]`
- Use `fail-fast: false` so both architectures run even if one fails
- Replace hardcoded `CC`/`CXX` paths (`/opt/homebrew/opt/llvm/bin/clang`) with dynamic resolution via `brew --prefix llvm`, which returns the correct prefix on both aarch64 (`/opt/homebrew`) and x86_64 (`/usr/local`)
- Make artifact name unique per matrix OS (`folly-${{ matrix.os }}`) to avoid upload collisions

## Runner availability

`macos-26-intel` is generally available (GA since February 2026) and supported until ~November 2028 ([GitHub announcement](https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/)).

## Note

This file is `@generated by getdeps.py`. The corresponding change to `getdeps.py` should be made separately to keep the generator in sync with this workflow file.

## Test plan

- [x] Workflow YAML validates (`yq` parse)
- [x] `brew --prefix llvm` returns correct path on both aarch64 and x86_64
- [ ] Both matrix jobs (aarch64 + x86_64) pass on CI
- [ ] Artifact upload works with per-OS names

Resolves #2692

Related: #2690, #2691
