### PR TITLE
ParkingLot: add symmetric seq_cst fence on the park side

### DIFF
--- a/folly/synchronization/ParkingLot.h
+++ b/folly/synchronization/ParkingLot.h
@@ -262,8 +262,14 @@ ParkResult ParkingLot<Data>::park_until(
   WaitNode node(key, lotid_, std::forward<D>(data));
 
   {
-    // A: Must be seq_cst.  Matches B.
+    // A: Must be seq_cst.  Matches B.  toPark() below may read caller state
+    // at any memory order the caller chooses (e.g. relaxed or acquire), so
+    // this fence -- not just the seq_cst tag on the fetch_add -- is what
+    // guarantees the increment is globally visible before that read, the
+    // same way B's fence guarantees the caller's state update is visible
+    // before the count_ check on the unpark side.
     bucket.count_.fetch_add(1, std::memory_order_seq_cst);
+    std::atomic_thread_fence(std::memory_order_seq_cst);
 
     std::unique_lock bucketLock(bucket.mutex_);
 

--- a/folly/synchronization/test/ParkingLotTest.cpp
+++ b/folly/synchronization/test/ParkingLotTest.cpp
@@ -106,6 +106,58 @@ TEST(ParkingLot, StressTestPingPong) {
   threadTwo.join();
 }
 
+// Same shape as StressTestPingPong, but the parking thread's toPark() check
+// deliberately reads with memory_order_relaxed rather than the default
+// (seq_cst). ParkingLot can't assume callers check their own state at
+// seq_cst -- the caller here uses relaxed/acquire/release throughout, same
+// as this file's other stress test does for its own state on the unpark
+// side. This exercises the park side's A fence the same way the original
+// test exercises the unpark side's B fence.
+TEST(ParkingLot, StressTestPingPongRelaxedToPark) {
+  auto lot = ParkingLot<std::uint32_t>{};
+  auto one = std::atomic<std::uint64_t>{0};
+  auto two = std::atomic<std::uint64_t>{0};
+
+  auto testDone = std::atomic<bool>{false};
+  auto threadOneDone = std::atomic<bool>{false};
+
+  auto threadOne = std::thread{[&]() {
+    auto local = std::uint64_t{0};
+    while (!testDone.load(std::memory_order_relaxed)) {
+      lot.park(
+          &one,
+          -1,
+          [&]() { return one.load(std::memory_order_relaxed) == local; },
+          []() {});
+      local = one.load(std::memory_order_acquire);
+      two.store(local, std::memory_order_release);
+    }
+
+    threadOneDone.store(true, std::memory_order_release);
+  }};
+
+  auto threadTwo = std::thread{[&]() {
+    for (auto i = std::uint64_t{1}; true; ++i) {
+      auto local = two.load(std::memory_order_acquire);
+
+      one.store(i, std::memory_order_release);
+      lot.unpark(&one, [&](auto&&) { return UnparkControl::RemoveBreak; });
+
+      while (two.load(std::memory_order_acquire) == local) {
+        if (threadOneDone.load(std::memory_order_acquire)) {
+          return;
+        }
+      }
+    }
+  }};
+
+  /* sleep override */
+  std::this_thread::sleep_for(std::chrono::seconds{10});
+  testDone.store(true);
+  threadOne.join();
+  threadTwo.join();
+}
+
 // This is not possible to implement with Futex, because futex
 // and the native linux syscall are 32-bit only.
 TEST(ParkingLot, LargeWord) {


### PR DESCRIPTION
Fixes #2649.

`ff7ab9d` fixed a StoreLoad-reordering hazard on the **unpark** side: a bare `seq_cst` tag on `count_`'s load wasn't enough to guarantee the caller's state update (which may use any memory order the caller chooses) was visible before the check, so an explicit `std::atomic_thread_fence` was added between them, with the comment "A: Must be seq_cst. Matches B."

The **park** side has the identical shape and was never given the mirror fix: `count_.fetch_add(seq_cst)` is immediately followed by `toPark()`, which — like the caller state checked on the unpark side — may read at any memory order the caller chooses (this file's own stress test uses `relaxed`/`acquire`/`release` for its own state, not `seq_cst`). `std::mutex::lock()` sits between the fetch_add and `toPark()`, but per the standard ([thread.mutex.requirements.mutex]) it only synchronizes with a matching `unlock()` on the *same* mutex — it provides no guarantee relevant to this specific hazard. So the gap is real per the abstract machine, regardless of what any particular compiler/CPU does today.

**On empirical validation — being upfront about what I did and didn't find:** I do not have a reproduced crash to point to. I built an isolated litmus test matching this commit's own example, with a proper per-round rendezvous barrier (not just a loose pacing bound) to force genuinely tight races, and ran 120M trials on arm64 across both same-cluster and cross-cluster core pairings — zero instances of the hazard. As a control, I reverted this fix's own precedent (`ff7ab9d`) and re-ran its `StressTestPingPong` regression test — that *also* didn't reproduce the already-documented, already-fixed bug across 20 runs. That tells me the hardware/OS/compiler combination I tested on doesn't expose this reordering empirically, not that the hazard isn't real — plenty of standards-non-compliant code runs fine on any one platform until it doesn't. I'm proposing this fix on the same reasoning basis as the original, not on an observed failure, and wanted to be explicit about that distinction rather than overstate the evidence.

**Testing:** added `StressTestPingPongRelaxedToPark`, mirroring `StressTestPingPong` but with the parking thread's `toPark()` check reading at `relaxed` instead of the default (`seq_cst`), so the park side's fence has the same kind of regression coverage the unpark side's already does.