### PR TITLE
Fix the aarch64 SVE tag-match in ConcurrentHashMap for GCC

### DIFF
--- a/folly/concurrency/detail/ConcurrentHashMap-detail.h
+++ b/folly/concurrency/detail/ConcurrentHashMap-detail.h
@@ -1031,8 +1031,10 @@ class alignas(64) SIMDTable {
       uint64x2_t vec;
       vec[0] = low;
       vec[1] = hi;
-      svbool_t matchPred =
-          svmatch_u8(pred, svset_neonq_u8(svundef_u8(), vec), needleV);
+      svbool_t matchPred = svmatch_u8(
+          pred,
+          svset_neonq_u8(svundef_u8(), vreinterpretq_u8_u64(vec)),
+          needleV);
       // get info from every byte into the bottom half of every uint16_t
       // by shifting right 4, then round to get it into a 64-bit vector
       uint8x8_t maskV = vshrn_n_u16(


### PR DESCRIPTION
## Problem

Building C++ Presto on ARM with GCC breaks because of this. What follows is an AI diagnosis of the problem.
I'm not an expert on this particular matter but the problem is real.

`SIMDTable::Chunk::tagMatchIter()` in `folly/concurrency/detail/ConcurrentHashMap-detail.h` does not compile with GCC. It packs the two 64-bit tag words into a `uint64x2_t` and hands it straight to `svset_neonq_u8()`, whose second parameter is a `uint8x16_t`:

```cpp
uint64x2_t vec;
vec[0] = low;
vec[1] = hi;
svbool_t matchPred =
    svmatch_u8(pred, svset_neonq_u8(svundef_u8(), vec), needleV);   // line 1035
```

clang defaults to `-flax-vector-conversions=integer` and lets that implicit bitcast through. GCC defaults to no lax vector conversions and rejects it:

```
folly/concurrency/detail/ConcurrentHashMap-detail.h:1035:63:
error: cannot convert 'uint64x2_t' to '__Uint8x16_t'
 1035 |   svmatch_u8(pred, svset_neonq_u8(svundef_u8(), vec), needleV);
      |                                                 ^~~
      |                                                 |
      |                                                 uint64x2_t
note: use '-flax-vector-conversions' to permit conversions between vectors with
      differing element types or numbers of subparts
note:   initializing argument 2 of 'svuint8_t svset_neonq_u8(svuint8_t, __Uint8x16_t)'
```

Because the failure is in a header, every translation unit that instantiates `folly::ConcurrentHashMap` fails.

### When it triggers

The block is guarded by `FOLLY_F14_DETAIL_ISA_SVE2_WITH_BRIDGE` (`FOLLY_ARM_FEATURE_NEON_SVE_BRIDGE && FOLLY_ARM_FEATURE_SVE2`), so you need GCC, aarch64, SVE2, and `<arm_neon_sve_bridge.h>` (which GCC ships from 14
onwards). That is the ordinary configuration on current server Arm: `-mcpu=neoverse-v2` (Graviton4, NVIDIA Grace), `-mcpu=neoverse-n2`, `-mcpu=olympus`. It is exactly what Velox's `get_cxx_flags()` selects on such a host.

Since the fault is in a header, the compiler that decides is the one compiling the consuming translation unit, not the one that built folly. That is how it reached us: The Presto dependency image installs folly with gcc-toolset-12, which has
no bridge header and so compiles the block out, and the error then appears when a Presto native translation unit that includes the installed header is compiled with gcc-toolset-14 on a Grace host.

Before [`7031d8bebb`](https://github.com/facebook/folly/commit/7031d8bebb) the gate was the wider `FOLLY_ARM_FEATURE_NEON_SVE_BRIDGE`, so on the currently released tags plain SVE (e.g. `-mcpu=neoverse-v1`) is enough to trigger it too.

I believe folly CI builds with clang only, so nothing here catches it.

Introduced in [`12fa4cb487`](https://github.com/facebook/folly/commit/12fa4cb487) ("Enhance concurrent hashmap with SVE", 2026-03-02); present in every release from `v2026.03.09.00` onwards.

## Fix

Add the explicit reinterpret:

```diff
-      svbool_t matchPred =
-          svmatch_u8(pred, svset_neonq_u8(svundef_u8(), vec), needleV);
+      svbool_t matchPred = svmatch_u8(
+          pred,
+          svset_neonq_u8(svundef_u8(), vreinterpretq_u8_u64(vec)),
+          needleV);
```

`vreinterpretq_u8_u64` is a pure type pun that emits no instruction. It is also exactly what the NEON fallback branch of the same function already does a dozen lines below:

```cpp
auto eqV = vceqq_u8(vreinterpretq_u8_u64(vec), needleV);
```

This is the only site that needs it. The other three `svset_neonq_u8()` calls in the tree — `folly/container/detail/F14Table.h:812`, `:833`, and `folly/algorithm/simd/find_first_of.h:505` — already pass a `uint8x16_t`.

## Verification

Cross-compiled the SVE bodies of `ConcurrentHashMap-detail.h` (and, as a control, the `F14Table.h` and `find_first_of.h` ones) at
`-mcpu=neoverse-v2 -O2 -std=gnu++20` with `aarch64-linux-gnu-g++ 14.2.0` and `clang 19.1.7`:

| | before | after |
|---|---|---|
| gcc 14.2 | **error: cannot convert `uint64x2_t` to `__Uint8x16_t`** | compiles |
| clang 19.1 | compiles | compiles |

clang's generated instructions are byte-identical before and after the change:

```asm
fmov    d1, x0
mov     v1.d[1], x1
match   p0.b, p0/z, z1.b, z0.b
ret
```

GCC emits the same sequence for the fixed form (`fmov` / `ins v.d[1]` / `match`), so there is no codegen cost on either compiler.