### PR TITLE
F14VectorMap remove iter/riter (#2696)

### DIFF
--- a/folly/container/F14Map.h
+++ b/folly/container/F14Map.h
@@ -1693,8 +1693,8 @@ class F14VectorMap
   //
   // No erase is provided for reverse_iterator or const_reverse_iterator
   // to make it harder to shoot yourself in the foot by erasing while
-  // reverse-iterating.  You can write that as map.erase(map.iter(riter))
-  // if you really need it.
+  // reverse-iterating.  You can write that as map.erase(riter->first)
+  // if you really need it; erase(iter) hashes the key too.
 
   /// @methodset Iterators
   reverse_iterator rbegin() [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
@@ -1720,19 +1720,6 @@ class F14VectorMap
   /// @methodset Iterators
   const_reverse_iterator crend() const [[FOLLY_ATTR_CLANG_LIFETIMEBOUND]] {
     return this->table_.values_ + this->table_.size();
-  }
-
-  /// Explicit conversions between iterator and reverse_iterator
-  /// @methodset Iterators
-  iterator iter(reverse_iterator riter) { return this->table_.iter(riter); }
-  const_iterator iter(const_reverse_iterator riter) const {
-    return this->table_.iter(riter);
-  }
-
-  /// @copydoc iter
-  reverse_iterator riter(iterator it) { return this->table_.riter(it); }
-  const_reverse_iterator riter(const_iterator it) const {
-    return this->table_.riter(it);
   }
 
   friend Range<const_reverse_iterator> tag_invoke(

--- a/folly/container/F14Set.h
+++ b/folly/container/F14Set.h
@@ -1275,8 +1275,8 @@ class F14VectorSet
   //
   // No erase is provided for reverse_iterator (AKA const_reverse_iterator)
   // to make it harder to shoot yourself in the foot by erasing while
-  // reverse-iterating.  You can write that as set.erase(set.iter(riter))
-  // if you need it.
+  // reverse-iterating.  You can write that as set.erase(*riter)
+  // if you need it; erase(iter) hashes the key too.
 
   reverse_iterator rbegin() { return this->table_.values_; }
   const_reverse_iterator rbegin() const { return crbegin(); }
@@ -1286,17 +1286,6 @@ class F14VectorSet
   const_reverse_iterator rend() const { return crend(); }
   const_reverse_iterator crend() const {
     return this->table_.values_ + this->table_.size();
-  }
-
-  // explicit conversions between iterator and reverse_iterator
-  iterator iter(reverse_iterator riter) { return this->table_.iter(riter); }
-  const_iterator iter(const_reverse_iterator riter) const {
-    return this->table_.iter(riter);
-  }
-
-  reverse_iterator riter(iterator it) { return this->table_.riter(it); }
-  const_reverse_iterator riter(const_iterator it) const {
-    return this->table_.riter(it);
   }
 
   friend Range<const_reverse_iterator> tag_invoke(

--- a/folly/container/detail/F14Policy.h
+++ b/folly/container/detail/F14Policy.h
@@ -1487,14 +1487,6 @@ class VectorContainerPolicy
 
   Iter indexToIter(Item index) const { return Iter{values_ + index, values_}; }
 
-  Iter iter(ReverseIter it) { return Iter{it, values_}; }
-
-  ConstIter iter(ConstReverseIter it) const { return ConstIter{it, values_}; }
-
-  ReverseIter riter(Iter it) { return it.current_; }
-
-  ConstReverseIter riter(ConstIter it) const { return it.current_; }
-
   ValuePtr values_{nullptr};
 };
 

--- a/folly/container/test/F14MapTest.cpp
+++ b/folly/container/test/F14MapTest.cpp
@@ -797,15 +797,11 @@ TEST(F14VectorMap, reverseIterator) {
     }
   };
   auto verify = [](TMap const& h, uint64_t lo, uint64_t hi) {
-    auto loIt = h.find(lo);
-    EXPECT_NE(h.end(), loIt);
+    EXPECT_NE(h.end(), h.find(lo));
     uint64_t val = lo;
-    for (auto rit = h.riter(loIt); rit != h.rend(); ++rit) {
+    for (auto rit = h.rbegin() + lo; rit != h.rend(); ++rit) {
       EXPECT_EQ(val, rit->first);
       EXPECT_EQ(val, rit->second);
-      TMap::const_iterator it = h.iter(rit);
-      EXPECT_EQ(val, it->first);
-      EXPECT_EQ(val, it->second);
       val++;
     }
     EXPECT_EQ(hi, val);

--- a/folly/container/test/F14SetTest.cpp
+++ b/folly/container/test/F14SetTest.cpp
@@ -778,13 +778,10 @@ TEST(F14VectorMap, reverseIterator) {
     }
   };
   auto verify = [](TSet const& h, uint64_t lo, uint64_t hi) {
-    auto loIt = h.find(lo);
-    EXPECT_NE(h.end(), loIt);
+    EXPECT_NE(h.end(), h.find(lo));
     uint64_t val = lo;
-    for (auto rit = h.riter(loIt); rit != h.rend(); ++rit) {
+    for (auto rit = h.rbegin() + lo; rit != h.rend(); ++rit) {
       EXPECT_EQ(val, *rit);
-      TSet::const_iterator it = h.iter(rit);
-      EXPECT_EQ(val, *it);
       val++;
     }
     EXPECT_EQ(hi, val);


### PR DESCRIPTION
Summary:

iter/riter methods are for erasing based on reverse iterator.
They are not really used and we found them awkward.

The only usecase we saw - we convert from `m.erase(m.iter(m.rbegin())` to `m.erase(m.rbegin()->first)` which is equivalent performance wise, since for vector map erasing by iterator requires to do a key lookup anyways.

Differential Revision: D119187522


