### PR TITLE
fix(result): include standard headers used by epitaph sources

### DIFF
--- a/folly/result/epitaph.cpp
+++ b/folly/result/epitaph.cpp
@@ -16,6 +16,8 @@
 
 #include <folly/result/epitaph.h>
 
+#include <vector>
+
 #include <folly/Portability.h> // FOLLY_HAS_RESULT
 
 // Enabled by default on platforms with ELF+DWARF; BUCK sets this to 0 on

--- a/folly/result/rich_error_code.h
+++ b/folly/result/rich_error_code.h
@@ -16,7 +16,12 @@
 
 #pragma once
 
+#include <concepts>
+#include <cstdint>
+#include <exception>
 #include <optional>
+#include <type_traits>
+
 #include <fmt/core.h>
 
 #include <folly/lang/Pretty.h>


### PR DESCRIPTION
Fixes #2694.

`folly/result/epitaph.cpp` now includes `<vector>`, and `folly/result/rich_error_code.h` includes the standard headers for the concepts, exception pointer, integer, optional, and type-trait APIs it uses. This removes the transitive-include dependency that caused the current macOS build to fail.
